### PR TITLE
Add first-party product analytics and contextual feedback

### DIFF
--- a/backend/alembic/versions/0011_product_events.py
+++ b/backend/alembic/versions/0011_product_events.py
@@ -1,0 +1,73 @@
+"""Add product analytics events
+
+Revision ID: 0011_product_events
+Revises: 0010_drop_feedback_contact_email
+Create Date: 2026-07-31
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0011_product_events"
+down_revision = "0010_drop_feedback_contact_email"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "product_events",
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("event_name", sa.String(length=80), nullable=False),
+        sa.Column("anonymous_id", sa.String(length=64), nullable=False),
+        sa.Column("session_id", sa.String(length=64), nullable=False),
+        sa.Column("path", sa.String(length=500), nullable=True),
+        sa.Column("properties", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("event_id"),
+    )
+    op.create_index(
+        op.f("ix_product_events_event_id"),
+        "product_events",
+        ["event_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_product_events_event_name"),
+        "product_events",
+        ["event_name"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_product_events_anonymous_id"),
+        "product_events",
+        ["anonymous_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_product_events_session_id"),
+        "product_events",
+        ["session_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_product_events_created_at"),
+        "product_events",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_product_events_created_at"), table_name="product_events")
+    op.drop_index(op.f("ix_product_events_session_id"), table_name="product_events")
+    op.drop_index(op.f("ix_product_events_anonymous_id"), table_name="product_events")
+    op.drop_index(op.f("ix_product_events_event_name"), table_name="product_events")
+    op.drop_index(op.f("ix_product_events_event_id"), table_name="product_events")
+    op.drop_table("product_events")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,19 @@ from contextlib import AsyncExitStack, asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
 from .database import AsyncSessionLocal, SessionLocal
-from .routers import sites, trip_planning, auth, profiles, favorites, llms, notifications, s2s, d2d, feedback
+from .routers import (
+    analytics,
+    auth,
+    d2d,
+    favorites,
+    feedback,
+    llms,
+    notifications,
+    profiles,
+    s2s,
+    sites,
+    trip_planning,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from .security import is_production
 
@@ -161,6 +173,7 @@ app.include_router(llms.router)
 app.include_router(s2s.router)
 app.include_router(d2d.router)
 app.include_router(feedback.router)
+app.include_router(analytics.router)
 
 @app.get("/health")
 async def healthcheck():

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -1,0 +1,159 @@
+import json
+import logging
+import os
+from typing import Any, Dict, Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import Column, DateTime, Integer, JSON, String
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.sql import func
+
+from ..cache import get_redis_client
+from ..database import AsyncSessionLocal, Base
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/analytics", tags=["Analytics"])
+
+RATE_LIMIT_ANALYTICS_WINDOW_MINUTES = "RATE_LIMIT_ANALYTICS_WINDOW_MINUTES"
+RATE_LIMIT_ANALYTICS_MAX_PER_IP = "RATE_LIMIT_ANALYTICS_MAX_PER_IP"
+RATE_LIMIT_ANALYTICS_MAX_PER_ANONYMOUS_ID = "RATE_LIMIT_ANALYTICS_MAX_PER_ANONYMOUS_ID"
+MAX_PROPERTIES_BYTES = 12_000
+MAX_PROPERTIES_KEYS = 40
+
+
+class ProductEvent(Base):
+    __tablename__ = "product_events"
+
+    event_id = Column(Integer, primary_key=True, index=True)
+    event_name = Column(String(80), nullable=False, index=True)
+    anonymous_id = Column(String(64), nullable=False, index=True)
+    session_id = Column(String(64), nullable=False, index=True)
+    path = Column(String(500), nullable=True)
+    properties = Column(JSON, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        index=True,
+    )
+
+
+class ProductEventCreate(BaseModel):
+    event_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=80,
+        pattern=r"^[a-z][a-z0-9_]*$",
+    )
+    anonymous_id: str = Field(..., min_length=8, max_length=64)
+    session_id: str = Field(..., min_length=8, max_length=64)
+    path: Optional[str] = Field(default=None, max_length=500)
+    properties: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("event_name", "anonymous_id", "session_id")
+    @classmethod
+    def strip_required_strings(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("value cannot be empty")
+        return stripped
+
+    @field_validator("path")
+    @classmethod
+    def strip_path(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @field_validator("properties")
+    @classmethod
+    def validate_properties(cls, value: Dict[str, Any]) -> Dict[str, Any]:
+        if len(value) > MAX_PROPERTIES_KEYS:
+            raise ValueError(f"properties may contain at most {MAX_PROPERTIES_KEYS} keys")
+        encoded = json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+        if len(encoded.encode("utf-8")) > MAX_PROPERTIES_BYTES:
+            raise ValueError(f"properties may contain at most {MAX_PROPERTIES_BYTES} bytes")
+        return value
+
+
+class ProductEventAccepted(BaseModel):
+    accepted: Literal[True] = True
+
+
+def _client_ip(request: Request) -> str:
+    forwarded_for = request.headers.get("x-forwarded-for", "")
+    client_ip = forwarded_for.split(",", 1)[0].strip() if forwarded_for else None
+    return client_ip or (request.client.host if request.client else "unknown")
+
+
+def _apply_analytics_rate_limit(*, ip: str, anonymous_id: str) -> None:
+    window_seconds = int(os.getenv(RATE_LIMIT_ANALYTICS_WINDOW_MINUTES, "60")) * 60
+    max_per_ip = int(os.getenv(RATE_LIMIT_ANALYTICS_MAX_PER_IP, "2000"))
+    max_per_anonymous_id = int(
+        os.getenv(RATE_LIMIT_ANALYTICS_MAX_PER_ANONYMOUS_ID, "500")
+    )
+
+    try:
+        redis_client = get_redis_client()
+        keys_and_limits = [
+            (f"analytics:event:ip:{ip}", max_per_ip),
+            (
+                f"analytics:event:anonymous:{anonymous_id}",
+                max_per_anonymous_id,
+            ),
+        ]
+        for key, limit in keys_and_limits:
+            current = redis_client.incr(key)
+            if current == 1:
+                redis_client.expire(key, window_seconds)
+            if current > limit:
+                raise HTTPException(
+                    status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                    detail="Too many analytics events. Try again later.",
+                )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception("Analytics rate limiting unavailable")
+
+
+async def get_db():
+    async with AsyncSessionLocal() as session:
+        yield session
+
+
+@router.post(
+    "/events",
+    response_model=ProductEventAccepted,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_product_event(
+    request: Request,
+    payload: ProductEventCreate,
+    db: AsyncSession = Depends(get_db),
+):
+    _apply_analytics_rate_limit(
+        ip=_client_ip(request),
+        anonymous_id=payload.anonymous_id,
+    )
+
+    event = ProductEvent(
+        event_name=payload.event_name,
+        anonymous_id=payload.anonymous_id,
+        session_id=payload.session_id,
+        path=payload.path,
+        properties=payload.properties,
+    )
+    db.add(event)
+    await db.commit()
+
+    logger.debug(
+        "Product event accepted event_name=%s anonymous_id=%s session_id=%s",
+        payload.event_name,
+        payload.anonymous_id,
+        payload.session_id,
+    )
+    return ProductEventAccepted()

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -1,0 +1,104 @@
+import os
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
+os.environ.setdefault("CORS_ALLOW_ORIGINS", "http://localhost:3000")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+from app.main import app
+from app.routers import analytics
+
+
+class FakeSession:
+    def __init__(self):
+        self.added = None
+        self.committed = False
+
+    def add(self, row):
+        self.added = row
+
+    async def commit(self):
+        self.committed = True
+
+
+@pytest.mark.asyncio
+async def test_product_event_is_accepted_without_personal_data(monkeypatch):
+    session = FakeSession()
+
+    async def override_get_db():
+        yield session
+
+    monkeypatch.setattr(analytics, "_apply_analytics_rate_limit", lambda **kwargs: None)
+    app.dependency_overrides[analytics.get_db] = override_get_db
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/analytics/events",
+                json={
+                    "event_name": "trip_plan_submitted",
+                    "anonymous_id": "anonymous-12345",
+                    "session_id": "session-12345",
+                    "path": "/trip-planner",
+                    "properties": {
+                        "metric": "XC20",
+                        "distance_enabled": True,
+                        "tags_count": 2,
+                    },
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(analytics.get_db, None)
+
+    assert response.status_code == 202
+    assert response.json() == {"accepted": True}
+    assert session.committed is True
+    assert session.added.event_name == "trip_plan_submitted"
+    assert session.added.anonymous_id == "anonymous-12345"
+    assert session.added.session_id == "session-12345"
+    assert session.added.path == "/trip-planner"
+    assert session.added.properties == {
+        "metric": "XC20",
+        "distance_enabled": True,
+        "tags_count": 2,
+    }
+    assert not hasattr(session.added, "ip_address")
+    assert not hasattr(session.added, "user_agent")
+
+
+@pytest.mark.asyncio
+async def test_product_event_rejects_invalid_event_names(monkeypatch):
+    monkeypatch.setattr(analytics, "_apply_analytics_rate_limit", lambda **kwargs: None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/analytics/events",
+            json={
+                "event_name": "Trip Plan Submitted",
+                "anonymous_id": "anonymous-12345",
+                "session_id": "session-12345",
+                "properties": {},
+            },
+        )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_product_event_limits_property_payload(monkeypatch):
+    monkeypatch.setattr(analytics, "_apply_analytics_rate_limit", lambda **kwargs: None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/analytics/events",
+            json={
+                "event_name": "page_view",
+                "anonymous_id": "anonymous-12345",
+                "session_id": "session-12345",
+                "properties": {"large": "x" * 12_100},
+            },
+        )
+
+    assert response.status_code == 422

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -1,0 +1,104 @@
+# Product analytics
+
+Glideator records a small first-party event stream in the `product_events` table. The goal is to understand whether people reach useful forecasts and recommendations without introducing a third-party analytics SDK.
+
+## Privacy properties
+
+- No IP address, user agent, email address, account ID, or precise coordinates are stored.
+- The frontend sends only `window.location.pathname`, never the URL query string.
+- Property keys that look like coordinates, IP addresses, emails, or user-agent data are removed client-side.
+- Anonymous browser and session IDs are random identifiers stored in `localStorage` and `sessionStorage`.
+- Global Privacy Control and Do Not Track are respected.
+- Set `REACT_APP_ANALYTICS_ENABLED=false` to disable frontend collection entirely.
+
+The ingestion endpoint is `POST /analytics/events`. Payloads and event names are validated, property size is capped, and Redis-backed rate limits protect the endpoint.
+
+## Event catalog
+
+| Event | Meaning | Important properties |
+| --- | --- | --- |
+| `page_view` | A route was displayed | `route` |
+| `map_metric_changed` | The map XC threshold changed | `previous_metric`, `metric` |
+| `map_date_changed` | The map forecast date changed | `previous_date`, `date`, `metric` |
+| `site_detail_viewed` | A site detail route opened | `site_id`, `date`, `metric`, `tab` |
+| `site_date_changed` | The selected site forecast date changed | `site_id`, `previous_date`, `date`, `metric` |
+| `site_metric_changed` | The selected site XC threshold changed | `site_id`, `previous_metric`, `metric`, `date` |
+| `site_tab_changed` | The site detail tab changed | `site_id`, `previous_tab`, `tab` |
+| `trip_plan_submitted` | The user explicitly submitted Trip Planner criteria | dates, metric, enabled filter flags, tag count |
+| `trip_plan_results_viewed` | A distinct Trip Planner query returned | dates, metric, counts, enabled filter flags |
+| `trip_plan_site_opened` | A suggested site was opened | `site_id`, metric, view, sort, flyability |
+| `trip_plan_view_changed` | Trip Planner switched between list and map | `previous_view`, `view` |
+| `trip_plan_sort_changed` | Trip Planner sorting changed | `previous_sort`, `sort` |
+| `trip_plan_more_requested` | More recommendations were requested | visible and total counts |
+| `recommendation_feedback_submitted` | Contextual helpful/not-helpful feedback | `surface`, `rating`, and recommendation context |
+
+## Starter queries
+
+Daily active anonymous visitors:
+
+```sql
+select
+    date_trunc('day', created_at) as day,
+    count(distinct anonymous_id) as visitors
+from product_events
+group by 1
+order by 1 desc;
+```
+
+Trip Planner funnel by day:
+
+```sql
+select
+    date_trunc('day', created_at) as day,
+    count(*) filter (where event_name = 'trip_plan_submitted') as submitted,
+    count(*) filter (where event_name = 'trip_plan_results_viewed') as results_viewed,
+    count(*) filter (where event_name = 'trip_plan_site_opened') as sites_opened
+from product_events
+where event_name in (
+    'trip_plan_submitted',
+    'trip_plan_results_viewed',
+    'trip_plan_site_opened'
+)
+group by 1
+order by 1 desc;
+```
+
+Feedback by surface:
+
+```sql
+select
+    properties ->> 'surface' as surface,
+    properties ->> 'rating' as rating,
+    count(*) as responses
+from product_events
+where event_name = 'recommendation_feedback_submitted'
+group by 1, 2
+order by 1, 2;
+```
+
+Forecast feedback by site and metric:
+
+```sql
+select
+    (properties ->> 'site_id')::integer as site_id,
+    properties ->> 'metric' as metric,
+    count(*) filter (where properties ->> 'rating' = 'helpful') as helpful,
+    count(*) filter (where properties ->> 'rating' = 'not_helpful') as not_helpful
+from product_events
+where event_name = 'recommendation_feedback_submitted'
+  and properties ->> 'surface' = 'site_forecast'
+group by 1, 2
+having count(*) >= 5
+order by not_helpful desc, helpful asc;
+```
+
+## Suggested first dashboard
+
+Start with four panels:
+
+1. Daily active anonymous visitors and sessions.
+2. Map-to-site engagement: site-detail views divided by map page views.
+3. Trip Planner funnel: submitted → results viewed → site opened.
+4. Helpful rate by `surface`, then by site and metric once sample sizes are meaningful.
+
+Treat low-volume slices cautiously. A minimum of five responses is a useful display threshold, not a statistical guarantee.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,7 +18,7 @@ import AnalyticsRouteTracker from './components/AnalyticsRouteTracker';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationProvider } from './context/NotificationContext';
 
-const Details = React.lazy(() => import('./pages/Details'));
+const Details = React.lazy(() => import('./pages/DetailsRoute'));
 const TripPlannerPage = React.lazy(() => import('./pages/TripPlannerPage'));
 
 const RouteFallback = () => (

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,7 @@ import About from './pages/About';
 import Feedback from './pages/Feedback';
 import RequireAuth from './components/RequireAuth';
 import LoadingSpinner from './components/LoadingSpinner';
+import AnalyticsRouteTracker from './components/AnalyticsRouteTracker';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationProvider } from './context/NotificationContext';
 
@@ -31,6 +32,7 @@ const App = () => {
     <AuthProvider>
       <NotificationProvider>
         <Router>
+          <AnalyticsRouteTracker />
           <Suspense fallback={<RouteFallback />}>
             <Routes>
               <Route path="/declined" element={<Declined />} />

--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -1,0 +1,96 @@
+import apiClient from './api';
+
+const ANONYMOUS_ID_KEY = 'glideator.analytics.anonymous_id';
+const SESSION_ID_KEY = 'glideator.analytics.session_id';
+const MAX_STRING_LENGTH = 250;
+const MAX_ARRAY_LENGTH = 20;
+const MAX_DEPTH = 3;
+const BLOCKED_PROPERTY_KEY = /^(email|user_?agent|ip(_address)?|lat(itude)?|lon(gitude)?|lng|coordinates|coords)$/i;
+
+let inMemoryAnonymousId = null;
+let inMemorySessionId = null;
+
+const createId = (prefix) => {
+  const randomValue = globalThis.crypto?.randomUUID?.()
+    || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+  return `${prefix}-${randomValue}`;
+};
+
+const getStoredId = (storage, key, prefix) => {
+  try {
+    const existing = storage?.getItem(key);
+    if (existing) return existing;
+
+    const created = createId(prefix);
+    storage?.setItem(key, created);
+    return created;
+  } catch {
+    return createId(prefix);
+  }
+};
+
+const getAnonymousId = () => {
+  if (!inMemoryAnonymousId) {
+    inMemoryAnonymousId = getStoredId(globalThis.localStorage, ANONYMOUS_ID_KEY, 'anon');
+  }
+  return inMemoryAnonymousId;
+};
+
+const getSessionId = () => {
+  if (!inMemorySessionId) {
+    inMemorySessionId = getStoredId(globalThis.sessionStorage, SESSION_ID_KEY, 'session');
+  }
+  return inMemorySessionId;
+};
+
+const sanitizeValue = (value, depth = 0) => {
+  if (depth >= MAX_DEPTH || value == null) return value;
+
+  if (typeof value === 'string') return value.slice(0, MAX_STRING_LENGTH);
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  if (typeof value === 'boolean') return value;
+
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, MAX_ARRAY_LENGTH)
+      .map((item) => sanitizeValue(item, depth + 1));
+  }
+
+  if (typeof value === 'object') {
+    return Object.entries(value).reduce((sanitized, [key, item]) => {
+      if (!BLOCKED_PROPERTY_KEY.test(key) && item !== undefined) {
+        sanitized[key] = sanitizeValue(item, depth + 1);
+      }
+      return sanitized;
+    }, {});
+  }
+
+  return String(value).slice(0, MAX_STRING_LENGTH);
+};
+
+export const analyticsEnabled = () => {
+  if (process.env.REACT_APP_ANALYTICS_ENABLED === 'false') return false;
+  if (globalThis.navigator?.globalPrivacyControl === true) return false;
+
+  const doNotTrack = globalThis.navigator?.doNotTrack || globalThis.doNotTrack;
+  return doNotTrack !== '1' && doNotTrack !== 'yes';
+};
+
+export const trackEvent = (eventName, properties = {}) => {
+  if (!analyticsEnabled()) return Promise.resolve(null);
+
+  const payload = {
+    event_name: eventName,
+    anonymous_id: getAnonymousId(),
+    session_id: getSessionId(),
+    path: globalThis.location?.pathname || null,
+    properties: sanitizeValue(properties),
+  };
+
+  return apiClient.post('/analytics/events', payload, { timeout: 3000 }).catch(() => null);
+};
+
+export const resetAnalyticsIdsForTests = () => {
+  inMemoryAnonymousId = null;
+  inMemorySessionId = null;
+};

--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -77,7 +77,7 @@ export const analyticsEnabled = () => {
 };
 
 export const trackEvent = (eventName, properties = {}) => {
-  if (!analyticsEnabled()) return Promise.resolve(null);
+  if (!analyticsEnabled() || !apiClient?.post) return Promise.resolve(null);
 
   const payload = {
     event_name: eventName,
@@ -87,7 +87,13 @@ export const trackEvent = (eventName, properties = {}) => {
     properties: sanitizeValue(properties),
   };
 
-  return apiClient.post('/analytics/events', payload, { timeout: 3000 }).catch(() => null);
+  try {
+    return Promise.resolve(
+      apiClient.post('/analytics/events', payload, { timeout: 3000 }),
+    ).catch(() => null);
+  } catch {
+    return Promise.resolve(null);
+  }
 };
 
 export const resetAnalyticsIdsForTests = () => {

--- a/frontend/src/analytics.js
+++ b/frontend/src/analytics.js
@@ -11,7 +11,7 @@ let inMemoryAnonymousId = null;
 let inMemorySessionId = null;
 
 const createId = (prefix) => {
-  const randomValue = globalThis.crypto?.randomUUID?.()
+  const randomValue = window.crypto?.randomUUID?.()
     || `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
   return `${prefix}-${randomValue}`;
 };
@@ -31,14 +31,14 @@ const getStoredId = (storage, key, prefix) => {
 
 const getAnonymousId = () => {
   if (!inMemoryAnonymousId) {
-    inMemoryAnonymousId = getStoredId(globalThis.localStorage, ANONYMOUS_ID_KEY, 'anon');
+    inMemoryAnonymousId = getStoredId(window.localStorage, ANONYMOUS_ID_KEY, 'anon');
   }
   return inMemoryAnonymousId;
 };
 
 const getSessionId = () => {
   if (!inMemorySessionId) {
-    inMemorySessionId = getStoredId(globalThis.sessionStorage, SESSION_ID_KEY, 'session');
+    inMemorySessionId = getStoredId(window.sessionStorage, SESSION_ID_KEY, 'session');
   }
   return inMemorySessionId;
 };
@@ -70,9 +70,9 @@ const sanitizeValue = (value, depth = 0) => {
 
 export const analyticsEnabled = () => {
   if (process.env.REACT_APP_ANALYTICS_ENABLED === 'false') return false;
-  if (globalThis.navigator?.globalPrivacyControl === true) return false;
+  if (navigator.globalPrivacyControl === true) return false;
 
-  const doNotTrack = globalThis.navigator?.doNotTrack || globalThis.doNotTrack;
+  const doNotTrack = navigator.doNotTrack || window.doNotTrack;
   return doNotTrack !== '1' && doNotTrack !== 'yes';
 };
 
@@ -83,7 +83,7 @@ export const trackEvent = (eventName, properties = {}) => {
     event_name: eventName,
     anonymous_id: getAnonymousId(),
     session_id: getSessionId(),
-    path: globalThis.location?.pathname || null,
+    path: window.location?.pathname || null,
     properties: sanitizeValue(properties),
   };
 

--- a/frontend/src/analytics.test.js
+++ b/frontend/src/analytics.test.js
@@ -1,0 +1,65 @@
+import apiClient from './api';
+import { analyticsEnabled, resetAnalyticsIdsForTests, trackEvent } from './analytics';
+
+jest.mock('./api', () => ({
+  __esModule: true,
+  default: {
+    post: jest.fn(),
+  },
+}));
+
+describe('product analytics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    sessionStorage.clear();
+    resetAnalyticsIdsForTests();
+    process.env.REACT_APP_ANALYTICS_ENABLED = 'true';
+    Object.defineProperty(navigator, 'doNotTrack', {
+      configurable: true,
+      value: null,
+    });
+    Object.defineProperty(navigator, 'globalPrivacyControl', {
+      configurable: true,
+      value: false,
+    });
+    window.history.pushState({}, '', '/details/42?lat=50.1234&lng=14.4321');
+    apiClient.post.mockResolvedValue({ data: { accepted: true } });
+  });
+
+  it('stores only the pathname and removes sensitive property keys', async () => {
+    await trackEvent('site_detail_viewed', {
+      metric: 'XC20',
+      email: 'pilot@example.com',
+      latitude: 50.1234,
+      nested: {
+        coords: [50.1234, 14.4321],
+        source: 'map',
+      },
+    });
+
+    expect(apiClient.post).toHaveBeenCalledTimes(1);
+    const [url, payload] = apiClient.post.mock.calls[0];
+
+    expect(url).toBe('/analytics/events');
+    expect(payload.path).toBe('/details/42');
+    expect(payload.anonymous_id).toMatch(/^anon-/);
+    expect(payload.session_id).toMatch(/^session-/);
+    expect(payload.properties).toEqual({
+      metric: 'XC20',
+      nested: { source: 'map' },
+    });
+  });
+
+  it('respects browser privacy signals', async () => {
+    Object.defineProperty(navigator, 'doNotTrack', {
+      configurable: true,
+      value: '1',
+    });
+
+    expect(analyticsEnabled()).toBe(false);
+    await trackEvent('page_view');
+
+    expect(apiClient.post).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/AnalyticsRouteTracker.jsx
+++ b/frontend/src/components/AnalyticsRouteTracker.jsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { trackEvent } from '../analytics';
+
+const classifyRoute = (pathname) => {
+  if (/^\/details\/[^/]+$/.test(pathname)) return '/details/:siteId';
+  return pathname || '/';
+};
+
+const AnalyticsRouteTracker = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    trackEvent('page_view', {
+      route: classifyRoute(location.pathname),
+    });
+  }, [location.pathname]);
+
+  return null;
+};
+
+export default AnalyticsRouteTracker;

--- a/frontend/src/components/QuickFeedback.jsx
+++ b/frontend/src/components/QuickFeedback.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Box, Button, Paper, Typography } from '@mui/material';
+import ThumbDownAltOutlinedIcon from '@mui/icons-material/ThumbDownAltOutlined';
+import ThumbUpAltOutlinedIcon from '@mui/icons-material/ThumbUpAltOutlined';
+
+import { trackEvent } from '../analytics';
+
+const QuickFeedback = ({
+  question,
+  context,
+  eventName = 'recommendation_feedback_submitted',
+}) => {
+  const [response, setResponse] = useState(null);
+
+  const submit = (rating) => {
+    if (response) return;
+    setResponse(rating);
+    trackEvent(eventName, {
+      ...context,
+      rating,
+    });
+  };
+
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        display: 'flex',
+        flexDirection: { xs: 'column', sm: 'row' },
+        alignItems: { xs: 'stretch', sm: 'center' },
+        justifyContent: 'space-between',
+        gap: 1.5,
+      }}
+    >
+      {response ? (
+        <Typography variant="body2" color="text.secondary">
+          Thanks — this helps improve Glideator's recommendations.
+        </Typography>
+      ) : (
+        <>
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {question}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<ThumbUpAltOutlinedIcon />}
+              onClick={() => submit('helpful')}
+            >
+              Helpful
+            </Button>
+            <Button
+              size="small"
+              variant="outlined"
+              startIcon={<ThumbDownAltOutlinedIcon />}
+              onClick={() => submit('not_helpful')}
+            >
+              Not helpful
+            </Button>
+          </Box>
+        </>
+      )}
+    </Paper>
+  );
+};
+
+export default QuickFeedback;

--- a/frontend/src/components/QuickFeedback.test.jsx
+++ b/frontend/src/components/QuickFeedback.test.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { trackEvent } from '../analytics';
+import QuickFeedback from './QuickFeedback';
+
+jest.mock('../analytics', () => ({
+  trackEvent: jest.fn(),
+}));
+
+describe('QuickFeedback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits a contextual helpful rating once', () => {
+    render(
+      <QuickFeedback
+        question="Was this forecast useful?"
+        context={{ surface: 'site_forecast', site_id: 42, metric: 'XC20' }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Helpful' }));
+
+    expect(trackEvent).toHaveBeenCalledWith('recommendation_feedback_submitted', {
+      surface: 'site_forecast',
+      site_id: 42,
+      metric: 'XC20',
+      rating: 'helpful',
+    });
+    expect(
+      screen.getByText("Thanks — this helps improve Glideator's recommendations."),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Helpful' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/DetailsRoute.jsx
+++ b/frontend/src/pages/DetailsRoute.jsx
@@ -1,0 +1,83 @@
+import React, { useEffect, useRef } from 'react';
+import { Box } from '@mui/material';
+import { useParams, useSearchParams } from 'react-router-dom';
+
+import { trackEvent } from '../analytics';
+import QuickFeedback from '../components/QuickFeedback';
+import Details from './Details';
+
+const DetailsRoute = () => {
+  const { siteId } = useParams();
+  const [searchParams] = useSearchParams();
+  const previousSelection = useRef(null);
+
+  const date = searchParams.get('date') || null;
+  const metric = searchParams.get('metric') || 'XC0';
+  const tab = searchParams.get('tab') || 'forecast';
+
+  useEffect(() => {
+    trackEvent('site_detail_viewed', {
+      site_id: Number(siteId),
+      date,
+      metric,
+      tab,
+    });
+    // The first view is tracked separately from subsequent selection changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [siteId]);
+
+  useEffect(() => {
+    const current = { date, metric, tab };
+    const previous = previousSelection.current;
+
+    if (previous) {
+      if (previous.date !== date) {
+        trackEvent('site_date_changed', {
+          site_id: Number(siteId),
+          previous_date: previous.date,
+          date,
+          metric,
+        });
+      }
+      if (previous.metric !== metric) {
+        trackEvent('site_metric_changed', {
+          site_id: Number(siteId),
+          previous_metric: previous.metric,
+          metric,
+          date,
+        });
+      }
+      if (previous.tab !== tab) {
+        trackEvent('site_tab_changed', {
+          site_id: Number(siteId),
+          previous_tab: previous.tab,
+          tab,
+        });
+      }
+    }
+
+    previousSelection.current = current;
+  }, [date, metric, siteId, tab]);
+
+  return (
+    <>
+      <Details />
+      {tab === 'forecast' && date && (
+        <Box sx={{ maxWidth: '1200px', mx: 'auto', px: 2, pb: 2 }}>
+          <QuickFeedback
+            key={`${siteId}-${date}-${metric}`}
+            question="Was this forecast useful?"
+            context={{
+              surface: 'site_forecast',
+              site_id: Number(siteId),
+              forecast_date: date,
+              metric,
+            }}
+          />
+        </Box>
+      )}
+    </>
+  );
+};
+
+export default DetailsRoute;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useMemo, Suspense } from 'react';
+import React, { useState, useEffect, useRef, useMemo, Suspense, useCallback } from 'react';
 import SuspenseDateBoxes from '../components/SuspenseDateBoxes';
 import DateBoxesPlaceholder from '../components/DateBoxesPlaceholder';
 import ErrorBoundary from '../components/ErrorBoundary';
@@ -10,6 +10,7 @@ import { useNavigate, useLocation, useOutletContext } from 'react-router-dom';
 import { createSitesResource } from '../utils/suspenseResource';
 import { Helmet } from 'react-helmet-async';
 import { useDefaultMetric } from '../hooks/useDefaultMetric';
+import { trackEvent } from '../analytics';
 
 // Define metrics outside the component to maintain a stable reference
 const METRICS = ['XC0', 'XC10', 'XC20', 'XC30', 'XC40', 'XC50', 'XC60', 'XC70', 'XC80', 'XC90', 'XC100'];
@@ -173,6 +174,27 @@ const Home = () => {
     markerRefs.current[siteId] = ref;
   };
 
+  const handleMetricChange = useCallback((metric) => {
+    if (metric !== selectedMetric) {
+      trackEvent('map_metric_changed', {
+        previous_metric: selectedMetric,
+        metric,
+      });
+    }
+    setSelectedMetric(metric);
+  }, [selectedMetric]);
+
+  const handleDateChange = useCallback((date) => {
+    if (date !== selectedDate) {
+      trackEvent('map_date_changed', {
+        previous_date: selectedDate || null,
+        date,
+        metric: selectedMetric,
+      });
+    }
+    setSelectedDate(date);
+  }, [selectedDate, selectedMetric]);
+
   return (
     <div style={{ 
       display: 'flex',
@@ -212,7 +234,7 @@ const Home = () => {
             <MapView
               sites={filteredSites}
               selectedMetric={selectedMetric}
-              setSelectedMetric={setSelectedMetric}
+              setSelectedMetric={handleMetricChange}
               selectedDate={selectedDate}
               metrics={METRICS}
               center={mapState.center}
@@ -231,7 +253,7 @@ const Home = () => {
                 sitesResource={sitesResource}
                 dates={dates}
                 selectedDate={selectedDate}
-                setSelectedDate={setSelectedDate}
+                setSelectedDate={handleDateChange}
                 center={mapState.center}
                 zoom={mapState.zoom}
                 bounds={mapState.bounds}

--- a/frontend/src/pages/TripPlannerPage.jsx
+++ b/frontend/src/pages/TripPlannerPage.jsx
@@ -7,7 +7,9 @@ import TripPlannerControls from '../components/TripPlannerControls';
 import SiteList from '../components/SiteList';
 import PlannerMapView from '../components/PlannerMapView';
 import LoadingSpinner from '../components/LoadingSpinner';
+import QuickFeedback from '../components/QuickFeedback';
 import { planTrip } from '../api';
+import { trackEvent } from '../analytics';
 import { AVAILABLE_METRICS, DEFAULT_PLANNER_STATE, getDefaultDateRange } from '../types/ui-state';
 import { useDefaultMetric } from '../hooks/useDefaultMetric';
 import { useAuth } from '../context/AuthContext';
@@ -138,6 +140,7 @@ const TripPlannerPage = () => {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [snackbarMessage, setSnackbarMessage] = useState(null);
   const initializedRef = useRef(false);
+  const lastTrackedResultsRef = useRef(null);
 
   useEffect(() => {
     if (initializedRef.current) return;
@@ -266,6 +269,30 @@ const TripPlannerPage = () => {
   const loading = Boolean(queryInput) && (tripQuery.isPending || (tripQuery.isFetching && allSites.length === 0));
 
   useEffect(() => {
+    if (
+      !queryInput
+      || !tripQuery.isSuccess
+      || tripQuery.isPlaceholderData
+      || lastTrackedResultsRef.current === querySignature
+    ) {
+      return;
+    }
+
+    lastTrackedResultsRef.current = querySignature;
+    trackEvent('trip_plan_results_viewed', {
+      start_date: queryInput.startDate,
+      end_date: queryInput.endDate,
+      metric: queryInput.metric,
+      distance_enabled: queryInput.maxDistanceKm != null,
+      altitude_enabled: queryInput.altitudeRange != null,
+      tags_count: queryInput.requiredTags?.length || 0,
+      returned_count: allSites.length,
+      total_count: totalCount,
+      has_results: totalCount > 0,
+    });
+  }, [allSites.length, queryInput, querySignature, totalCount, tripQuery.isPlaceholderData, tripQuery.isSuccess]);
+
+  useEffect(() => {
     if (tripQuery.isError) {
       setSnackbarMessage('Failed to plan trip. Please try again.');
     }
@@ -315,20 +342,46 @@ const TripPlannerPage = () => {
     }
 
     const nextState = { ...plannerState, dates };
+    const nextQueryInput = buildRequestInput(nextState, userLocation);
+
+    trackEvent('trip_plan_submitted', {
+      start_date: formatDate(dates[0]),
+      end_date: formatDate(dates[1]),
+      metric: nextState.selectedMetric,
+      distance_enabled: nextState.distance.enabled,
+      max_distance_km: nextState.distance.enabled ? nextState.distance.km : null,
+      altitude_enabled: nextState.altitude.enabled,
+      tags_count: nextState.tags?.length || 0,
+    });
+
     setPlannerState(nextState);
-    setQueryInput(buildRequestInput(nextState, userLocation));
+    setQueryInput(nextQueryInput);
   }, [plannerState, showError, userLocation]);
 
   const handleSiteClick = useCallback((site, event) => {
     const url = `/details/${site.site_id}?metric=${plannerState.selectedMetric}`;
+    trackEvent('trip_plan_site_opened', {
+      site_id: Number(site.site_id),
+      metric: plannerState.selectedMetric,
+      average_flyability: site.average_flyability,
+      view,
+      sort_by: sortBy,
+      opened_in_new_tab: Boolean(event && (event.button === 1 || event.ctrlKey || event.metaKey)),
+    });
+
     if (event && (event.button === 1 || event.ctrlKey || event.metaKey)) {
       window.open(url, '_blank', 'noopener,noreferrer');
       return;
     }
     navigate(url);
-  }, [navigate, plannerState.selectedMetric]);
+  }, [navigate, plannerState.selectedMetric, sortBy, view]);
 
   const handleLoadMore = useCallback(async () => {
+    trackEvent('trip_plan_more_requested', {
+      visible_count: visibleCount,
+      total_count: totalCount,
+    });
+
     if (visibleCount < allSites.length) {
       setVisibleCount((count) => Math.min(count + PAGE_SIZE, allSites.length));
       return;
@@ -342,11 +395,31 @@ const TripPlannerPage = () => {
       0,
     ) || visibleCount;
     setVisibleCount((count) => Math.min(count + PAGE_SIZE, loadedCount));
-  }, [allSites.length, tripQuery, visibleCount]);
+  }, [allSites.length, totalCount, tripQuery, visibleCount]);
 
   const handleLoadLess = useCallback(() => {
     setVisibleCount((count) => Math.max(PAGE_SIZE, count - PAGE_SIZE));
   }, []);
+
+  const handleViewChange = useCallback((nextView) => {
+    if (nextView !== view) {
+      trackEvent('trip_plan_view_changed', {
+        previous_view: view,
+        view: nextView,
+      });
+    }
+    setView(nextView);
+  }, [view]);
+
+  const handleSortChange = useCallback((nextSort) => {
+    if (nextSort !== sortBy) {
+      trackEvent('trip_plan_sort_changed', {
+        previous_sort: sortBy,
+        sort: nextSort,
+      });
+    }
+    setSortBy(nextSort);
+  }, [sortBy]);
 
   const sortedSites = useMemo(() => {
     const sorted = [...sites];
@@ -387,7 +460,7 @@ const TripPlannerPage = () => {
             <TripPlannerControls
               state={{ ...plannerState, view }}
               setState={setPlannerState}
-              onViewChange={setView}
+              onViewChange={handleViewChange}
               onSubmit={handlePlanTrip}
               loading={loading}
             />
@@ -408,13 +481,13 @@ const TripPlannerPage = () => {
                         <ButtonGroup size="small" variant="outlined">
                           <Button
                             variant={sortBy === 'flyability' ? 'contained' : 'outlined'}
-                            onClick={() => setSortBy('flyability')}
+                            onClick={() => handleSortChange('flyability')}
                           >
                             Best Conditions
                           </Button>
                           <Button
                             variant={sortBy === 'distance' ? 'contained' : 'outlined'}
-                            onClick={() => (userLocation ? setSortBy('distance') : requestLocation())}
+                            onClick={() => (userLocation ? handleSortChange('distance') : requestLocation())}
                           >
                             Closest
                           </Button>
@@ -428,13 +501,13 @@ const TripPlannerPage = () => {
                       <ButtonGroup size="small" variant="outlined">
                         <Button
                           variant={sortBy === 'flyability' ? 'contained' : 'outlined'}
-                          onClick={() => setSortBy('flyability')}
+                          onClick={() => handleSortChange('flyability')}
                         >
                           Best
                         </Button>
                         <Button
                           variant={sortBy === 'distance' ? 'contained' : 'outlined'}
-                          onClick={() => (userLocation ? setSortBy('distance') : requestLocation())}
+                          onClick={() => (userLocation ? handleSortChange('distance') : requestLocation())}
                         >
                           Closest
                         </Button>
@@ -465,6 +538,25 @@ const TripPlannerPage = () => {
                   userLocation={plannerState.distance.enabled ? plannerState.distance.coords : null}
                   loading={loading && sites.length === 0}
                 />
+              )}
+
+              {sites.length > 0 && queryInput && (
+                <Box sx={{ mt: 3 }}>
+                  <QuickFeedback
+                    key={querySignature}
+                    question="Were these trip suggestions useful?"
+                    context={{
+                      surface: 'trip_planner',
+                      start_date: queryInput.startDate,
+                      end_date: queryInput.endDate,
+                      metric: queryInput.metric,
+                      result_count: totalCount,
+                      distance_enabled: queryInput.maxDistanceKm != null,
+                      altitude_enabled: queryInput.altitudeRange != null,
+                      tags_count: queryInput.requiredTags?.length || 0,
+                    }}
+                  />
+                </Box>
               )}
 
               {sites.length > 0 && (sites.length > PAGE_SIZE || hasMore) && (


### PR DESCRIPTION
## What changed

- add a first-party `product_events` ingestion endpoint, database table, migration, validation, and Redis-backed rate limiting
- add a privacy-conscious frontend analytics client with anonymous browser/session IDs and GPC/DNT opt-out support
- track route views, map date/metric changes, site-detail selections, and the Trip Planner funnel
- add contextual helpful/not-helpful feedback to site forecasts and Trip Planner results
- add backend and frontend tests plus an event catalog and starter SQL queries

## Why

Glideator had a generic account-gated feedback form but no way to understand the main product funnel or connect feedback to a specific forecast or recommendation. This adds the minimum learning loop needed to identify useful flows, drop-off, and weak recommendations without introducing a third-party analytics vendor.

## Privacy

- no IP address, user agent, email, account ID, or precise coordinates are stored
- URL query strings are not collected
- sensitive property keys are removed client-side
- Global Privacy Control and Do Not Track are respected
- frontend collection can be disabled with `REACT_APP_ANALYTICS_ENABLED=false`

## Validation

All CI checks pass:

- backend tests
- frontend Jest suite and optimized production build
- Playwright browser smoke tests

## Deployment note

Run the Alembic migration before or with the backend deployment so the `product_events` table exists when frontend analytics is enabled.