### PR TITLE
Add single-admin operations dashboard

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from fastapi import FastAPI, HTTPException
 from .database import AsyncSessionLocal, SessionLocal
 from .routers import (
+    admin,
     analytics,
     auth,
     d2d,
@@ -174,6 +175,7 @@ app.include_router(s2s.router)
 app.include_router(d2d.router)
 app.include_router(feedback.router)
 app.include_router(analytics.router)
+app.include_router(admin.router)
 
 @app.get("/health")
 async def healthcheck():

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,429 @@
+import logging
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, func, select, text
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import crud, models
+from ..celery_client import celery
+from ..database import AsyncSessionLocal
+from ..security import decode_token, is_admin_identity
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+async def get_db():
+    async with AsyncSessionLocal() as session:
+        yield session
+
+
+async def require_admin(
+    authorization: Optional[str] = Header(default=None),
+    db: AsyncSession = Depends(get_db),
+) -> models.User:
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing bearer token")
+
+    payload = decode_token(authorization.split(" ", 1)[1])
+    if not payload or "sub" not in payload:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    try:
+        user_id = int(payload["sub"])
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+    user = await db.get(models.User, user_id)
+    if not user or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    if not is_admin_identity(email=user.email, role=user.role):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Administrator access required")
+    return user
+
+
+class AdminOverview(BaseModel):
+    total_sites: int
+    latest_gfs_forecast_at: Optional[datetime] = None
+    latest_computed_at: Optional[datetime] = None
+    covered_sites: int = 0
+    coverage_percent: float = 0
+    forecast_start_date: Optional[str] = None
+    forecast_end_date: Optional[str] = None
+    resource_sites: Optional[int] = None
+    resource_coverage_percent: Optional[float] = None
+
+
+class ForecastRunSummary(BaseModel):
+    gfs_forecast_at: datetime
+    computed_at: datetime
+    completed_at: datetime
+    covered_sites: int
+    expected_sites: int
+    coverage_percent: float
+    prediction_rows: int
+    forecast_start_date: str
+    forecast_end_date: str
+    status: str
+
+
+class AdminSite(BaseModel):
+    site_id: int
+    name: str
+    latitude: float
+    longitude: float
+    altitude: int
+    lat_gfs: float
+    lon_gfs: float
+    country: Optional[str] = None
+    html: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    latest_gfs_forecast_at: Optional[datetime] = None
+
+
+class AdminSiteUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=200)
+    latitude: Optional[float] = Field(default=None, ge=-90, le=90)
+    longitude: Optional[float] = Field(default=None, ge=-180, le=180)
+    altitude: Optional[int] = Field(default=None, ge=-500, le=9000)
+    lat_gfs: Optional[float] = Field(default=None, ge=-90, le=90)
+    lon_gfs: Optional[float] = Field(default=None, ge=-180, le=360)
+    country: Optional[str] = Field(default=None, max_length=120)
+    html: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+
+class AdminResourceLink(BaseModel):
+    candidate_id: int
+    name: Optional[str] = None
+    url: str
+    host: Optional[str] = None
+    takeoff_landing_areas: Optional[bool] = None
+    rules: Optional[bool] = None
+    fees: Optional[bool] = None
+    access: Optional[bool] = None
+    meteostation: Optional[bool] = None
+    webcams: Optional[bool] = None
+
+
+class AdminResourceSite(BaseModel):
+    site_id: int
+    site_name: str
+    source_run_id: Optional[int] = None
+    run_extracted_at: Optional[datetime] = None
+    resources: List[AdminResourceLink] = Field(default_factory=list)
+    webcam_urls: List[str] = Field(default_factory=list)
+    meteostation_urls: List[str] = Field(default_factory=list)
+
+
+class AdminResourcePage(BaseModel):
+    items: List[AdminResourceSite]
+    total: int
+    offset: int
+    limit: int
+
+
+class AdminOperation(BaseModel):
+    operation: str
+    task_id: str
+    status: str = "queued"
+
+
+async def _resource_site_count(db: AsyncSession) -> Optional[int]:
+    json_index = crud._site_resources_json_index()
+    if json_index is not None:
+        return sum(
+            1
+            for row in json_index.values()
+            if row.get("local_resources") or row.get("webcam_urls") or row.get("meteostation_urls")
+        )
+
+    try:
+        result = await db.execute(
+            text(
+                """
+                SELECT COUNT(DISTINCT r.site_id)
+                FROM glideator_ground_crew.extraction_runs r
+                WHERE EXISTS (
+                    SELECT 1
+                    FROM glideator_ground_crew.extraction_candidates c
+                    LEFT JOIN LATERAL (
+                        SELECT status
+                        FROM glideator_ground_crew.candidate_validations v
+                        WHERE v.candidate_id = c.candidate_id
+                        ORDER BY v.validated_at DESC
+                        LIMIT 1
+                    ) latest ON TRUE
+                    WHERE c.run_id = r.run_id
+                      AND latest.status IN ('ok', 'redirected')
+                )
+                """
+            )
+        )
+        return int(result.scalar_one() or 0)
+    except SQLAlchemyError:
+        await db.rollback()
+        logger.info("Ground Crew resource tables are unavailable", exc_info=True)
+        return None
+
+
+def _coverage_percent(covered: int, total: int) -> float:
+    if total <= 0:
+        return 0.0
+    return round(100 * covered / total, 1)
+
+
+@router.get("/overview", response_model=AdminOverview)
+async def get_overview(
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    total_sites = int((await db.execute(select(func.count(models.Site.site_id)))).scalar_one() or 0)
+    latest_cycle = (await db.execute(select(func.max(models.Prediction.gfs_forecast_at)))).scalar_one_or_none()
+
+    covered_sites = 0
+    latest_computed_at = None
+    forecast_start_date = None
+    forecast_end_date = None
+    if latest_cycle is not None:
+        row = (
+            await db.execute(
+                select(
+                    func.count(func.distinct(models.Prediction.site_id)),
+                    func.max(models.Prediction.computed_at),
+                    func.min(models.Prediction.date),
+                    func.max(models.Prediction.date),
+                ).where(models.Prediction.gfs_forecast_at == latest_cycle)
+            )
+        ).one()
+        covered_sites = int(row[0] or 0)
+        latest_computed_at = row[1]
+        forecast_start_date = row[2].isoformat() if row[2] else None
+        forecast_end_date = row[3].isoformat() if row[3] else None
+
+    resource_sites = await _resource_site_count(db)
+    return AdminOverview(
+        total_sites=total_sites,
+        latest_gfs_forecast_at=latest_cycle,
+        latest_computed_at=latest_computed_at,
+        covered_sites=covered_sites,
+        coverage_percent=_coverage_percent(covered_sites, total_sites),
+        forecast_start_date=forecast_start_date,
+        forecast_end_date=forecast_end_date,
+        resource_sites=resource_sites,
+        resource_coverage_percent=(
+            _coverage_percent(resource_sites, total_sites) if resource_sites is not None else None
+        ),
+    )
+
+
+@router.get("/forecast-runs", response_model=List[ForecastRunSummary])
+async def list_forecast_runs(
+    limit: int = Query(default=20, ge=1, le=100),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    total_sites = int((await db.execute(select(func.count(models.Site.site_id)))).scalar_one() or 0)
+    result = await db.execute(
+        select(
+            models.Prediction.gfs_forecast_at,
+            func.min(models.Prediction.computed_at),
+            func.max(models.Prediction.computed_at),
+            func.count(func.distinct(models.Prediction.site_id)),
+            func.count(),
+            func.min(models.Prediction.date),
+            func.max(models.Prediction.date),
+        )
+        .group_by(models.Prediction.gfs_forecast_at)
+        .order_by(models.Prediction.gfs_forecast_at.desc())
+        .limit(limit)
+    )
+
+    runs = []
+    for row in result.all():
+        covered_sites = int(row[3] or 0)
+        coverage = _coverage_percent(covered_sites, total_sites)
+        runs.append(
+            ForecastRunSummary(
+                gfs_forecast_at=row[0],
+                computed_at=row[1],
+                completed_at=row[2],
+                covered_sites=covered_sites,
+                expected_sites=total_sites,
+                coverage_percent=coverage,
+                prediction_rows=int(row[4] or 0),
+                forecast_start_date=row[5].isoformat(),
+                forecast_end_date=row[6].isoformat(),
+                status="complete" if covered_sites >= total_sites and total_sites > 0 else "partial",
+            )
+        )
+    return runs
+
+
+@router.post("/forecast/check", response_model=AdminOperation, status_code=status.HTTP_202_ACCEPTED)
+async def trigger_forecast_check(_: models.User = Depends(require_admin)):
+    task = celery.send_task("app.celery_app.check_and_trigger_forecast_processing")
+    return AdminOperation(operation="check_and_trigger_forecast_processing", task_id=task.id)
+
+
+async def _site_rows(
+    db: AsyncSession,
+    *,
+    offset: int = 0,
+    limit: int = 500,
+    site_id: Optional[int] = None,
+):
+    latest_prediction = (
+        select(
+            models.Prediction.site_id.label("site_id"),
+            func.max(models.Prediction.gfs_forecast_at).label("latest_gfs_forecast_at"),
+        )
+        .group_by(models.Prediction.site_id)
+        .subquery()
+    )
+    query = (
+        select(
+            models.Site,
+            models.SiteInfo.country,
+            models.SiteInfo.html,
+            latest_prediction.c.latest_gfs_forecast_at,
+        )
+        .outerjoin(models.SiteInfo, models.SiteInfo.site_id == models.Site.site_id)
+        .outerjoin(latest_prediction, latest_prediction.c.site_id == models.Site.site_id)
+        .order_by(models.Site.name.asc())
+    )
+    if site_id is not None:
+        query = query.where(models.Site.site_id == site_id)
+    else:
+        query = query.offset(offset).limit(limit)
+    return (await db.execute(query)).all()
+
+
+async def _serialize_sites(db: AsyncSession, rows) -> List[AdminSite]:
+    site_ids = [row[0].site_id for row in rows]
+    tags_by_site = await crud.get_tags_by_site_ids(db, site_ids)
+    return [
+        AdminSite(
+            site_id=site.site_id,
+            name=site.name,
+            latitude=site.latitude,
+            longitude=site.longitude,
+            altitude=site.altitude,
+            lat_gfs=site.lat_gfs,
+            lon_gfs=site.lon_gfs,
+            country=country,
+            html=html,
+            tags=tags_by_site.get(site.site_id, []),
+            latest_gfs_forecast_at=latest_cycle,
+        )
+        for site, country, html, latest_cycle in rows
+    ]
+
+
+@router.get("/sites", response_model=List[AdminSite])
+async def list_sites(
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=500, ge=1, le=1000),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    return await _serialize_sites(db, await _site_rows(db, offset=offset, limit=limit))
+
+
+@router.patch("/sites/{site_id}", response_model=AdminSite)
+async def update_site(
+    site_id: int,
+    payload: AdminSiteUpdate,
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    site = await db.get(models.Site, site_id)
+    if not site:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Site not found")
+
+    updates = payload.model_dump(exclude_unset=True)
+    tags = updates.pop("tags", None)
+    country_supplied = "country" in updates
+    html_supplied = "html" in updates
+    country = updates.pop("country", None)
+    html = updates.pop("html", None)
+
+    for field, value in updates.items():
+        setattr(site, field, value)
+
+    info = await db.get(models.SiteInfo, site_id)
+    if country_supplied or html_supplied:
+        if info is None:
+            info = models.SiteInfo(
+                site_id=site_id,
+                site_name=site.name,
+                country=country or "Unknown",
+                html=html or "",
+            )
+            db.add(info)
+        else:
+            info.site_name = site.name
+            if country_supplied:
+                info.country = country or "Unknown"
+            if html_supplied:
+                info.html = html or ""
+
+    if tags is not None:
+        normalized_tags = sorted({tag.strip() for tag in tags if tag.strip()})
+        await db.execute(delete(models.SiteTag).where(models.SiteTag.site_id == site_id))
+        for tag in normalized_tags:
+            db.add(models.SiteTag(site_id=site_id, tag=tag))
+
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Site update conflicts with existing data") from exc
+
+    rows = await _site_rows(db, site_id=site_id)
+    return (await _serialize_sites(db, rows))[0]
+
+
+@router.get("/resources", response_model=AdminResourcePage)
+async def list_resources(
+    offset: int = Query(default=0, ge=0),
+    limit: int = Query(default=50, ge=1, le=250),
+    missing_only: bool = False,
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    all_sites = (await db.execute(select(models.Site).order_by(models.Site.name.asc()))).scalars().all()
+    items: List[AdminResourceSite] = []
+
+    for site in all_sites:
+        try:
+            resource = await crud.get_site_resources(db, site.site_id)
+        except SQLAlchemyError:
+            await db.rollback()
+            logger.info("Resources unavailable for site_id=%s", site.site_id, exc_info=True)
+            resource = None
+
+        links = resource.local_resources if resource else []
+        webcam_urls = resource.webcam_urls if resource else []
+        meteostation_urls = resource.meteostation_urls if resource else []
+        if missing_only and (links or webcam_urls or meteostation_urls):
+            continue
+        items.append(
+            AdminResourceSite(
+                site_id=site.site_id,
+                site_name=site.name,
+                source_run_id=resource.source_run_id if resource else None,
+                run_extracted_at=resource.run_extracted_at if resource else None,
+                resources=[AdminResourceLink.model_validate(link, from_attributes=True) for link in links],
+                webcam_urls=webcam_urls,
+                meteostation_urls=meteostation_urls,
+            )
+        )
+
+    total = len(items)
+    return AdminResourcePage(items=items[offset : offset + limit], total=total, offset=offset, limit=limit)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -12,6 +12,7 @@ from ..security import (
     create_access_token,
     create_refresh_token,
     decode_token,
+    effective_role,
     get_access_token_exp_minutes,
     get_refresh_token_exp_days,
     is_cookie_secure,
@@ -139,7 +140,12 @@ async def me(authorization: Optional[str] = Header(default=None), db: AsyncSessi
     user = await db.get(models.User, user_id)
     if not user:
         raise HTTPException(status_code=401, detail="Invalid token")
-    return user
+    return schemas.UserOut(
+        user_id=user.user_id,
+        email=user.email,
+        is_active=user.is_active,
+        role=effective_role(email=user.email, role=user.role),
+    )
 
 
 @router.post("/refresh", response_model=schemas.TokenOut)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -14,6 +14,23 @@ def normalize_email(email: str) -> str:
     return email.strip().lower()
 
 
+def get_admin_emails() -> set[str]:
+    raw = os.getenv("ADMIN_EMAILS", "")
+    return {
+        normalize_email(email)
+        for email in raw.split(",")
+        if email.strip()
+    }
+
+
+def is_admin_identity(*, email: str, role: str) -> bool:
+    return role == "admin" or normalize_email(email) in get_admin_emails()
+
+
+def effective_role(*, email: str, role: str) -> str:
+    return "admin" if is_admin_identity(email=email, role=role) else role
+
+
 def get_app_env() -> str:
     return os.getenv("APP_ENV", os.getenv("ENV", "development")).strip().lower()
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,78 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+from app.routers import admin
+from app.security import effective_role, is_admin_identity
+
+
+class FakeSession:
+    def __init__(self, user):
+        self.user = user
+
+    async def get(self, model, user_id):
+        return self.user if self.user.user_id == user_id else None
+
+
+@pytest.mark.asyncio
+async def test_require_admin_accepts_configured_email(monkeypatch):
+    monkeypatch.setenv("ADMIN_EMAILS", "owner@example.com")
+    monkeypatch.setattr(admin, "decode_token", lambda token: {"sub": "7"})
+    user = SimpleNamespace(
+        user_id=7,
+        email="owner@example.com",
+        role="user",
+        is_active=True,
+    )
+
+    result = await admin.require_admin("Bearer token", FakeSession(user))
+
+    assert result is user
+    assert effective_role(email=user.email, role=user.role) == "admin"
+
+
+@pytest.mark.asyncio
+async def test_require_admin_rejects_regular_user(monkeypatch):
+    monkeypatch.delenv("ADMIN_EMAILS", raising=False)
+    monkeypatch.setattr(admin, "decode_token", lambda token: {"sub": "7"})
+    user = SimpleNamespace(
+        user_id=7,
+        email="pilot@example.com",
+        role="user",
+        is_active=True,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await admin.require_admin("Bearer token", FakeSession(user))
+
+    assert exc.value.status_code == 403
+
+
+def test_database_admin_role_is_always_accepted(monkeypatch):
+    monkeypatch.delenv("ADMIN_EMAILS", raising=False)
+
+    assert is_admin_identity(email="anyone@example.com", role="admin") is True
+
+
+@pytest.mark.asyncio
+async def test_forecast_check_queues_existing_celery_task(monkeypatch):
+    calls = []
+
+    class FakeTask:
+        id = "task-123"
+
+    def fake_send_task(name):
+        calls.append(name)
+        return FakeTask()
+
+    monkeypatch.setattr(admin.celery, "send_task", fake_send_task)
+
+    result = await admin.trigger_forecast_check(SimpleNamespace())
+
+    assert result.task_id == "task-123"
+    assert calls == ["app.celery_app.check_and_trigger_forecast_processing"]

--- a/docs/admin-dashboard.md
+++ b/docs/admin-dashboard.md
@@ -1,0 +1,43 @@
+# Administrator dashboard
+
+Glideator includes a private operator cockpit at `/admin` for the single project administrator.
+
+## Access
+
+The dashboard uses the normal Glideator login and access-token flow. A user is treated as an administrator when either:
+
+- the `users.role` database column is `admin`; or
+- the normalized email appears in the comma-separated `ADMIN_EMAILS` environment variable.
+
+For the current single-admin setup, configure the backend web service on Render with:
+
+```text
+ADMIN_EMAILS=<the email used for the Glideator account>
+```
+
+Log out and back in after changing the variable so `/auth/me` refreshes the effective role shown to the frontend.
+
+## Included workflows
+
+- **Overview** — latest GFS cycle, publication time, forecast horizon, site coverage, and Ground Crew resource coverage.
+- **Forecast runs** — recent cycles grouped from the existing `predictions` table, including covered sites, horizon, row count, and complete/partial status.
+- **Manual forecast check** — queues the existing `app.celery_app.check_and_trigger_forecast_processing` Celery task.
+- **Site editor** — edits site coordinates, altitude, GFS point, country, information HTML, and tags.
+- **Resource inventory** — shows validated local links, webcam counts, meteostation counts, extraction time, and sites with no resources.
+
+No new database migration is required. Forecast-run state is derived from existing prediction records, while resources use the same bundled JSON or `glideator_ground_crew` SQL source as the public site-resource endpoint.
+
+## API
+
+All endpoints require an administrator bearer token:
+
+```text
+GET   /admin/overview
+GET   /admin/forecast-runs
+POST  /admin/forecast/check
+GET   /admin/sites
+PATCH /admin/sites/{site_id}
+GET   /admin/resources
+```
+
+The manual action deliberately exposes the existing safe forecast-discovery task rather than a generic Celery command runner.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,11 +13,13 @@ import Notifications from './pages/Notifications';
 import About from './pages/About';
 import Feedback from './pages/Feedback';
 import RequireAuth from './components/RequireAuth';
+import RequireAdmin from './components/RequireAdmin';
 import LoadingSpinner from './components/LoadingSpinner';
 import AnalyticsRouteTracker from './components/AnalyticsRouteTracker';
 import { AuthProvider } from './context/AuthContext';
 import { NotificationProvider } from './context/NotificationContext';
 
+const Admin = React.lazy(() => import('./pages/Admin'));
 const Details = React.lazy(() => import('./pages/DetailsRoute'));
 const TripPlannerPage = React.lazy(() => import('./pages/TripPlannerPage'));
 
@@ -42,6 +44,14 @@ const App = () => {
                 <Route index element={<Home />} />
                 <Route path="trip-planner" element={<TripPlannerPage />} />
                 <Route path="about" element={<About />} />
+                <Route
+                  path="admin"
+                  element={(
+                    <RequireAdmin>
+                      <Admin />
+                    </RequireAdmin>
+                  )}
+                />
                 <Route
                   path="feedback"
                   element={(

--- a/frontend/src/adminApi.js
+++ b/frontend/src/adminApi.js
@@ -1,0 +1,36 @@
+import apiClient from './api';
+
+export const fetchAdminOverview = async () => {
+  const response = await apiClient.get('/admin/overview');
+  return response.data;
+};
+
+export const fetchAdminForecastRuns = async (limit = 20) => {
+  const response = await apiClient.get('/admin/forecast-runs', { params: { limit } });
+  return response.data;
+};
+
+export const triggerAdminForecastCheck = async () => {
+  const response = await apiClient.post('/admin/forecast/check');
+  return response.data;
+};
+
+export const fetchAdminSites = async (limit = 1000) => {
+  const response = await apiClient.get('/admin/sites', { params: { limit } });
+  return response.data;
+};
+
+export const updateAdminSite = async (siteId, payload) => {
+  const response = await apiClient.patch(`/admin/sites/${siteId}`, payload);
+  return response.data;
+};
+
+export const fetchAdminResources = async ({ missingOnly = false, limit = 250 } = {}) => {
+  const response = await apiClient.get('/admin/resources', {
+    params: {
+      missing_only: missingOnly,
+      limit,
+    },
+  });
+  return response.data;
+};

--- a/frontend/src/components/RequireAdmin.jsx
+++ b/frontend/src/components/RequireAdmin.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Alert, Box } from '@mui/material';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+import LoadingSpinner from './LoadingSpinner';
+
+const RequireAdmin = ({ children }) => {
+  const location = useLocation();
+  const { isAuthenticated, isLoading, user } = useAuth();
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (user?.role !== 'admin') {
+    return (
+      <Box sx={{ p: 3 }}>
+        <Alert severity="error">Administrator access is required.</Alert>
+      </Box>
+    );
+  }
+
+  return children;
+};
+
+export default RequireAdmin;

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -1,0 +1,546 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Container,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControlLabel,
+  Grid,
+  IconButton,
+  LinearProgress,
+  Link,
+  Paper,
+  Stack,
+  Switch,
+  Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tabs,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import EditIcon from '@mui/icons-material/Edit';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import {
+  fetchAdminForecastRuns,
+  fetchAdminOverview,
+  fetchAdminResources,
+  fetchAdminSites,
+  triggerAdminForecastCheck,
+  updateAdminSite,
+} from '../adminApi';
+
+const formatDateTime = (value) => {
+  if (!value) return '—';
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+};
+
+const MetricCard = ({ label, value, detail }) => (
+  <Card variant="outlined" sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="overline" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h4" sx={{ mt: 0.5, fontWeight: 700 }}>
+        {value}
+      </Typography>
+      {detail && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {detail}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const Admin = () => {
+  const [tab, setTab] = useState(0);
+  const [overview, setOverview] = useState(null);
+  const [runs, setRuns] = useState([]);
+  const [sites, setSites] = useState([]);
+  const [resources, setResources] = useState(null);
+  const [missingResourcesOnly, setMissingResourcesOnly] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [resourceLoading, setResourceLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [notice, setNotice] = useState('');
+  const [editingSite, setEditingSite] = useState(null);
+  const [savingSite, setSavingSite] = useState(false);
+
+  const loadPrimaryData = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [overviewData, runData, siteData] = await Promise.all([
+        fetchAdminOverview(),
+        fetchAdminForecastRuns(),
+        fetchAdminSites(),
+      ]);
+      setOverview(overviewData);
+      setRuns(runData);
+      setSites(siteData);
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load the administrator dashboard.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadResources = useCallback(async () => {
+    setResourceLoading(true);
+    setError('');
+    try {
+      const data = await fetchAdminResources({
+        missingOnly: missingResourcesOnly,
+        limit: 250,
+      });
+      setResources(data);
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load site resources.');
+    } finally {
+      setResourceLoading(false);
+    }
+  }, [missingResourcesOnly]);
+
+  useEffect(() => {
+    loadPrimaryData();
+  }, [loadPrimaryData]);
+
+  useEffect(() => {
+    if (tab === 3) {
+      loadResources();
+    }
+  }, [tab, loadResources]);
+
+  const handleRefresh = async () => {
+    setNotice('');
+    await loadPrimaryData();
+    if (tab === 3) {
+      await loadResources();
+    }
+  };
+
+  const handleTriggerForecast = async () => {
+    setError('');
+    setNotice('');
+    try {
+      const operation = await triggerAdminForecastCheck();
+      setNotice(`Forecast check queued as task ${operation.task_id}.`);
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to queue the forecast check.');
+    }
+  };
+
+  const openSiteEditor = (site) => {
+    setEditingSite({
+      ...site,
+      tagsText: (site.tags || []).join(', '),
+    });
+  };
+
+  const updateEditingField = (field) => (event) => {
+    setEditingSite((current) => ({
+      ...current,
+      [field]: event.target.value,
+    }));
+  };
+
+  const handleSaveSite = async () => {
+    if (!editingSite) return;
+    setSavingSite(true);
+    setError('');
+    try {
+      const updated = await updateAdminSite(editingSite.site_id, {
+        name: editingSite.name.trim(),
+        latitude: Number(editingSite.latitude),
+        longitude: Number(editingSite.longitude),
+        altitude: Number(editingSite.altitude),
+        lat_gfs: Number(editingSite.lat_gfs),
+        lon_gfs: Number(editingSite.lon_gfs),
+        country: editingSite.country?.trim() || null,
+        html: editingSite.html || '',
+        tags: editingSite.tagsText
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter(Boolean),
+      });
+      setSites((current) => current.map((site) => (
+        site.site_id === updated.site_id ? updated : site
+      )));
+      setEditingSite(null);
+      setNotice(`${updated.name} was updated.`);
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to update the site.');
+    } finally {
+      setSavingSite(false);
+    }
+  };
+
+  const forecastHealthy = overview && overview.covered_sites >= overview.total_sites;
+
+  return (
+    <Container maxWidth="xl" sx={{ py: 3 }}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={2}
+        sx={{ mb: 3 }}
+      >
+        <Box>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <AdminPanelSettingsIcon color="primary" />
+            <Typography variant="h4" component="h1" sx={{ fontWeight: 700 }}>
+              Glideator cockpit
+            </Typography>
+          </Stack>
+          <Typography color="text.secondary" sx={{ mt: 0.5 }}>
+            Forecast operations, site data and Ground Crew resources.
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant="outlined"
+            startIcon={<RefreshIcon />}
+            onClick={handleRefresh}
+            disabled={loading || resourceLoading}
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<PlayArrowIcon />}
+            onClick={handleTriggerForecast}
+          >
+            Check forecasts
+          </Button>
+        </Stack>
+      </Stack>
+
+      {loading && <LinearProgress sx={{ mb: 2 }} />}
+      {error && <Alert severity="error" sx={{ mb: 2 }}>{error}</Alert>}
+      {notice && <Alert severity="success" sx={{ mb: 2 }}>{notice}</Alert>}
+
+      <Paper variant="outlined">
+        <Tabs
+          value={tab}
+          onChange={(_, value) => setTab(value)}
+          variant="scrollable"
+          scrollButtons="auto"
+          sx={{ px: 1, borderBottom: 1, borderColor: 'divider' }}
+        >
+          <Tab label="Overview" />
+          <Tab label="Forecast runs" />
+          <Tab label="Sites" />
+          <Tab label="Resources" />
+        </Tabs>
+
+        <Box sx={{ p: { xs: 2, md: 3 } }}>
+          {tab === 0 && overview && (
+            <Stack spacing={3}>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6} lg={3}>
+                  <MetricCard
+                    label="Forecast coverage"
+                    value={`${overview.coverage_percent}%`}
+                    detail={`${overview.covered_sites} of ${overview.total_sites} sites`}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} lg={3}>
+                  <MetricCard
+                    label="Latest GFS cycle"
+                    value={formatDateTime(overview.latest_gfs_forecast_at)}
+                    detail={`Published ${formatDateTime(overview.latest_computed_at)}`}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} lg={3}>
+                  <MetricCard
+                    label="Forecast horizon"
+                    value={overview.forecast_start_date || '—'}
+                    detail={overview.forecast_end_date ? `through ${overview.forecast_end_date}` : null}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} lg={3}>
+                  <MetricCard
+                    label="Sites with resources"
+                    value={overview.resource_sites ?? '—'}
+                    detail={overview.resource_coverage_percent == null
+                      ? 'Ground Crew data unavailable'
+                      : `${overview.resource_coverage_percent}% coverage`}
+                  />
+                </Grid>
+              </Grid>
+
+              <Alert
+                severity={forecastHealthy ? 'success' : 'warning'}
+                icon={forecastHealthy ? <CheckCircleIcon /> : <WarningAmberIcon />}
+              >
+                {forecastHealthy
+                  ? 'The latest forecast cycle covers every configured site.'
+                  : `The latest cycle is missing ${Math.max(0, overview.total_sites - overview.covered_sites)} site(s).`}
+              </Alert>
+            </Stack>
+          )}
+
+          {tab === 1 && (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>GFS cycle</TableCell>
+                    <TableCell>Status</TableCell>
+                    <TableCell align="right">Coverage</TableCell>
+                    <TableCell>Horizon</TableCell>
+                    <TableCell>Completed</TableCell>
+                    <TableCell align="right">Rows</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {runs.map((run) => (
+                    <TableRow key={run.gfs_forecast_at} hover>
+                      <TableCell>{formatDateTime(run.gfs_forecast_at)}</TableCell>
+                      <TableCell>
+                        <Chip
+                          size="small"
+                          label={run.status}
+                          color={run.status === 'complete' ? 'success' : 'warning'}
+                        />
+                      </TableCell>
+                      <TableCell align="right">
+                        {run.covered_sites}/{run.expected_sites} ({run.coverage_percent}%)
+                      </TableCell>
+                      <TableCell>{run.forecast_start_date} – {run.forecast_end_date}</TableCell>
+                      <TableCell>{formatDateTime(run.completed_at)}</TableCell>
+                      <TableCell align="right">{run.prediction_rows.toLocaleString()}</TableCell>
+                    </TableRow>
+                  ))}
+                  {!loading && runs.length === 0 && (
+                    <TableRow>
+                      <TableCell colSpan={6} align="center">No forecast runs found.</TableCell>
+                    </TableRow>
+                  )}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+
+          {tab === 2 && (
+            <TableContainer sx={{ maxHeight: '65vh' }}>
+              <Table stickyHeader size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Site</TableCell>
+                    <TableCell>Country</TableCell>
+                    <TableCell align="right">Altitude</TableCell>
+                    <TableCell>GFS point</TableCell>
+                    <TableCell>Tags</TableCell>
+                    <TableCell>Latest forecast</TableCell>
+                    <TableCell align="right">Edit</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sites.map((site) => (
+                    <TableRow key={site.site_id} hover>
+                      <TableCell>
+                        <Link href={`/details/${site.site_id}`} target="_blank" rel="noreferrer">
+                          {site.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>{site.country || '—'}</TableCell>
+                      <TableCell align="right">{site.altitude} m</TableCell>
+                      <TableCell>{site.lat_gfs}, {site.lon_gfs}</TableCell>
+                      <TableCell>
+                        <Stack direction="row" spacing={0.5} useFlexGap flexWrap="wrap">
+                          {(site.tags || []).slice(0, 4).map((tag) => (
+                            <Chip key={tag} label={tag} size="small" variant="outlined" />
+                          ))}
+                          {(site.tags || []).length > 4 && (
+                            <Chip label={`+${site.tags.length - 4}`} size="small" />
+                          )}
+                        </Stack>
+                      </TableCell>
+                      <TableCell>{formatDateTime(site.latest_gfs_forecast_at)}</TableCell>
+                      <TableCell align="right">
+                        <Tooltip title="Edit site">
+                          <IconButton size="small" onClick={() => openSiteEditor(site)}>
+                            <EditIcon fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+
+          {tab === 3 && (
+            <Stack spacing={2}>
+              <FormControlLabel
+                control={(
+                  <Switch
+                    checked={missingResourcesOnly}
+                    onChange={(event) => setMissingResourcesOnly(event.target.checked)}
+                  />
+                )}
+                label="Show only sites without resources"
+              />
+              {resourceLoading && <LinearProgress />}
+              <TableContainer sx={{ maxHeight: '65vh' }}>
+                <Table stickyHeader size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Site</TableCell>
+                      <TableCell>Validated resources</TableCell>
+                      <TableCell>Webcams</TableCell>
+                      <TableCell>Meteostations</TableCell>
+                      <TableCell>Last extraction</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {(resources?.items || []).map((site) => (
+                      <TableRow key={site.site_id} hover>
+                        <TableCell>
+                          <Link href={`/details/${site.site_id}`} target="_blank" rel="noreferrer">
+                            {site.site_name}
+                          </Link>
+                        </TableCell>
+                        <TableCell>
+                          <Stack spacing={0.5}>
+                            {site.resources.map((resource) => (
+                              <Link
+                                key={resource.candidate_id}
+                                href={resource.url}
+                                target="_blank"
+                                rel="noreferrer"
+                                sx={{ display: 'inline-flex', alignItems: 'center', gap: 0.5 }}
+                              >
+                                {resource.name || resource.host || resource.url}
+                                <OpenInNewIcon sx={{ fontSize: 14 }} />
+                              </Link>
+                            ))}
+                            {site.resources.length === 0 && (
+                              <Typography variant="body2" color="text.secondary">None</Typography>
+                            )}
+                          </Stack>
+                        </TableCell>
+                        <TableCell>{site.webcam_urls.length}</TableCell>
+                        <TableCell>{site.meteostation_urls.length}</TableCell>
+                        <TableCell>{formatDateTime(site.run_extracted_at)}</TableCell>
+                      </TableRow>
+                    ))}
+                    {!resourceLoading && (resources?.items || []).length === 0 && (
+                      <TableRow>
+                        <TableCell colSpan={5} align="center">No matching sites found.</TableCell>
+                      </TableRow>
+                    )}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+              {resources && (
+                <Typography variant="caption" color="text.secondary">
+                  Showing {resources.items.length} of {resources.total} matching sites.
+                </Typography>
+              )}
+            </Stack>
+          )}
+        </Box>
+      </Paper>
+
+      <Dialog
+        open={Boolean(editingSite)}
+        onClose={() => !savingSite && setEditingSite(null)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>Edit site</DialogTitle>
+        <DialogContent dividers>
+          {editingSite && (
+            <Grid container spacing={2} sx={{ mt: 0 }}>
+              <Grid item xs={12} md={8}>
+                <TextField
+                  label="Name"
+                  value={editingSite.name}
+                  onChange={updateEditingField('name')}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField
+                  label="Country"
+                  value={editingSite.country || ''}
+                  onChange={updateEditingField('country')}
+                  fullWidth
+                />
+              </Grid>
+              {[
+                ['latitude', 'Latitude'],
+                ['longitude', 'Longitude'],
+                ['altitude', 'Altitude (m)'],
+                ['lat_gfs', 'GFS latitude'],
+                ['lon_gfs', 'GFS longitude'],
+              ].map(([field, label]) => (
+                <Grid item xs={12} sm={6} md={field === 'altitude' ? 4 : 6} key={field}>
+                  <TextField
+                    label={label}
+                    type="number"
+                    value={editingSite[field]}
+                    onChange={updateEditingField(field)}
+                    fullWidth
+                  />
+                </Grid>
+              ))}
+              <Grid item xs={12}>
+                <TextField
+                  label="Tags"
+                  helperText="Comma-separated"
+                  value={editingSite.tagsText}
+                  onChange={updateEditingField('tagsText')}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12}>
+                <TextField
+                  label="Site information HTML"
+                  value={editingSite.html || ''}
+                  onChange={updateEditingField('html')}
+                  multiline
+                  minRows={8}
+                  fullWidth
+                />
+              </Grid>
+            </Grid>
+          )}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditingSite(null)} disabled={savingSite}>Cancel</Button>
+          <Button variant="contained" onClick={handleSaveSite} disabled={savingSite}>
+            {savingSite ? 'Saving…' : 'Save'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </Container>
+  );
+};
+
+export default Admin;

--- a/frontend/src/pages/Layout.jsx
+++ b/frontend/src/pages/Layout.jsx
@@ -19,6 +19,7 @@ import {
   Tooltip,
 } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
+import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import CloseIcon from '@mui/icons-material/Close';
 import ExploreIcon from '@mui/icons-material/Explore';
 import HomeIcon from '@mui/icons-material/Home';
@@ -32,11 +33,10 @@ import SearchBar from '../components/SearchBar';
 import DisclaimerModal from '../components/DisclaimerModal';
 import NotificationDropdown from '../components/NotificationDropdown';
 import useDisclaimer from '../hooks/useDisclaimer';
-import { fetchSitesList } from '../api';  // Reverted back to fetchSitesList
+import { fetchSitesList } from '../api';
 import { useAuth } from '../context/AuthContext';
 
 const Layout = () => {
-  // This state and function will be passed down to components that need it
   const [selectedSite, setSelectedSite] = useState(null);
   const [sites, setSites] = useState([]);
   const { showDisclaimer, handleAccept, handleDecline } = useDisclaimer();
@@ -47,7 +47,6 @@ const Layout = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
-  // Update these values - make header taller on mobile for better touch targets
   const headerHeight = isMobile ? '56px' : '64px';
   const footerHeight = '30px';
 
@@ -99,11 +98,10 @@ const Layout = () => {
   };
 
   const displayLabel = profile?.display_name || user?.email;
+  const isAdmin = user?.role === 'admin';
 
-  // Mobile drawer content
   const mobileDrawerContent = (
     <Box sx={{ width: 280 }}>
-      {/* Header with logo and close button */}
       <Box
         sx={{
           display: 'flex',
@@ -126,27 +124,25 @@ const Layout = () => {
         </IconButton>
       </Box>
 
-      {/* Search Bar */}
       <Box sx={{ px: 2, py: 1.5 }}>
-        <SearchBar 
+        <SearchBar
           sites={sites}
           onSiteSelect={(site) => {
             setSelectedSite(site);
             setMobileDrawerOpen(false);
           }}
-          mobile={true}
+          mobile
         />
       </Box>
 
       <Divider />
 
-      {/* Main Navigation */}
       <List sx={{ py: 1 }}>
         <ListItemButton onClick={() => handleMobileMenuClick('/')}>
           <ListItemIcon><HomeIcon /></ListItemIcon>
           <ListItemText primary="Home" />
         </ListItemButton>
-        
+
         <ListItemButton onClick={() => handleMobileMenuClick('/trip-planner')}>
           <ListItemIcon><ExploreIcon /></ListItemIcon>
           <ListItemText primary="Plan a Trip" />
@@ -160,7 +156,6 @@ const Layout = () => {
 
       <Divider />
 
-      {/* User Section */}
       <List sx={{ py: 1 }}>
         {isAuthenticated ? (
           <>
@@ -172,6 +167,12 @@ const Layout = () => {
               <ListItemIcon><PersonIcon /></ListItemIcon>
               <ListItemText primary="Profile" />
             </ListItemButton>
+            {isAdmin && (
+              <ListItemButton onClick={() => handleMobileMenuClick('/admin')}>
+                <ListItemIcon><AdminPanelSettingsIcon /></ListItemIcon>
+                <ListItemText primary="Admin cockpit" />
+              </ListItemButton>
+            )}
           </>
         ) : (
           <>
@@ -187,7 +188,6 @@ const Layout = () => {
         )}
       </List>
 
-      {/* Logout at bottom */}
       {isAuthenticated && (
         <>
           <Divider />
@@ -204,14 +204,12 @@ const Layout = () => {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
-      {/* Disclaimer Modal */}
-      <DisclaimerModal 
-        open={showDisclaimer} 
-        onAccept={handleAccept} 
-        onDecline={handleDecline} 
+      <DisclaimerModal
+        open={showDisclaimer}
+        onAccept={handleAccept}
+        onDecline={handleDecline}
       />
 
-      {/* Mobile Navigation Drawer */}
       <Drawer
         anchor="left"
         open={mobileDrawerOpen}
@@ -220,18 +218,16 @@ const Layout = () => {
       >
         {mobileDrawerContent}
       </Drawer>
-      
-      {/* Top Navigation Bar */}
+
       <AppBar
         position="static"
         sx={{
           backgroundColor: '#424242',
-          zIndex: (theme) => theme.zIndex.drawer + 1,
+          zIndex: (themeValue) => themeValue.zIndex.drawer + 1,
           height: headerHeight,
         }}
       >
         <Toolbar>
-          {/* Mobile: Hamburger menu */}
           {isMobile && (
             <IconButton
               color="inherit"
@@ -242,8 +238,7 @@ const Layout = () => {
               <MenuIcon />
             </IconButton>
           )}
-          
-          {/* Logo - links to home */}
+
           <Box
             component={RouterLink}
             to="/"
@@ -269,11 +264,10 @@ const Layout = () => {
               </Typography>
             )}
           </Box>
-          
-          {/* Desktop: Search bar */}
+
           {!isMobile && (
             <Box sx={{ ml: 3, flexGrow: 1, maxWidth: 400 }}>
-              <SearchBar 
+              <SearchBar
                 sites={sites}
                 onSiteSelect={setSelectedSite}
               />
@@ -282,9 +276,7 @@ const Layout = () => {
 
           <Box sx={{ flexGrow: 1 }} />
 
-          {/* Right side icons */}
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            {/* Desktop: Plan a Trip */}
             {!isMobile && (
               <Tooltip title="Plan a Trip">
                 <IconButton
@@ -297,7 +289,6 @@ const Layout = () => {
               </Tooltip>
             )}
 
-            {/* Desktop: How It Works */}
             {!isMobile && (
               <Tooltip title="How It Works">
                 <IconButton
@@ -310,7 +301,6 @@ const Layout = () => {
               </Tooltip>
             )}
 
-            {/* Desktop: Favorites (authenticated only) */}
             {!isMobile && isAuthenticated && (
               <Tooltip title="Favorites">
                 <IconButton
@@ -323,10 +313,8 @@ const Layout = () => {
               </Tooltip>
             )}
 
-            {/* Notifications - always visible */}
             <NotificationDropdown iconColor="inherit" />
 
-            {/* Profile menu */}
             {isAuthenticated ? (
               <>
                 <Tooltip title="Account">
@@ -347,6 +335,12 @@ const Layout = () => {
                     </Typography>
                   </MenuItem>
                   <Divider />
+                  {isAdmin && (
+                    <MenuItem component={RouterLink} to="/admin" onClick={handleMenuClose}>
+                      <ListItemIcon><AdminPanelSettingsIcon fontSize="small" /></ListItemIcon>
+                      Admin cockpit
+                    </MenuItem>
+                  )}
                   <MenuItem component={RouterLink} to="/profile" onClick={handleMenuClose}>
                     <ListItemIcon><PersonIcon fontSize="small" /></ListItemIcon>
                     Profile
@@ -358,7 +352,6 @@ const Layout = () => {
                 </Menu>
               </>
             ) : (
-              /* Not authenticated - show login icon on desktop */
               !isMobile && (
                 <Tooltip title="Log In">
                   <IconButton
@@ -375,7 +368,6 @@ const Layout = () => {
         </Toolbar>
       </AppBar>
 
-      {/* Main Content */}
       <Box
         component="main"
         sx={{
@@ -384,21 +376,18 @@ const Layout = () => {
           overflow: 'auto',
           backgroundColor: '#f5f5f5',
           padding: 0,
-          // Ensure proper touch scrolling on mobile
           WebkitOverflowScrolling: 'touch',
         }}
       >
-        {/* This is where child routes will be rendered */}
         <Outlet context={{ selectedSite, setSelectedSite }} />
       </Box>
 
-      {/* Bottom Footer Bar */}
       <AppBar
         position="static"
         sx={{
           backgroundColor: '#424242',
           height: footerHeight,
-          zIndex: (theme) => theme.zIndex.drawer + 1,
+          zIndex: (themeValue) => themeValue.zIndex.drawer + 1,
         }}
       >
         <Toolbar


### PR DESCRIPTION
## What changed

- adds an authenticated `/admin` cockpit inside the existing React application
- adds administrator-only FastAPI endpoints for operational overview, forecast-run history, manual forecast checks, site editing, and Ground Crew resource inventory
- reuses the existing user login and supports a single configured owner through `ADMIN_EMAILS`
- adds desktop/mobile navigation for administrator accounts
- adds backend authorization and Celery-trigger tests
- documents Render configuration and the available admin API

## Why

The project currently requires logs, SQL, or command-line access for routine operational checks. This provides a focused private cockpit for the single administrator without introducing multi-user roles, approval workflows, or a generic command runner.

## Implementation notes

- no database migration is required
- forecast runs are derived from existing `predictions` records
- resource coverage uses the same bundled JSON or Ground Crew SQL source as the public resource endpoint
- the manual action queues the existing `check_and_trigger_forecast_processing` task

## Validation

- Python syntax for the new admin router was checked locally
- GitHub CI will run backend tests, frontend tests/build, and Playwright smoke tests on this draft PR
