### PR TITLE
Add core backend and frontend coverage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: python -m pip install --upgrade pip && pip install -r requirements-web.txt
 
       - name: Run backend tests
-        run: python -m pytest -q
+        run: python -m pytest -q --cov=app --cov-report=term-missing:skip-covered --cov-report=xml
 
   frontend:
     name: Frontend tests and build
@@ -91,7 +91,7 @@ jobs:
       - name: Run frontend tests
         env:
           CI: "true"
-        run: npm test -- --watchAll=false
+        run: npm test -- --watchAll=false --coverage --coverageReporters=text-summary --collectCoverageFrom='src/**/*.{js,jsx}'
 
       - name: Build frontend
         # CRA promotes all lint warnings to build failures when CI=true. Keep

--- a/backend/requirements-web.txt
+++ b/backend/requirements-web.txt
@@ -34,5 +34,5 @@ numpy==2.1.1
 email-validator==2.2.0
 pytest==7.4.4
 pytest-asyncio==0.23.8
+pytest-cov==5.0.0
 fakeredis==2.23.3
-

--- a/backend/tests/test_sites_api.py
+++ b/backend/tests/test_sites_api.py
@@ -1,7 +1,7 @@
 import os
 from datetime import date, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -107,7 +107,7 @@ async def test_forecast_endpoint_serializes_forecast_payloads(monkeypatch):
     assert payload["forecast_12"] == {"wind_speed": 4.1}
     assert payload["forecast_15"] == {"wind_speed": 5.0}
     get_forecast.assert_awaited_once_with(
-        pytest.ANY,
+        ANY,
         date(2026, 8, 3),
         50.0,
         14.0,

--- a/backend/tests/test_sites_api.py
+++ b/backend/tests/test_sites_api.py
@@ -1,0 +1,133 @@
+import os
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
+os.environ.setdefault("CORS_ALLOW_ORIGINS", "http://localhost:3000")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+from app import crud
+from app.main import app
+
+
+@pytest.mark.asyncio
+async def test_predictions_endpoint_orders_metrics_and_fills_missing_values(monkeypatch):
+    now = datetime(2026, 8, 1, 12, 0, 0)
+    site = SimpleNamespace(
+        site_id=42,
+        name="Rana",
+        latitude=50.404,
+        longitude=13.771,
+        altitude=457,
+    )
+    predictions = [
+        SimpleNamespace(
+            date=date(2026, 8, 2),
+            metric="XC20",
+            value=0.42,
+            computed_at=now,
+            gfs_forecast_at=now,
+        ),
+        SimpleNamespace(
+            date=date(2026, 8, 2),
+            metric="XC0",
+            value=0.81,
+            computed_at=now,
+            gfs_forecast_at=now,
+        ),
+    ]
+
+    monkeypatch.setattr(crud, "get_site", AsyncMock(return_value=site))
+    monkeypatch.setattr(crud, "get_predictions", AsyncMock(return_value=predictions))
+    monkeypatch.setattr(crud, "get_tags_by_site_id", AsyncMock(return_value=["flats", "official"]))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/sites/42/predictions")
+
+    assert response.status_code == 200
+    payload = response.json()[0]
+    assert payload["site_id"] == 42
+    assert payload["tags"] == ["flats", "official"]
+    assert payload["predictions"][0]["date"] == "2026-08-02"
+    assert payload["predictions"][0]["values"] == [
+        0.81,
+        0.0,
+        0.42,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_predictions_endpoint_returns_404_for_unknown_site(monkeypatch):
+    monkeypatch.setattr(crud, "get_site", AsyncMock(return_value=None))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/sites/999/predictions")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Site not found"}
+
+
+@pytest.mark.asyncio
+async def test_forecast_endpoint_serializes_forecast_payloads(monkeypatch):
+    now = datetime(2026, 8, 1, 6, 0, 0)
+    site = SimpleNamespace(site_id=7, lat_gfs=50.0, lon_gfs=14.0)
+    forecast = SimpleNamespace(
+        date=date(2026, 8, 3),
+        computed_at=now,
+        gfs_forecast_at=now,
+        lat_gfs=50.0,
+        lon_gfs=14.0,
+        forecast_9={"wind_speed": 3.2},
+        forecast_12={"wind_speed": 4.1},
+        forecast_15={"wind_speed": 5.0},
+    )
+
+    monkeypatch.setattr(crud, "get_site", AsyncMock(return_value=site))
+    get_forecast = AsyncMock(return_value=forecast)
+    monkeypatch.setattr(crud, "get_forecast", get_forecast)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/sites/7/forecast", params={"query_date": "2026-08-03"})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["forecast_9"] == {"wind_speed": 3.2}
+    assert payload["forecast_12"] == {"wind_speed": 4.1}
+    assert payload["forecast_15"] == {"wind_speed": 5.0}
+    get_forecast.assert_awaited_once_with(
+        pytest.ANY,
+        date(2026, 8, 3),
+        50.0,
+        14.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_spots_endpoint_distinguishes_empty_result_from_missing_site(monkeypatch):
+    monkeypatch.setattr(crud, "get_site", AsyncMock(return_value=SimpleNamespace(site_id=11)))
+    monkeypatch.setattr(crud, "get_spots_by_site_id", AsyncMock(return_value=[]))
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/sites/11/spots")
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+    monkeypatch.setattr(crud, "get_site", AsyncMock(return_value=None))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        missing_response = await client.get("/sites/11/spots")
+
+    assert missing_response.status_code == 404
+    assert missing_response.json() == {"detail": "Site with ID 11 not found"}

--- a/backend/tests/test_trip_planning_api.py
+++ b/backend/tests/test_trip_planning_api.py
@@ -1,0 +1,116 @@
+import os
+from unittest.mock import ANY, AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
+os.environ.setdefault("CORS_ALLOW_ORIGINS", "http://localhost:3000")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+from app.main import app
+from app.services import trip_planner_service
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_rejects_reversed_date_range(monkeypatch):
+    plan_service = AsyncMock()
+    monkeypatch.setattr(trip_planner_service, "plan_trip_service", plan_service)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/plan-trip",
+            json={
+                "start_date": "2026-08-10",
+                "end_date": "2026-08-01",
+                "metric": "XC0",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.json() == {"detail": "Start date cannot be after end date."}
+    plan_service.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_forwards_filters_and_pagination(monkeypatch):
+    service_response = {
+        "sites": [
+            {
+                "site_name": "Rana",
+                "average_flyability": 0.76,
+                "site_id": "1",
+                "latitude": 50.404,
+                "longitude": 13.771,
+                "altitude": 457,
+                "distance_km": 63.4,
+                "daily_probabilities": [
+                    {
+                        "date": "2026-08-02",
+                        "probability": 0.76,
+                        "source": "forecast",
+                    }
+                ],
+            }
+        ],
+        "total_count": 21,
+        "has_more": True,
+    }
+    plan_service = AsyncMock(return_value=service_response)
+    monkeypatch.setattr(trip_planner_service, "plan_trip_service", plan_service)
+
+    request_payload = {
+        "start_date": "2026-08-02",
+        "end_date": "2026-08-04",
+        "metric": "XC20",
+        "user_latitude": 50.0755,
+        "user_longitude": 14.4378,
+        "max_distance_km": 250,
+        "min_altitude_m": 100,
+        "max_altitude_m": 1800,
+        "required_tags": ["official", "alps"],
+        "offset": 10,
+        "limit": 5,
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post("/plan-trip", json=request_payload)
+
+    assert response.status_code == 200
+    assert response.json() == service_response
+    plan_service.assert_awaited_once_with(
+        db=ANY,
+        start_date=ANY,
+        end_date=ANY,
+        metric="XC20",
+        user_latitude=50.0755,
+        user_longitude=14.4378,
+        max_distance_km=250.0,
+        min_altitude_m=100,
+        max_altitude_m=1800,
+        required_tags=["official", "alps"],
+        offset=10,
+        limit=5,
+    )
+    call_kwargs = plan_service.await_args.kwargs
+    assert call_kwargs["start_date"].isoformat() == "2026-08-02"
+    assert call_kwargs["end_date"].isoformat() == "2026-08-04"
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_rejects_unknown_metric_before_service_call(monkeypatch):
+    plan_service = AsyncMock()
+    monkeypatch.setattr(trip_planner_service, "plan_trip_service", plan_service)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/plan-trip",
+            json={
+                "start_date": "2026-08-01",
+                "end_date": "2026-08-02",
+                "metric": "XC15",
+            },
+        )
+
+    assert response.status_code == 422
+    plan_service.assert_not_awaited()

--- a/frontend/src/api.test.jsx
+++ b/frontend/src/api.test.jsx
@@ -1,21 +1,25 @@
-const mockApiClient = jest.fn();
-mockApiClient.get = jest.fn();
-mockApiClient.post = jest.fn();
-mockApiClient.patch = jest.fn();
-mockApiClient.delete = jest.fn();
-mockApiClient.interceptors = {
-  request: { use: jest.fn() },
-  response: { use: jest.fn() },
-};
+jest.mock('axios', () => {
+  const client = jest.fn();
+  client.get = jest.fn();
+  client.post = jest.fn();
+  client.patch = jest.fn();
+  client.delete = jest.fn();
+  client.interceptors = {
+    request: { use: jest.fn() },
+    response: { use: jest.fn() },
+  };
 
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: {
-    create: jest.fn(() => mockApiClient),
-    isCancel: jest.fn(() => false),
-  },
-}));
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(() => client),
+      isCancel: jest.fn(() => false),
+      __mockClient: client,
+    },
+  };
+});
 
+import axios from 'axios';
 import {
   fetchSiteForecast,
   getAccessToken,
@@ -25,6 +29,7 @@ import {
   setAccessToken,
 } from './api';
 
+const mockApiClient = axios.__mockClient;
 const requestInterceptor = mockApiClient.interceptors.request.use.mock.calls[0][0];
 const responseErrorInterceptor = mockApiClient.interceptors.response.use.mock.calls[0][1];
 

--- a/frontend/src/api.test.jsx
+++ b/frontend/src/api.test.jsx
@@ -1,0 +1,180 @@
+const mockApiClient = jest.fn();
+mockApiClient.get = jest.fn();
+mockApiClient.post = jest.fn();
+mockApiClient.patch = jest.fn();
+mockApiClient.delete = jest.fn();
+mockApiClient.interceptors = {
+  request: { use: jest.fn() },
+  response: { use: jest.fn() },
+};
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(() => mockApiClient),
+    isCancel: jest.fn(() => false),
+  },
+}));
+
+import {
+  fetchSiteForecast,
+  getAccessToken,
+  loginUser,
+  logoutUser,
+  planTrip,
+  setAccessToken,
+} from './api';
+
+const requestInterceptor = mockApiClient.interceptors.request.use.mock.calls[0][0];
+const responseErrorInterceptor = mockApiClient.interceptors.response.use.mock.calls[0][1];
+
+describe('API client', () => {
+  beforeEach(() => {
+    mockApiClient.mockReset();
+    mockApiClient.get.mockReset();
+    mockApiClient.post.mockReset();
+    mockApiClient.patch.mockReset();
+    mockApiClient.delete.mockReset();
+    setAccessToken(null);
+  });
+
+  it('adds the bearer token and request metadata', () => {
+    setAccessToken('access-token');
+    const config = {
+      headers: {},
+      method: 'get',
+      url: '/sites/list',
+    };
+
+    const result = requestInterceptor(config);
+
+    expect(result.headers.Authorization).toBe('Bearer access-token');
+    expect(result.metadata.requestId).toMatch(/^api-\d+$/);
+    expect(result.metadata.startedAt).toEqual(expect.any(Number));
+  });
+
+  it('passes AbortSignal and query parameters to forecast requests', async () => {
+    const controller = new AbortController();
+    mockApiClient.get.mockResolvedValue({ data: { date: '2026-08-02' } });
+
+    const result = await fetchSiteForecast(42, '2026-08-02', { signal: controller.signal });
+
+    expect(result).toEqual({ date: '2026-08-02' });
+    expect(mockApiClient.get).toHaveBeenCalledWith('/sites/42/forecast', {
+      params: { query_date: '2026-08-02' },
+      signal: controller.signal,
+    });
+  });
+
+  it('builds a complete cancellable trip-planning request, including zero coordinates', async () => {
+    const controller = new AbortController();
+    mockApiClient.post.mockResolvedValue({ data: { sites: [], total_count: 0, has_more: false } });
+
+    await planTrip(
+      '2026-08-02',
+      '2026-08-04',
+      'XC20',
+      { latitude: 0, longitude: 0 },
+      250,
+      { min: 0, max: 1800 },
+      10,
+      5,
+      ['official', 'alps'],
+      { signal: controller.signal },
+    );
+
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      '/plan-trip',
+      {
+        start_date: '2026-08-02',
+        end_date: '2026-08-04',
+        metric: 'XC20',
+        user_latitude: 0,
+        user_longitude: 0,
+        max_distance_km: 250,
+        min_altitude_m: 0,
+        max_altitude_m: 1800,
+        required_tags: ['official', 'alps'],
+        offset: 10,
+        limit: 5,
+      },
+      { signal: controller.signal },
+    );
+  });
+
+  it('omits disabled optional trip-planning filters', async () => {
+    mockApiClient.post.mockResolvedValue({ data: { sites: [], total_count: 0, has_more: false } });
+
+    await planTrip(
+      '2026-08-02',
+      '2026-08-04',
+      'XC0',
+      null,
+      0,
+      { min: null, max: -1 },
+      0,
+      10,
+      [],
+    );
+
+    expect(mockApiClient.post).toHaveBeenCalledWith(
+      '/plan-trip',
+      {
+        start_date: '2026-08-02',
+        end_date: '2026-08-04',
+        metric: 'XC0',
+        offset: 0,
+        limit: 10,
+      },
+      { signal: undefined },
+    );
+  });
+
+  it('refreshes once after a 401 and retries with the new token', async () => {
+    const originalRequest = {
+      url: '/users/me/profile',
+      method: 'get',
+      headers: { Authorization: 'Bearer expired' },
+    };
+    const retriedResponse = { data: { display_name: 'Pilot' } };
+    mockApiClient.post.mockResolvedValue({ data: { access_token: 'fresh-token' } });
+    mockApiClient.mockResolvedValue(retriedResponse);
+
+    const result = await responseErrorInterceptor({
+      config: originalRequest,
+      response: { status: 401 },
+      message: 'Unauthorized',
+    });
+
+    expect(mockApiClient.post).toHaveBeenCalledWith('/auth/refresh');
+    expect(originalRequest._retry).toBe(true);
+    expect(originalRequest.headers.Authorization).toBe('Bearer fresh-token');
+    expect(mockApiClient).toHaveBeenCalledWith(originalRequest);
+    expect(result).toBe(retriedResponse);
+    expect(getAccessToken()).toBe('fresh-token');
+  });
+
+  it('does not recursively refresh the refresh endpoint', async () => {
+    const error = {
+      config: { url: '/auth/refresh', method: 'post', headers: {} },
+      response: { status: 401 },
+      message: 'Unauthorized',
+    };
+
+    await expect(responseErrorInterceptor(error)).rejects.toBe(error);
+    expect(mockApiClient.post).not.toHaveBeenCalled();
+  });
+
+  it('stores a token on login and clears it on logout', async () => {
+    mockApiClient.post
+      .mockResolvedValueOnce({ data: { access_token: 'login-token' } })
+      .mockResolvedValueOnce({ data: { ok: true } });
+
+    await loginUser('pilot@example.com', 'StrongPass1!');
+    expect(getAccessToken()).toBe('login-token');
+
+    await logoutUser();
+    expect(getAccessToken()).toBeNull();
+    expect(mockApiClient.post).toHaveBeenNthCalledWith(2, '/auth/logout');
+  });
+});

--- a/frontend/src/pages/Details.test.jsx
+++ b/frontend/src/pages/Details.test.jsx
@@ -13,6 +13,11 @@ import {
   fetchSiteResources,
 } from '../api';
 
+jest.mock('@mui/material', () => ({
+  ...jest.requireActual('@mui/material'),
+  useMediaQuery: () => false,
+}));
+
 jest.mock('../api', () => ({
   fetchFlightStats: jest.fn(),
   fetchSiteForecast: jest.fn(),
@@ -83,22 +88,6 @@ const renderDetails = () => {
 };
 
 describe('Details data loading', () => {
-  beforeAll(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation((query) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: jest.fn(),
-        removeListener: jest.fn(),
-        addEventListener: jest.fn(),
-        removeEventListener: jest.fn(),
-        dispatchEvent: jest.fn(),
-      })),
-    });
-  });
-
   beforeEach(() => {
     jest.clearAllMocks();
 

--- a/frontend/src/pages/Details.test.jsx
+++ b/frontend/src/pages/Details.test.jsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import Details from './Details';
+import {
+  fetchFlightStats,
+  fetchSiteForecast,
+  fetchSiteInfo,
+  fetchSitePredictions,
+  fetchSiteResources,
+} from '../api';
+
+jest.mock('../api', () => ({
+  fetchFlightStats: jest.fn(),
+  fetchSiteForecast: jest.fn(),
+  fetchSiteInfo: jest.fn(),
+  fetchSitePredictions: jest.fn(),
+  fetchSiteResources: jest.fn(),
+}));
+
+jest.mock('../context/AuthContext', () => ({
+  useAuth: () => ({
+    isAuthenticated: false,
+    toggleFavoriteSite: jest.fn(),
+    isFavorite: jest.fn(() => false),
+  }),
+}));
+
+jest.mock('../hooks/useDefaultMetric', () => ({
+  useDefaultMetric: () => ({ preferredMetric: 'XC0' }),
+}));
+
+jest.mock('../components/GlideatorForecast', () => () => <div>Forecast summary</div>);
+jest.mock('../components/LoadingSpinner', () => () => <div>Loading</div>);
+jest.mock('../components/D3Forecast', () => ({
+  __esModule: true,
+  default: () => <div>Atmospheric profile</div>,
+}));
+jest.mock('../components/FlightStatsChart', () => ({
+  __esModule: true,
+  default: () => <div>Season chart</div>,
+}));
+jest.mock('../components/SearchRecs', () => ({
+  __esModule: true,
+  default: () => <div>Search recommendations</div>,
+}));
+jest.mock('../components/SimilarDaysPanel', () => ({
+  __esModule: true,
+  default: () => <div>Similar days</div>,
+}));
+jest.mock('../components/SiteMap', () => ({
+  __esModule: true,
+  default: () => <div>Site map</div>,
+}));
+
+const renderDetails = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+
+  render(
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/details/1?date=2026-08-02&metric=XC0&tab=forecast']}>
+          <Routes>
+            <Route path="/details/:siteId" element={<Details />} />
+            <Route path="/404" element={<div>Not found</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+
+  return queryClient;
+};
+
+describe('Details data loading', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    fetchSitePredictions.mockResolvedValue([
+      {
+        site_id: 1,
+        name: 'Raná',
+        latitude: 50.404,
+        longitude: 13.771,
+        altitude: 457,
+        tags: ['flats'],
+        predictions: [
+          {
+            date: '2026-08-02',
+            values: [0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1, 0.05, 0.02, 0.01],
+            computed_at: '2026-08-01T06:00:00',
+            gfs_forecast_at: '2026-08-01T00:00:00',
+          },
+        ],
+      },
+    ]);
+    fetchSiteInfo.mockResolvedValue({
+      site_id: 1,
+      site_name: 'Raná',
+      country: 'Czechia',
+      html: '<p>Site information</p>',
+    });
+    fetchSiteResources.mockResolvedValue({
+      site_id: 1,
+      local_resources: [],
+      webcam_urls: [],
+      meteostation_urls: [],
+    });
+    fetchFlightStats.mockResolvedValue({ 0: [1, 2, 3] });
+    fetchSiteForecast.mockResolvedValue({
+      date: '2026-08-02',
+      computed_at: '2026-08-01T06:00:00',
+      gfs_forecast_at: '2026-08-01T00:00:00',
+      forecast_9: { wind_speed: 3 },
+      forecast_12: { wind_speed: 4 },
+      forecast_15: { wind_speed: 5 },
+    });
+  });
+
+  it('loads expensive tab data only when the user opens it', async () => {
+    const queryClient = renderDetails();
+
+    expect(await screen.findByRole('heading', { name: 'Raná' })).toBeInTheDocument();
+    expect(fetchSitePredictions).toHaveBeenCalledTimes(1);
+    expect(fetchSiteInfo).toHaveBeenCalledTimes(1);
+    expect(fetchSiteForecast).not.toHaveBeenCalled();
+    expect(fetchFlightStats).not.toHaveBeenCalled();
+    expect(fetchSiteResources).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('tab', { name: /resources/i }));
+    await waitFor(() => expect(fetchSiteResources).toHaveBeenCalledTimes(1));
+    expect(fetchFlightStats).not.toHaveBeenCalled();
+    expect(fetchSiteForecast).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('tab', { name: /season/i }));
+    await waitFor(() => expect(fetchFlightStats).toHaveBeenCalledTimes(1));
+    expect(fetchSiteForecast).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('tab', { name: /activity forecast/i }));
+    fireEvent.click(screen.getByRole('button', { name: /see what's driving this/i }));
+    await waitFor(() => expect(fetchSiteForecast).toHaveBeenCalledTimes(1));
+
+    const forecastCall = fetchSiteForecast.mock.calls[0];
+    expect(forecastCall[0]).toBe('1');
+    expect(forecastCall[1]).toBe('2026-08-02');
+    expect(forecastCall[2].signal).toBeDefined();
+
+    queryClient.clear();
+  });
+});


### PR DESCRIPTION
## What changed

- add backend API regression tests for site predictions, forecast serialization, spot lookup semantics, and trip-planning validation/filter forwarding
- add frontend API tests for AbortSignal propagation, trip-request construction, bearer-token injection, and 401 refresh/retry behavior
- add a Details page integration test verifying that forecast, season, and resource data are fetched lazily when the relevant UI is opened
- report backend and frontend coverage in CI without enforcing an initial percentage threshold

## Why

The existing suite was concentrated around authentication and notifications, while core forecasting and trip-planning flows had little regression protection. PR #80 also introduced cancellable React Query requests and lazy tab loading without tests covering those lifecycle behaviors.

## Validation

- backend: 25 tests passed
- backend application coverage: 51% statements
- frontend: 4 suites and 10 tests passed
- frontend coverage: 8.4% statements, 7.43% branches, 5.97% functions, 8.72% lines
- optimized frontend production build completed successfully

## Interpretation

This PR establishes a measurable baseline and protects several high-risk request and endpoint paths, but overall coverage is still not sufficient. The next highest-value additions are TripPlannerPage interaction and pagination tests, direct trip-planner service tests, Celery task tests, and a small Playwright smoke suite.

## Developer impact

CI now exposes concrete coverage numbers on every pull request. No threshold is enforced yet, avoiding a low global target becoming permanent; a threshold can be introduced after the next focused coverage tranche.