### PR TITLE
Add trip planner service and interaction coverage

### DIFF
--- a/backend/app/services/trip_planner_service.py
+++ b/backend/app/services/trip_planner_service.py
@@ -1,71 +1,60 @@
-import datetime
 import calendar
+import datetime
 import math
-from sqlalchemy.ext.asyncio import AsyncSession
-from typing import List, Dict, Any, Tuple, Literal, Optional
 from collections import defaultdict
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
-from .. import schemas, crud, models # Ensure crud and models are imported
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud, models, schemas
 
 
 def calculate_distance_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """
-    Calculate the great circle distance between two points on Earth using the Haversine formula.
-    
-    Args:
-        lat1, lon1: Latitude and longitude of first point in decimal degrees
-        lat2, lon2: Latitude and longitude of second point in decimal degrees
-    
-    Returns:
-        Distance in kilometers
-    """
-    # Convert decimal degrees to radians
+    """Calculate great-circle distance between two coordinates in kilometers."""
     lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
-    
-    # Haversine formula
     dlat = lat2 - lat1
     dlon = lon2 - lon1
-    a = math.sin(dlat/2)**2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon/2)**2
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
     c = 2 * math.asin(math.sqrt(a))
-    
-    # Radius of Earth in kilometers
-    r = 6371
-    
-    return c * r
+    return c * 6371
 
 
 def get_flight_stats_attr_for_metric(metric: str) -> str:
-    """Maps metric name to the corresponding FlightStats attribute name."""
+    """Map a metric name to the matching FlightStats attribute."""
     metric_to_attr = {
-        'XC0': 'avg_days_over_0',
-        'XC10': 'avg_days_over_10', 
-        'XC20': 'avg_days_over_20',
-        'XC30': 'avg_days_over_30',
-        'XC40': 'avg_days_over_40',
-        'XC50': 'avg_days_over_50',
-        'XC60': 'avg_days_over_60',
-        'XC70': 'avg_days_over_70',
-        'XC80': 'avg_days_over_80',
-        'XC90': 'avg_days_over_90',
-        'XC100': 'avg_days_over_100'
+        "XC0": "avg_days_over_0",
+        "XC10": "avg_days_over_10",
+        "XC20": "avg_days_over_20",
+        "XC30": "avg_days_over_30",
+        "XC40": "avg_days_over_40",
+        "XC50": "avg_days_over_50",
+        "XC60": "avg_days_over_60",
+        "XC70": "avg_days_over_70",
+        "XC80": "avg_days_over_80",
+        "XC90": "avg_days_over_90",
+        "XC100": "avg_days_over_100",
     }
-    return metric_to_attr.get(metric, 'avg_days_over_0')
+    return metric_to_attr.get(metric, "avg_days_over_0")
 
-def get_historical_prob(flight_stats: models.FlightStats, year: int, month: int, metric: str) -> float:
-    """Calculates historical flyability probability from FlightStats for the given metric."""
+
+def get_historical_prob(
+    flight_stats: models.FlightStats,
+    year: int,
+    month: int,
+    metric: str,
+) -> float:
+    """Calculate historical flyability probability for a month and metric."""
     days_in_month = calendar.monthrange(year, month)[1]
-    
-    # Get the appropriate attribute based on the metric
     attr_name = get_flight_stats_attr_for_metric(metric)
     avg_flyable_days = getattr(flight_stats, attr_name, 0.0)
-    
     return (avg_flyable_days / days_in_month) if days_in_month > 0 else 0
 
+
 async def plan_trip_service(
-    db: AsyncSession, 
-    start_date: datetime.date, 
-    end_date: datetime.date, 
-    metric: str = 'XC0',
+    db: AsyncSession,
+    start_date: datetime.date,
+    end_date: datetime.date,
+    metric: str = "XC0",
     user_latitude: Optional[float] = None,
     user_longitude: Optional[float] = None,
     max_distance_km: Optional[float] = None,
@@ -73,136 +62,144 @@ async def plan_trip_service(
     max_altitude_m: Optional[int] = None,
     required_tags: Optional[List[str]] = None,
     offset: int = 0,
-    limit: int = 10
+    limit: int = 10,
 ) -> schemas.TripPlanResponse:
-    """
-    Core logic to query forecasts and historical stats, aggregate data, and rank sites.
-    """
-    # --- 1. Define Date Ranges & Fetch Data ---
-    
+    """Query forecasts and historical stats, aggregate them, and rank sites."""
     today = datetime.date.today()
     forecast_horizon = today + datetime.timedelta(days=7)
-
     forecast_start_date = max(start_date, today)
     forecast_end_date = min(end_date, forecast_horizon)
-    
+
     predictions = []
     if forecast_start_date <= forecast_end_date:
         predictions = await crud.get_predictions_for_range(
-            db, start_date=forecast_start_date, end_date=forecast_end_date, metric=metric
+            db,
+            start_date=forecast_start_date,
+            end_date=forecast_end_date,
+            metric=metric,
         )
 
     all_flight_stats = await crud.get_all_flight_stats(db)
-    all_sites = await crud.get_sites(db, skip=0, limit=1000)  # Get all sites with coordinates
+    all_sites = await crud.get_sites(db, skip=0, limit=1000)
 
     if not all_sites:
-        return []
+        return schemas.TripPlanResponse(sites=[], total_count=0, has_more=False)
 
-    # --- 2. Pre-process Data into Lookup Maps ---
-
-    pred_map = {(p.site_id, p.date): p.value for p in predictions}
+    pred_map = {(prediction.site_id, prediction.date): prediction.value for prediction in predictions}
     stats_map: Dict[Tuple[int, int], float] = {}
-    
+
     unique_months = set()
-    d = start_date
-    while d <= end_date:
-        unique_months.add((d.year, d.month))
-        d = (d.replace(day=1) + datetime.timedelta(days=32)).replace(day=1)
+    current_month = start_date
+    while current_month <= end_date:
+        unique_months.add((current_month.year, current_month.month))
+        current_month = (
+            current_month.replace(day=1) + datetime.timedelta(days=32)
+        ).replace(day=1)
 
     for stat in all_flight_stats:
         for year, month in unique_months:
             if stat.month == month:
-                prob = get_historical_prob(stat, year, month, metric)
-                stats_map[(stat.site_id, month)] = prob
+                stats_map[(stat.site_id, month)] = get_historical_prob(
+                    stat,
+                    year,
+                    month,
+                    metric,
+                )
 
     site_name_map = {site.site_id: site.name for site in all_sites}
     site_lat_map = {site.site_id: site.latitude for site in all_sites}
     site_lon_map = {site.site_id: site.longitude for site in all_sites}
     site_altitude_map = {site.site_id: site.altitude for site in all_sites}
 
-    # --- 3. Aggregate Probabilities Per Site ---
+    site_data: Dict[int, Dict[str, Any]] = defaultdict(
+        lambda: {"total_prob": 0.0, "count": 0, "daily_probs": []}
+    )
 
-    site_data: Dict[int, Dict[str, Any]] = defaultdict(lambda: {'total_prob': 0.0, 'count': 0, 'daily_probs': []})
-    
     current_date = start_date
     while current_date <= end_date:
-        for site_id, site_name in site_name_map.items():
-            prob = pred_map.get((site_id, current_date))
-            source: Literal['forecast', 'historical'] = 'forecast'
+        for site_id in site_name_map:
+            probability = pred_map.get((site_id, current_date))
+            source: Literal["forecast", "historical"] = "forecast"
 
-            if prob is None:
-                prob = stats_map.get((site_id, current_date.month), 0.0)
-                source = 'historical'
+            if probability is None:
+                probability = stats_map.get((site_id, current_date.month), 0.0)
+                source = "historical"
 
-            site_data[site_id]['total_prob'] += prob
-            site_data[site_id]['count'] += 1
-            site_data[site_id]['daily_probs'].append(
-                schemas.DailyProbability(date=current_date, probability=prob, source=source)
-            )
-        
-        current_date += datetime.timedelta(days=1)
-
-    # --- 4. Format and Rank Results ---
-    
-    # Bulk load all tags if needed (to avoid N+1 query problem)
-    site_tags_map = {}
-    if required_tags:
-        site_ids_with_data = [site_id for site_id, data in site_data.items() if data['count'] > 0]
-        site_tags_map = await crud.get_tags_by_site_ids(db, site_ids_with_data)
-    
-    suggestions = []
-    for site_id, data in site_data.items():
-        if data['count'] > 0:
-            site_lat = site_lat_map.get(site_id, 0.0)
-            site_lon = site_lon_map.get(site_id, 0.0)
-            site_altitude = site_altitude_map.get(site_id, 0)
-            # Apply tag filter (logical AND) if required_tags provided
-            if required_tags:
-                site_tags = set(site_tags_map.get(site_id, []))
-                if not set(required_tags).issubset(site_tags):
-                    continue
-            
-            # Apply altitude filtering if provided
-            if min_altitude_m is not None and site_altitude < min_altitude_m:
-                continue  # Skip sites below minimum altitude
-            if max_altitude_m is not None and site_altitude > max_altitude_m:
-                continue  # Skip sites above maximum altitude
-            
-            # Calculate distance if user location is provided
-            distance_km = None
-            if user_latitude is not None and user_longitude is not None:
-                distance_km = calculate_distance_km(user_latitude, user_longitude, site_lat, site_lon)
-                
-                # Apply distance filtering if max distance is also provided
-                if max_distance_km is not None and max_distance_km > 0:
-                    if distance_km > max_distance_km:
-                        continue  # Skip sites beyond max distance
-            
-            avg_flyability = data['total_prob'] / data['count']
-            suggestions.append(
-                schemas.SiteSuggestion(
-                    site_id=str(site_id),
-                    site_name=site_name_map.get(site_id, f'Site ID: {site_id}'),
-                    latitude=site_lat,
-                    longitude=site_lon,
-                    altitude=site_altitude,
-                    average_flyability=round(avg_flyability, 3),
-                    daily_probabilities=data['daily_probs'],
-                    distance_km=round(distance_km, 1) if distance_km is not None else None
+            site_data[site_id]["total_prob"] += probability
+            site_data[site_id]["count"] += 1
+            site_data[site_id]["daily_probs"].append(
+                schemas.DailyProbability(
+                    date=current_date,
+                    probability=probability,
+                    source=source,
                 )
             )
 
-    suggestions.sort(key=lambda s: s.average_flyability, reverse=True)
-    
-    # Calculate pagination
+        current_date += datetime.timedelta(days=1)
+
+    site_tags_map = {}
+    if required_tags:
+        site_ids_with_data = [
+            site_id for site_id, data in site_data.items() if data["count"] > 0
+        ]
+        site_tags_map = await crud.get_tags_by_site_ids(db, site_ids_with_data)
+
+    suggestions = []
+    for site_id, data in site_data.items():
+        if data["count"] <= 0:
+            continue
+
+        site_lat = site_lat_map.get(site_id, 0.0)
+        site_lon = site_lon_map.get(site_id, 0.0)
+        site_altitude = site_altitude_map.get(site_id, 0)
+
+        if required_tags:
+            site_tags = set(site_tags_map.get(site_id, []))
+            if not set(required_tags).issubset(site_tags):
+                continue
+
+        if min_altitude_m is not None and site_altitude < min_altitude_m:
+            continue
+        if max_altitude_m is not None and site_altitude > max_altitude_m:
+            continue
+
+        distance_km = None
+        if user_latitude is not None and user_longitude is not None:
+            distance_km = calculate_distance_km(
+                user_latitude,
+                user_longitude,
+                site_lat,
+                site_lon,
+            )
+            if (
+                max_distance_km is not None
+                and max_distance_km > 0
+                and distance_km > max_distance_km
+            ):
+                continue
+
+        average_flyability = data["total_prob"] / data["count"]
+        suggestions.append(
+            schemas.SiteSuggestion(
+                site_id=str(site_id),
+                site_name=site_name_map.get(site_id, f"Site ID: {site_id}"),
+                latitude=site_lat,
+                longitude=site_lon,
+                altitude=site_altitude,
+                average_flyability=round(average_flyability, 3),
+                daily_probabilities=data["daily_probs"],
+                distance_km=round(distance_km, 1) if distance_km is not None else None,
+            )
+        )
+
+    suggestions.sort(key=lambda suggestion: suggestion.average_flyability, reverse=True)
+
     total_count = len(suggestions)
-    start_idx = offset
-    end_idx = offset + limit
-    paginated_sites = suggestions[start_idx:end_idx]
-    has_more = end_idx < total_count
-    
+    end_index = offset + limit
+    paginated_sites = suggestions[offset:end_index]
+
     return schemas.TripPlanResponse(
         sites=paginated_sites,
         total_count=total_count,
-        has_more=has_more
+        has_more=end_index < total_count,
     )

--- a/backend/app/services/trip_planner_service.py
+++ b/backend/app/services/trip_planner_service.py
@@ -1,60 +1,71 @@
-import calendar
 import datetime
+import calendar
 import math
-from collections import defaultdict
-from typing import Any, Dict, List, Literal, Optional, Tuple
-
 from sqlalchemy.ext.asyncio import AsyncSession
+from typing import List, Dict, Any, Tuple, Literal, Optional
+from collections import defaultdict
 
-from .. import crud, models, schemas
+from .. import schemas, crud, models # Ensure crud and models are imported
 
 
 def calculate_distance_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
-    """Calculate great-circle distance between two coordinates in kilometers."""
+    """
+    Calculate the great circle distance between two points on Earth using the Haversine formula.
+    
+    Args:
+        lat1, lon1: Latitude and longitude of first point in decimal degrees
+        lat2, lon2: Latitude and longitude of second point in decimal degrees
+    
+    Returns:
+        Distance in kilometers
+    """
+    # Convert decimal degrees to radians
     lat1, lon1, lat2, lon2 = map(math.radians, [lat1, lon1, lat2, lon2])
+    
+    # Haversine formula
     dlat = lat2 - lat1
     dlon = lon2 - lon1
-    a = math.sin(dlat / 2) ** 2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2) ** 2
+    a = math.sin(dlat/2)**2 + math.cos(lat1) * math.cos(lat2) * math.sin(dlon/2)**2
     c = 2 * math.asin(math.sqrt(a))
-    return c * 6371
+    
+    # Radius of Earth in kilometers
+    r = 6371
+    
+    return c * r
 
 
 def get_flight_stats_attr_for_metric(metric: str) -> str:
-    """Map a metric name to the matching FlightStats attribute."""
+    """Maps metric name to the corresponding FlightStats attribute name."""
     metric_to_attr = {
-        "XC0": "avg_days_over_0",
-        "XC10": "avg_days_over_10",
-        "XC20": "avg_days_over_20",
-        "XC30": "avg_days_over_30",
-        "XC40": "avg_days_over_40",
-        "XC50": "avg_days_over_50",
-        "XC60": "avg_days_over_60",
-        "XC70": "avg_days_over_70",
-        "XC80": "avg_days_over_80",
-        "XC90": "avg_days_over_90",
-        "XC100": "avg_days_over_100",
+        'XC0': 'avg_days_over_0',
+        'XC10': 'avg_days_over_10', 
+        'XC20': 'avg_days_over_20',
+        'XC30': 'avg_days_over_30',
+        'XC40': 'avg_days_over_40',
+        'XC50': 'avg_days_over_50',
+        'XC60': 'avg_days_over_60',
+        'XC70': 'avg_days_over_70',
+        'XC80': 'avg_days_over_80',
+        'XC90': 'avg_days_over_90',
+        'XC100': 'avg_days_over_100'
     }
-    return metric_to_attr.get(metric, "avg_days_over_0")
+    return metric_to_attr.get(metric, 'avg_days_over_0')
 
-
-def get_historical_prob(
-    flight_stats: models.FlightStats,
-    year: int,
-    month: int,
-    metric: str,
-) -> float:
-    """Calculate historical flyability probability for a month and metric."""
+def get_historical_prob(flight_stats: models.FlightStats, year: int, month: int, metric: str) -> float:
+    """Calculates historical flyability probability from FlightStats for the given metric."""
     days_in_month = calendar.monthrange(year, month)[1]
+    
+    # Get the appropriate attribute based on the metric
     attr_name = get_flight_stats_attr_for_metric(metric)
     avg_flyable_days = getattr(flight_stats, attr_name, 0.0)
+    
     return (avg_flyable_days / days_in_month) if days_in_month > 0 else 0
 
-
 async def plan_trip_service(
-    db: AsyncSession,
-    start_date: datetime.date,
-    end_date: datetime.date,
-    metric: str = "XC0",
+    db: AsyncSession, 
+    start_date: datetime.date, 
+    end_date: datetime.date, 
+    metric: str = 'XC0',
     user_latitude: Optional[float] = None,
     user_longitude: Optional[float] = None,
     max_distance_km: Optional[float] = None,
@@ -62,144 +73,136 @@ async def plan_trip_service(
     max_altitude_m: Optional[int] = None,
     required_tags: Optional[List[str]] = None,
     offset: int = 0,
-    limit: int = 10,
+    limit: int = 10
 ) -> schemas.TripPlanResponse:
-    """Query forecasts and historical stats, aggregate them, and rank sites."""
+    """
+    Core logic to query forecasts and historical stats, aggregate data, and rank sites.
+    """
+    # --- 1. Define Date Ranges & Fetch Data ---
+    
     today = datetime.date.today()
     forecast_horizon = today + datetime.timedelta(days=7)
+
     forecast_start_date = max(start_date, today)
     forecast_end_date = min(end_date, forecast_horizon)
-
+    
     predictions = []
     if forecast_start_date <= forecast_end_date:
         predictions = await crud.get_predictions_for_range(
-            db,
-            start_date=forecast_start_date,
-            end_date=forecast_end_date,
-            metric=metric,
+            db, start_date=forecast_start_date, end_date=forecast_end_date, metric=metric
         )
 
     all_flight_stats = await crud.get_all_flight_stats(db)
-    all_sites = await crud.get_sites(db, skip=0, limit=1000)
+    all_sites = await crud.get_sites(db, skip=0, limit=1000)  # Get all sites with coordinates
 
     if not all_sites:
         return schemas.TripPlanResponse(sites=[], total_count=0, has_more=False)
 
-    pred_map = {(prediction.site_id, prediction.date): prediction.value for prediction in predictions}
-    stats_map: Dict[Tuple[int, int], float] = {}
+    # --- 2. Pre-process Data into Lookup Maps ---
 
+    pred_map = {(p.site_id, p.date): p.value for p in predictions}
+    stats_map: Dict[Tuple[int, int], float] = {}
+    
     unique_months = set()
-    current_month = start_date
-    while current_month <= end_date:
-        unique_months.add((current_month.year, current_month.month))
-        current_month = (
-            current_month.replace(day=1) + datetime.timedelta(days=32)
-        ).replace(day=1)
+    d = start_date
+    while d <= end_date:
+        unique_months.add((d.year, d.month))
+        d = (d.replace(day=1) + datetime.timedelta(days=32)).replace(day=1)
 
     for stat in all_flight_stats:
         for year, month in unique_months:
             if stat.month == month:
-                stats_map[(stat.site_id, month)] = get_historical_prob(
-                    stat,
-                    year,
-                    month,
-                    metric,
-                )
+                prob = get_historical_prob(stat, year, month, metric)
+                stats_map[(stat.site_id, month)] = prob
 
     site_name_map = {site.site_id: site.name for site in all_sites}
     site_lat_map = {site.site_id: site.latitude for site in all_sites}
     site_lon_map = {site.site_id: site.longitude for site in all_sites}
     site_altitude_map = {site.site_id: site.altitude for site in all_sites}
 
-    site_data: Dict[int, Dict[str, Any]] = defaultdict(
-        lambda: {"total_prob": 0.0, "count": 0, "daily_probs": []}
-    )
+    # --- 3. Aggregate Probabilities Per Site ---
 
+    site_data: Dict[int, Dict[str, Any]] = defaultdict(lambda: {'total_prob': 0.0, 'count': 0, 'daily_probs': []})
+    
     current_date = start_date
     while current_date <= end_date:
-        for site_id in site_name_map:
-            probability = pred_map.get((site_id, current_date))
-            source: Literal["forecast", "historical"] = "forecast"
+        for site_id, site_name in site_name_map.items():
+            prob = pred_map.get((site_id, current_date))
+            source: Literal['forecast', 'historical'] = 'forecast'
 
-            if probability is None:
-                probability = stats_map.get((site_id, current_date.month), 0.0)
-                source = "historical"
+            if prob is None:
+                prob = stats_map.get((site_id, current_date.month), 0.0)
+                source = 'historical'
 
-            site_data[site_id]["total_prob"] += probability
-            site_data[site_id]["count"] += 1
-            site_data[site_id]["daily_probs"].append(
-                schemas.DailyProbability(
-                    date=current_date,
-                    probability=probability,
-                    source=source,
+            site_data[site_id]['total_prob'] += prob
+            site_data[site_id]['count'] += 1
+            site_data[site_id]['daily_probs'].append(
+                schemas.DailyProbability(date=current_date, probability=prob, source=source)
+            )
+        
+        current_date += datetime.timedelta(days=1)
+
+    # --- 4. Format and Rank Results ---
+    
+    # Bulk load all tags if needed (to avoid N+1 query problem)
+    site_tags_map = {}
+    if required_tags:
+        site_ids_with_data = [site_id for site_id, data in site_data.items() if data['count'] > 0]
+        site_tags_map = await crud.get_tags_by_site_ids(db, site_ids_with_data)
+    
+    suggestions = []
+    for site_id, data in site_data.items():
+        if data['count'] > 0:
+            site_lat = site_lat_map.get(site_id, 0.0)
+            site_lon = site_lon_map.get(site_id, 0.0)
+            site_altitude = site_altitude_map.get(site_id, 0)
+            # Apply tag filter (logical AND) if required_tags provided
+            if required_tags:
+                site_tags = set(site_tags_map.get(site_id, []))
+                if not set(required_tags).issubset(site_tags):
+                    continue
+            
+            # Apply altitude filtering if provided
+            if min_altitude_m is not None and site_altitude < min_altitude_m:
+                continue  # Skip sites below minimum altitude
+            if max_altitude_m is not None and site_altitude > max_altitude_m:
+                continue  # Skip sites above maximum altitude
+            
+            # Calculate distance if user location is provided
+            distance_km = None
+            if user_latitude is not None and user_longitude is not None:
+                distance_km = calculate_distance_km(user_latitude, user_longitude, site_lat, site_lon)
+                
+                # Apply distance filtering if max distance is also provided
+                if max_distance_km is not None and max_distance_km > 0:
+                    if distance_km > max_distance_km:
+                        continue  # Skip sites beyond max distance
+            
+            avg_flyability = data['total_prob'] / data['count']
+            suggestions.append(
+                schemas.SiteSuggestion(
+                    site_id=str(site_id),
+                    site_name=site_name_map.get(site_id, f'Site ID: {site_id}'),
+                    latitude=site_lat,
+                    longitude=site_lon,
+                    altitude=site_altitude,
+                    average_flyability=round(avg_flyability, 3),
+                    daily_probabilities=data['daily_probs'],
+                    distance_km=round(distance_km, 1) if distance_km is not None else None
                 )
             )
 
-        current_date += datetime.timedelta(days=1)
-
-    site_tags_map = {}
-    if required_tags:
-        site_ids_with_data = [
-            site_id for site_id, data in site_data.items() if data["count"] > 0
-        ]
-        site_tags_map = await crud.get_tags_by_site_ids(db, site_ids_with_data)
-
-    suggestions = []
-    for site_id, data in site_data.items():
-        if data["count"] <= 0:
-            continue
-
-        site_lat = site_lat_map.get(site_id, 0.0)
-        site_lon = site_lon_map.get(site_id, 0.0)
-        site_altitude = site_altitude_map.get(site_id, 0)
-
-        if required_tags:
-            site_tags = set(site_tags_map.get(site_id, []))
-            if not set(required_tags).issubset(site_tags):
-                continue
-
-        if min_altitude_m is not None and site_altitude < min_altitude_m:
-            continue
-        if max_altitude_m is not None and site_altitude > max_altitude_m:
-            continue
-
-        distance_km = None
-        if user_latitude is not None and user_longitude is not None:
-            distance_km = calculate_distance_km(
-                user_latitude,
-                user_longitude,
-                site_lat,
-                site_lon,
-            )
-            if (
-                max_distance_km is not None
-                and max_distance_km > 0
-                and distance_km > max_distance_km
-            ):
-                continue
-
-        average_flyability = data["total_prob"] / data["count"]
-        suggestions.append(
-            schemas.SiteSuggestion(
-                site_id=str(site_id),
-                site_name=site_name_map.get(site_id, f"Site ID: {site_id}"),
-                latitude=site_lat,
-                longitude=site_lon,
-                altitude=site_altitude,
-                average_flyability=round(average_flyability, 3),
-                daily_probabilities=data["daily_probs"],
-                distance_km=round(distance_km, 1) if distance_km is not None else None,
-            )
-        )
-
-    suggestions.sort(key=lambda suggestion: suggestion.average_flyability, reverse=True)
-
+    suggestions.sort(key=lambda s: s.average_flyability, reverse=True)
+    
+    # Calculate pagination
     total_count = len(suggestions)
-    end_index = offset + limit
-    paginated_sites = suggestions[offset:end_index]
-
+    start_idx = offset
+    end_idx = offset + limit
+    paginated_sites = suggestions[start_idx:end_idx]
+    has_more = end_idx < total_count
+    
     return schemas.TripPlanResponse(
         sites=paginated_sites,
         total_count=total_count,
-        has_more=end_index < total_count,
+        has_more=has_more
     )

--- a/backend/tests/test_trip_planner_service.py
+++ b/backend/tests/test_trip_planner_service.py
@@ -1,7 +1,7 @@
 import calendar
 import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -93,7 +93,7 @@ async def test_plan_trip_prefers_forecasts_then_falls_back_and_ranks(monkeypatch
     ]
     assert [day.probability for day in response.sites[1].daily_probabilities] == [0.9, 0.3]
     get_predictions.assert_awaited_once_with(
-        pytest.ANY,
+        ANY,
         start_date=start_date,
         end_date=end_date,
         metric=metric,
@@ -141,7 +141,7 @@ async def test_plan_trip_applies_tags_altitude_and_distance_together(monkeypatch
     assert response.has_more is False
     assert response.sites[0].site_name == "Matching Site"
     assert response.sites[0].distance_km == pytest.approx(11.1, abs=0.1)
-    get_tags.assert_awaited_once_with(pytest.ANY, [1, 2, 3, 4])
+    get_tags.assert_awaited_once_with(ANY, [1, 2, 3, 4])
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_trip_planner_service.py
+++ b/backend/tests/test_trip_planner_service.py
@@ -1,0 +1,194 @@
+import calendar
+import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app import crud
+from app.services.trip_planner_service import (
+    get_flight_stats_attr_for_metric,
+    get_historical_prob,
+    plan_trip_service,
+)
+
+
+def _site(site_id, name, latitude, longitude, altitude):
+    return SimpleNamespace(
+        site_id=site_id,
+        name=name,
+        latitude=latitude,
+        longitude=longitude,
+        altitude=altitude,
+    )
+
+
+def _prediction(site_id, forecast_date, value):
+    return SimpleNamespace(site_id=site_id, date=forecast_date, value=value)
+
+
+def _stats(site_id, year, month, metric, probability):
+    days_in_month = calendar.monthrange(year, month)[1]
+    return SimpleNamespace(
+        site_id=site_id,
+        month=month,
+        **{get_flight_stats_attr_for_metric(metric): probability * days_in_month},
+    )
+
+
+def _stats_for_range(site_id, start_date, end_date, metric, probability):
+    months = set()
+    current = start_date
+    while current <= end_date:
+        months.add((current.year, current.month))
+        current += datetime.timedelta(days=1)
+    return [
+        _stats(site_id, year, month, metric, probability)
+        for year, month in sorted(months)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_prefers_forecasts_then_falls_back_and_ranks(monkeypatch):
+    start_date = datetime.date.today()
+    end_date = start_date + datetime.timedelta(days=1)
+    metric = "XC20"
+    sites = [
+        _site(1, "Forecast Ridge", 50.0, 14.0, 900),
+        _site(2, "Reliable Hill", 49.0, 15.0, 700),
+        _site(3, "Quiet Slope", 48.0, 16.0, 500),
+    ]
+    predictions = [
+        _prediction(1, start_date, 0.9),
+        _prediction(2, start_date, 0.6),
+    ]
+    stats = [
+        *_stats_for_range(1, start_date, end_date, metric, 0.3),
+        *_stats_for_range(2, start_date, end_date, metric, 0.8),
+        *_stats_for_range(3, start_date, end_date, metric, 0.2),
+    ]
+
+    get_predictions = AsyncMock(return_value=predictions)
+    monkeypatch.setattr(crud, "get_predictions_for_range", get_predictions)
+    monkeypatch.setattr(crud, "get_all_flight_stats", AsyncMock(return_value=stats))
+    monkeypatch.setattr(crud, "get_sites", AsyncMock(return_value=sites))
+
+    response = await plan_trip_service(
+        db=object(),
+        start_date=start_date,
+        end_date=end_date,
+        metric=metric,
+        offset=0,
+        limit=2,
+    )
+
+    assert response.total_count == 3
+    assert response.has_more is True
+    assert [site.site_name for site in response.sites] == ["Reliable Hill", "Forecast Ridge"]
+    assert response.sites[0].average_flyability == 0.7
+    assert response.sites[1].average_flyability == 0.6
+    assert [day.source for day in response.sites[1].daily_probabilities] == [
+        "forecast",
+        "historical",
+    ]
+    assert [day.probability for day in response.sites[1].daily_probabilities] == [0.9, 0.3]
+    get_predictions.assert_awaited_once_with(
+        pytest.ANY,
+        start_date=start_date,
+        end_date=end_date,
+        metric=metric,
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_applies_tags_altitude_and_distance_together(monkeypatch):
+    plan_date = datetime.date.today()
+    sites = [
+        _site(1, "Matching Site", 0.0, 0.1, 1000),
+        _site(2, "Too Far", 2.0, 2.0, 1000),
+        _site(3, "Too Low", 0.0, 0.2, 300),
+        _site(4, "Missing Tag", 0.0, 0.2, 1000),
+    ]
+    predictions = [_prediction(site.site_id, plan_date, 0.7) for site in sites]
+    get_tags = AsyncMock(
+        return_value={
+            1: ["official", "alps", "school"],
+            2: ["official", "alps"],
+            3: ["official", "alps"],
+            4: ["official"],
+        }
+    )
+
+    monkeypatch.setattr(crud, "get_predictions_for_range", AsyncMock(return_value=predictions))
+    monkeypatch.setattr(crud, "get_all_flight_stats", AsyncMock(return_value=[]))
+    monkeypatch.setattr(crud, "get_sites", AsyncMock(return_value=sites))
+    monkeypatch.setattr(crud, "get_tags_by_site_ids", get_tags)
+
+    response = await plan_trip_service(
+        db=object(),
+        start_date=plan_date,
+        end_date=plan_date,
+        metric="XC0",
+        user_latitude=0.0,
+        user_longitude=0.0,
+        max_distance_km=50,
+        min_altitude_m=500,
+        max_altitude_m=1500,
+        required_tags=["official", "alps"],
+    )
+
+    assert response.total_count == 1
+    assert response.has_more is False
+    assert response.sites[0].site_name == "Matching Site"
+    assert response.sites[0].distance_km == pytest.approx(11.1, abs=0.1)
+    get_tags.assert_awaited_once_with(pytest.ANY, [1, 2, 3, 4])
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_uses_historical_data_outside_forecast_horizon(monkeypatch):
+    plan_date = datetime.date.today() + datetime.timedelta(days=8)
+    site = _site(1, "Historical Site", 50.0, 14.0, 600)
+    stats = _stats_for_range(1, plan_date, plan_date, "XC100", 0.25)
+    get_predictions = AsyncMock(return_value=[])
+
+    monkeypatch.setattr(crud, "get_predictions_for_range", get_predictions)
+    monkeypatch.setattr(crud, "get_all_flight_stats", AsyncMock(return_value=stats))
+    monkeypatch.setattr(crud, "get_sites", AsyncMock(return_value=[site]))
+
+    response = await plan_trip_service(
+        db=object(),
+        start_date=plan_date,
+        end_date=plan_date,
+        metric="XC100",
+    )
+
+    assert response.sites[0].average_flyability == 0.25
+    assert response.sites[0].daily_probabilities[0].source == "historical"
+    assert response.sites[0].daily_probabilities[0].probability == 0.25
+    get_predictions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_returns_empty_response_when_no_sites_exist(monkeypatch):
+    plan_date = datetime.date.today()
+    monkeypatch.setattr(crud, "get_predictions_for_range", AsyncMock(return_value=[]))
+    monkeypatch.setattr(crud, "get_all_flight_stats", AsyncMock(return_value=[]))
+    monkeypatch.setattr(crud, "get_sites", AsyncMock(return_value=[]))
+
+    response = await plan_trip_service(
+        db=object(),
+        start_date=plan_date,
+        end_date=plan_date,
+    )
+
+    assert response.sites == []
+    assert response.total_count == 0
+    assert response.has_more is False
+
+
+def test_historical_probability_uses_selected_metric_and_month_length():
+    stats = SimpleNamespace(month=2, avg_days_over_50=14.5)
+
+    assert get_flight_stats_attr_for_metric("XC50") == "avg_days_over_50"
+    assert get_flight_stats_attr_for_metric("unknown") == "avg_days_over_0"
+    assert get_historical_prob(stats, 2024, 2, "XC50") == 0.5

--- a/frontend/src/pages/TripPlannerPage.test.jsx
+++ b/frontend/src/pages/TripPlannerPage.test.jsx
@@ -1,0 +1,333 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import TripPlannerPage from './TripPlannerPage';
+import { planTrip } from '../api';
+
+jest.mock('../api', () => ({
+  planTrip: jest.fn(),
+}));
+
+jest.mock('../hooks/useDefaultMetric', () => ({
+  useDefaultMetric: () => ({ preferredMetric: 'XC0' }),
+}));
+
+jest.mock('../context/AuthContext', () => ({
+  useAuth: () => ({
+    profile: {
+      home_lat: 50.1,
+      home_lon: 14.4,
+    },
+  }),
+}));
+
+jest.mock('../components/TripPlannerControls', () => {
+  const React = require('react');
+
+  return function MockTripPlannerControls({ setState, onSubmit }) {
+    return React.createElement(
+      'div',
+      null,
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => setState((previous) => ({
+            ...previous,
+            selectedMetric: 'XC50',
+            flightQuality: {
+              ...previous.flightQuality,
+              enabled: true,
+              selectedValues: ['XC0', 'XC10', 'XC20', 'XC30', 'XC40', 'XC50'],
+            },
+            altitude: {
+              enabled: true,
+              min: 800,
+              max: 1600,
+            },
+            tags: ['ridge'],
+          })),
+        },
+        'Apply filters',
+      ),
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => onSubmit([
+            new Date('2000-01-02T12:00:00Z'),
+            new Date('2000-01-01T12:00:00Z'),
+          ]),
+        },
+        'Submit invalid dates',
+      ),
+    );
+  };
+});
+
+jest.mock('../components/SiteList', () => {
+  const React = require('react');
+
+  return function MockSiteList({ sites, onSiteClick }) {
+    return React.createElement(
+      'div',
+      { 'data-testid': 'site-list' },
+      sites.map((site) => React.createElement(
+        'button',
+        {
+          type: 'button',
+          key: site.site_id,
+          onClick: (event) => onSiteClick(site, event),
+        },
+        site.site_name,
+      )),
+    );
+  };
+});
+
+jest.mock('../components/PlannerMapView', () => {
+  const React = require('react');
+  return function MockPlannerMapView({ sites }) {
+    return React.createElement('div', null, `Map with ${sites.length} sites`);
+  };
+});
+
+jest.mock('../components/LoadingSpinner', () => {
+  const React = require('react');
+  return function MockLoadingSpinner() {
+    return React.createElement('div', null, 'Loading planner');
+  };
+});
+
+const dateString = (daysFromToday) => {
+  const value = new Date();
+  value.setHours(12, 0, 0, 0);
+  value.setDate(value.getDate() + daysFromToday);
+  return value.toISOString().split('T')[0];
+};
+
+const makeSite = (siteId, overrides = {}) => ({
+  site_id: String(siteId),
+  site_name: `Site ${siteId}`,
+  latitude: 50 + siteId / 100,
+  longitude: 14 + siteId / 100,
+  altitude: 500 + siteId,
+  average_flyability: 1 - siteId / 100,
+  daily_probabilities: [],
+  distance_km: siteId,
+  ...overrides,
+});
+
+const makePage = (sites, totalCount = sites.length, hasMore = false) => ({
+  sites,
+  total_count: totalCount,
+  has_more: hasMore,
+});
+
+const renderPlanner = (query = '') => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: Infinity,
+      },
+    },
+  });
+
+  render(
+    <HelmetProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={[`/trip-planner${query}`]}>
+          <Routes>
+            <Route path="/trip-planner" element={<TripPlannerPage />} />
+            <Route path="/details/:siteId" element={<div>Details page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </HelmetProvider>,
+  );
+
+  return queryClient;
+};
+
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('TripPlannerPage', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: jest.fn().mockImplementation((query) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(),
+        removeListener: jest.fn(),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      })),
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: jest.fn(),
+      },
+    });
+  });
+
+  it('restores URL filters and uses the saved home location', async () => {
+    const startDate = dateString(1);
+    const endDate = dateString(3);
+    planTrip.mockResolvedValue(makePage([makeSite(1)]));
+
+    renderPlanner(
+      `?startDate=${startDate}`
+      + `&endDate=${endDate}`
+      + '&metric=XC20'
+      + '&distEnabled=true'
+      + '&distKm=120'
+      + '&locSrc=home'
+      + '&altMin=500'
+      + '&altMax=1800'
+      + '&tags=official,alps',
+    );
+
+    await waitFor(() => expect(planTrip).toHaveBeenCalled());
+    const call = planTrip.mock.calls.at(-1);
+
+    expect(call[0]).toBe(startDate);
+    expect(call[1]).toBe(endDate);
+    expect(call[2]).toBe('XC20');
+    expect(call[3]).toEqual({ latitude: 50.1, longitude: 14.4 });
+    expect(call[4]).toBe(120);
+    expect(call[5]).toEqual({ min: 500, max: 1800 });
+    expect(call[6]).toBe(0);
+    expect(call[7]).toBe(10);
+    expect(call[8]).toEqual(['alps', 'official']);
+    expect(call[9].signal).toBeDefined();
+    expect(await screen.findByText('Site 1')).toBeInTheDocument();
+  });
+
+  it('requests the next offset, appends results, and can collapse them again', async () => {
+    const startDate = dateString(1);
+    const endDate = dateString(2);
+    planTrip.mockImplementation((...args) => {
+      const offset = args[6];
+      if (offset === 0) {
+        return Promise.resolve(makePage(
+          Array.from({ length: 10 }, (_, index) => makeSite(index + 1)),
+          15,
+          true,
+        ));
+      }
+      return Promise.resolve(makePage(
+        Array.from({ length: 5 }, (_, index) => makeSite(index + 11)),
+        15,
+        false,
+      ));
+    });
+
+    renderPlanner(`?startDate=${startDate}&endDate=${endDate}`);
+
+    expect(await screen.findByText('Top 10 sites (15 total)')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'More' }));
+
+    expect(await screen.findByText('Site 15')).toBeInTheDocument();
+    expect(planTrip.mock.calls.map((call) => call[6])).toEqual([0, 10]);
+    expect(screen.getByText('Top 15 sites (15 total)')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Less' }));
+    await waitFor(() => expect(screen.queryByText('Site 11')).not.toBeInTheDocument());
+    expect(screen.getByText('Top 10 sites (15 total)')).toBeInTheDocument();
+  });
+
+  it('aborts an obsolete request when filters change and keeps the new result', async () => {
+    const startDate = dateString(1);
+    const endDate = dateString(2);
+    const firstRequest = deferred();
+    planTrip
+      .mockImplementationOnce(() => firstRequest.promise)
+      .mockResolvedValueOnce(makePage([
+        makeSite(50, { site_name: 'Filtered Site', average_flyability: 0.95 }),
+      ]));
+
+    renderPlanner(`?startDate=${startDate}&endDate=${endDate}`);
+
+    await waitFor(() => expect(planTrip).toHaveBeenCalledTimes(1));
+    const firstSignal = planTrip.mock.calls[0][9].signal;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Apply filters' }));
+
+    await waitFor(() => expect(planTrip).toHaveBeenCalledTimes(2));
+    expect(planTrip.mock.calls[1][2]).toBe('XC50');
+    expect(planTrip.mock.calls[1][5]).toEqual({ min: 800, max: 1600 });
+    expect(planTrip.mock.calls[1][8]).toEqual(['ridge']);
+    await waitFor(() => expect(firstSignal.aborted).toBe(true));
+    expect(await screen.findByText('Filtered Site')).toBeInTheDocument();
+
+    await act(async () => {
+      firstRequest.resolve(makePage([
+        makeSite(1, { site_name: 'Obsolete Site' }),
+      ]));
+      await firstRequest.promise;
+    });
+
+    expect(screen.queryByText('Obsolete Site')).not.toBeInTheDocument();
+    expect(screen.getByText('Filtered Site')).toBeInTheDocument();
+  });
+
+  it('rejects an invalid submitted date range without another API request', async () => {
+    const startDate = dateString(1);
+    const endDate = dateString(2);
+    planTrip.mockResolvedValue(makePage([makeSite(1)]));
+
+    renderPlanner(`?startDate=${startDate}&endDate=${endDate}`);
+    await waitFor(() => expect(planTrip).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit invalid dates' }));
+
+    expect(await screen.findByText('End date cannot be before start date')).toBeInTheDocument();
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(planTrip).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a useful empty-result message', async () => {
+    const startDate = dateString(1);
+    const endDate = dateString(2);
+    planTrip.mockResolvedValue(makePage([], 0, false));
+
+    renderPlanner(`?startDate=${startDate}&endDate=${endDate}`);
+
+    expect(
+      await screen.findByText('No suitable sites found for the selected criteria'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a useful API failure message', async () => {
+    const startDate = dateString(1);
+    const endDate = dateString(2);
+    planTrip.mockRejectedValue(new Error('network failure'));
+
+    renderPlanner(`?startDate=${startDate}&endDate=${endDate}`);
+
+    expect(
+      await screen.findByText('Failed to plan trip. Please try again.'),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## What changed

- add direct tests for trip-planner forecast priority, historical fallback, metric selection, ranking, pagination, tag filtering, altitude filtering and distance filtering
- add TripPlannerPage interaction tests for URL restoration, saved home location, cancellable requests, filter changes, pagination, invalid dates, empty results and API failures
- fix the no-sites service path to return an empty `TripPlanResponse` rather than a raw list

## Why

After PR #81, the backend service remained one of the least-covered core modules and the Trip Planner page had no interaction coverage. These tests protect the central recommendation workflow and the React Query pagination/cancellation behavior introduced during the frontend data-loading refactor.

## Validation

- backend: 30 tests passed
- backend application coverage: 54%, up from 51%
- `trip_planner_service.py`: 99% coverage, up from 11%
- frontend: 5 suites and 16 tests passed
- frontend statements: 14.11%, up from 8.4%
- frontend branches: 14.96%, up from 7.43%
- frontend functions: 10.3%, up from 5.97%
- frontend lines: 14.1%, up from 8.72%
- optimized frontend production build completed successfully

## Product fix

When the database contained no sites, `plan_trip_service` returned a raw list despite its declared `TripPlanResponse` contract. It now returns `{ sites: [], total_count: 0, has_more: false }` consistently.

## Notes

The test run still reports existing React/MUI `act(...)` warnings and dependency deprecation warnings, but all tests and the production build pass. Cleaning those warnings should be handled separately rather than expanding this coverage-focused change.