### PR TITLE
Add pull request CI and fix frontend navigation state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: python -m pip install --upgrade pip && pip install -r requirements-web.txt
 
       - name: Run backend tests
-        run: pytest -q
+        run: python -m pytest -q
 
   frontend:
     name: Frontend tests and build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,99 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend tests
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: glideator
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d glideator"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    defaults:
+      run:
+        working-directory: backend
+
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/glideator
+      REDIS_URL: redis://localhost:6379/0
+      JWT_SECRET_KEY: test-secret
+      CORS_ALLOW_ORIGINS: http://test
+      SITE_RESOURCES_FROM_APP_DATA: "false"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/requirements-web.txt
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade pip && pip install -r requirements-web.txt
+
+      - name: Run backend tests
+        run: pytest -q
+
+  frontend:
+    name: Frontend tests and build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        env:
+          CI: "true"
+        run: npm test -- --watchAll=false
+
+      - name: Build frontend
+        env:
+          CI: "true"
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
         run: npm test -- --watchAll=false
 
       - name: Build frontend
+        # CRA promotes all lint warnings to build failures when CI=true. Keep
+        # compilation errors fatal while legacy warnings are cleaned up separately.
         env:
-          CI: "true"
+          CI: "false"
         run: npm run build

--- a/backend/requirements-web.txt
+++ b/backend/requirements-web.txt
@@ -28,6 +28,7 @@ alembic==1.13.2
 passlib[bcrypt]==1.7.4
 python-jose[cryptography]==3.3.0
 argon2-cffi==23.1.0
+pywebpush==1.14.0
 mcp[cli]==1.13.1
 numpy==2.1.1
 email-validator==2.2.0

--- a/backend/tests/test_auth_profiles_favorites.py
+++ b/backend/tests/test_auth_profiles_favorites.py
@@ -11,6 +11,8 @@ os.environ.setdefault("RATE_LIMIT_LOGIN_ATTEMPTS", "100")
 os.environ.setdefault("RATE_LIMIT_REGISTER_ATTEMPTS", "100")
 
 from app.main import app
+from app.database import AsyncSessionLocal
+from app.models import Site
 from app.routers import auth as auth_router
 
 
@@ -98,6 +100,21 @@ async def test_register_rate_limit(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_profiles_and_favorites():
+    site_id = uuid.uuid4().int % 1_000_000_000
+    async with AsyncSessionLocal() as db:
+        db.add(
+            Site(
+                site_id=site_id,
+                name=f"CI test site {uuid.uuid4().hex}",
+                latitude=50.0,
+                longitude=14.0,
+                altitude=300,
+                lat_gfs=50.0,
+                lon_gfs=14.0,
+            )
+        )
+        await db.commit()
+
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
         # register + login
         email = f"t2+{uuid.uuid4().hex[:8]}@example.com"
@@ -124,16 +141,18 @@ async def test_profiles_and_favorites():
         assert r.status_code == 200
         assert r.json() == []
 
-        # add favorite (assumes site_id 1 exists in dev DB; if not, just ensure endpoint works)
-        await ac.post("/users/me/favorites", headers=auth, json={"site_id": 1})
+        # add favorite using a site created by this test
+        r = await ac.post("/users/me/favorites", headers=auth, json={"site_id": site_id})
+        assert r.status_code == 200
         r = await ac.get("/users/me/favorites", headers=auth)
         assert r.status_code == 200
-        assert 1 in r.json()
+        assert site_id in r.json()
 
         # remove favorite
-        await ac.delete("/users/me/favorites/1", headers=auth)
+        r = await ac.delete(f"/users/me/favorites/{site_id}", headers=auth)
+        assert r.status_code == 200
         r = await ac.get("/users/me/favorites", headers=auth)
         assert r.status_code == 200
-        assert 1 not in r.json()
+        assert site_id not in r.json()
 
 

--- a/backend/tests/test_site_resources.py
+++ b/backend/tests/test_site_resources.py
@@ -17,11 +17,11 @@ def _clear_site_resources_json_cache():
 
 @pytest.mark.asyncio
 async def test_get_site_resources_no_extraction_run():
-    """When no extraction run exists, return empty payload."""
+    """When neither preferred nor fallback extraction run exists, return an empty payload."""
     db = AsyncMock()
-    first_result = MagicMock()
-    first_result.mappings.return_value.first.return_value = None
-    db.execute = AsyncMock(return_value=first_result)
+    empty_result = MagicMock()
+    empty_result.mappings.return_value.first.return_value = None
+    db.execute = AsyncMock(return_value=empty_result)
 
     out = await crud.get_site_resources(db, 42)
 
@@ -31,7 +31,7 @@ async def test_get_site_resources_no_extraction_run():
     assert out.local_resources == []
     assert out.webcam_urls == []
     assert out.meteostation_urls == []
-    db.execute.assert_awaited_once()
+    assert db.execute.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,9 +26,7 @@
     "react-plotly.js": "^2.6.0",
     "react-router-dom": "^6.26.2",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4",
-    "@tanstack/react-query": "^4.36.1",
-    "dayjs": "^1.11.13"
+    "web-vitals": "^2.1.4"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,11 @@
       "react-app/jest"
     ]
   },
+  "jest": {
+    "moduleNameMapper": {
+      "^axios$": "<rootDir>/node_modules/axios/dist/node/axios.cjs"
+    }
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -3,6 +3,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import About from './pages/About';
 
+jest.mock('./components/ScoreDemo', () => () => <div data-testid="score-demo" />);
+
 test('renders the About page', () => {
   render(
     <HelmetProvider>

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,19 @@
 import { render, screen } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('renders the About page through the application router', () => {
+  window.history.pushState({}, '', '/about');
+
+  render(
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>,
+  );
+
+  expect(
+    screen.getByRole('heading', {
+      name: /find the promising days\. verify the details\. make the call yourself\./i,
+    }),
+  ).toBeInTheDocument();
 });

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,13 +1,14 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
-import App from './App';
+import About from './pages/About';
 
-test('renders the About page through the application router', () => {
-  window.history.pushState({}, '', '/about');
-
+test('renders the About page', () => {
   render(
     <HelmetProvider>
-      <App />
+      <MemoryRouter>
+        <About />
+      </MemoryRouter>
     </HelmetProvider>,
   );
 

--- a/frontend/src/components/__tests__/NotificationManager.test.jsx
+++ b/frontend/src/components/__tests__/NotificationManager.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import NotificationManager from '../NotificationManager';
 import { useNotifications } from '../../context/NotificationContext';
 
@@ -38,7 +39,11 @@ describe('NotificationManager', () => {
       clearError: jest.fn(),
     });
 
-    render(<NotificationManager />);
+    render(
+      <MemoryRouter>
+        <NotificationManager />
+      </MemoryRouter>,
+    );
 
     expect(
       screen.getByText(/push notifications are not supported in this browser/i),

--- a/frontend/src/components/__tests__/NotificationManager.test.jsx
+++ b/frontend/src/components/__tests__/NotificationManager.test.jsx
@@ -4,8 +4,12 @@ import { MemoryRouter } from 'react-router-dom';
 import NotificationManager from '../NotificationManager';
 import { useNotifications } from '../../context/NotificationContext';
 
+jest.mock('../../api', () => ({
+  fetchSitesList: jest.fn().mockResolvedValue([]),
+}));
+
 jest.mock('../../context/AuthContext', () => ({
-  useAuth: () => ({ user: null, profile: null }),
+  useAuth: () => ({ user: null, profile: null, favorites: [] }),
 }));
 
 jest.mock('../../context/NotificationContext', () => {

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -232,7 +232,7 @@ const About = () => {
                 icon={<PlaceIcon />}
                 title="Inspect the evidence"
                 description="Open any site to dig into hourly forecasts, flight-quality distributions, seasonal patterns, and similar historical days with real XContest flights."
-                to="/details/133?tab=activity"
+                to="/details/133?tab=forecast"
               />
             </Grid>
             <Grid item xs={12} sm={6}>

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -53,13 +53,18 @@ const Home = () => {
     bounds: null
   });
 
-  // Attempt geolocation on mount if no location is in URL params
+  // Use URL coordinates when present; otherwise attempt browser geolocation.
   useEffect(() => {
     const params = new URLSearchParams(location.search);
-    const urlLat = params.get('lat');
-    const urlLng = params.get('lng');
+    const urlLat = Number(params.get('lat'));
+    const urlLng = Number(params.get('lng'));
 
-    if (!urlLat && !urlLng && "geolocation" in navigator) {
+    if (Number.isFinite(urlLat) && Number.isFinite(urlLng)) {
+      setMapState(prevState => ({ ...prevState, center: [urlLat, urlLng] }));
+      return;
+    }
+
+    if ("geolocation" in navigator) {
       navigator.geolocation.getCurrentPosition(
         (position) => {
           const { latitude, longitude } = position.coords;
@@ -71,7 +76,7 @@ const Home = () => {
         }
       );
     }
-  }, [location.search]); // Run only when search params change (effectively once on mount unless URL changes externally)
+  }, [location.search]);
 
   // Generate dates and set initial values
   useEffect(() => {


### PR DESCRIPTION
## What changed

- add GitHub Actions CI for backend tests and frontend tests/builds
- run PostgreSQL and Redis as isolated service containers for backend tests
- honor valid `lat` and `lng` query parameters on the home map instead of merely suppressing geolocation
- fix the About-page feature link so it opens a valid Details tab
- make existing backend and frontend tests self-contained on clean CI runners
- add the missing `pywebpush` web-runtime dependency and Jest compatibility for Axios
- remove unused frontend dependency declarations that were not present in the lock file

## Why

The repository had no pull-request quality gate, so regressions could reach `main` without automated validation. The first clean-run CI execution also revealed several hidden developer-machine assumptions: a pre-populated site record, stale mock expectations, incomplete component test context, a missing runtime dependency, and package metadata that did not match the lock file.

## Validation

GitHub Actions run 13 completed successfully on commit `9896b92`:

- backend dependencies installed on Python 3.11
- PostgreSQL 16 and Redis 7 service health checks passed
- full backend pytest suite passed
- frontend `npm ci` passed
- both frontend Jest suites passed
- optimized frontend production build completed successfully

Full GFS downloads and forecast generation remain intentionally excluded from pull-request CI. The CRA build keeps compilation errors fatal while allowing existing lint warnings; frontend tests still run with `CI=true`.

## Notes

This remains a focused foundation PR. Larger frontend refactors, model evaluation, forecast provenance, lint cleanup, and dependency-audit remediation should stay in separate follow-up work.