### PR TITLE
Add coverage regression gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: python -m pip install --upgrade pip && pip install -r requirements-web.txt
 
       - name: Run backend tests
-        run: python -m pytest -q --cov=app --cov-report=term-missing:skip-covered --cov-report=xml
+        run: python -m pytest -q --cov=app --cov-fail-under=53 --cov-report=term-missing:skip-covered --cov-report=xml
 
   frontend:
     name: Frontend tests and build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,14 @@
   "jest": {
     "moduleNameMapper": {
       "^axios$": "<rootDir>/node_modules/axios/dist/node/axios.cjs"
+    },
+    "coverageThreshold": {
+      "global": {
+        "branches": 14,
+        "functions": 10,
+        "lines": 14,
+        "statements": 14
+      }
     }
   },
   "browserslist": {


### PR DESCRIPTION
## What changed

- require backend application coverage to remain at or above 53% in CI
- add Jest global coverage thresholds for the frontend:
  - statements: 14%
  - branches: 14%
  - functions: 10%
  - lines: 14%

## Why

The project now has backend, frontend and Playwright test coverage, but CI previously reported coverage without failing when it regressed. These deliberately conservative floors sit just below the current measured baselines and turn coverage into a no-regression guard rather than a target-chasing exercise.

## Impact

Future pull requests that remove meaningful coverage without replacing it will fail CI. The thresholds can be raised incrementally as product work adds tests.

## Validation

- workflow YAML was parsed successfully
- frontend package configuration is valid JSON
- CI should run the existing backend, frontend and Playwright suites with the new coverage gates