### PR TITLE
Add user feedback and product insights to admin

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
@@ -11,7 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from .. import crud, models
 from ..celery_client import celery
 from ..database import AsyncSessionLocal
-from ..security import decode_token, is_admin_identity
+from ..security import decode_token, effective_role, is_admin_identity
+from .analytics import ProductEvent
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,11 @@ class AdminOverview(BaseModel):
     forecast_end_date: Optional[str] = None
     resource_sites: Optional[int] = None
     resource_coverage_percent: Optional[float] = None
+    total_users: int = 0
+    new_users_30d: int = 0
+    feedback_count: int = 0
+    visitors_30d: int = 0
+    sessions_30d: int = 0
 
 
 class ForecastRunSummary(BaseModel):
@@ -128,6 +134,101 @@ class AdminResourcePage(BaseModel):
     limit: int
 
 
+class AdminUserRow(BaseModel):
+    user_id: int
+    email: str
+    display_name: Optional[str] = None
+    is_active: bool
+    role: str
+    created_at: datetime
+    favorite_count: int = 0
+    notification_count: int = 0
+    active_push_subscriptions: int = 0
+
+
+class AdminUsersResponse(BaseModel):
+    total_users: int
+    active_users: int
+    new_users_7d: int
+    new_users_30d: int
+    users_with_favorites: int
+    users_with_notifications: int
+    users_with_push: int
+    items: List[AdminUserRow]
+
+
+class AdminFeedbackRow(BaseModel):
+    id: int
+    message: str
+    user_id: Optional[int] = None
+    user_email: Optional[str] = None
+    display_name: Optional[str] = None
+    created_at: datetime
+
+
+class AdminFeedbackResponse(BaseModel):
+    total: int
+    items: List[AdminFeedbackRow]
+
+
+class AnalyticsDailyPoint(BaseModel):
+    day: str
+    visitors: int
+    sessions: int
+    events: int
+
+
+class AnalyticsEventCount(BaseModel):
+    event_name: str
+    events: int
+    visitors: int
+
+
+class AnalyticsPathCount(BaseModel):
+    path: str
+    events: int
+    visitors: int
+
+
+class AnalyticsFunnel(BaseModel):
+    submitted_sessions: int = 0
+    results_sessions: int = 0
+    opened_site_sessions: int = 0
+    results_rate: float = 0
+    site_open_rate: float = 0
+
+
+class AnalyticsFeedbackSurface(BaseModel):
+    surface: str
+    helpful: int = 0
+    not_helpful: int = 0
+    total: int = 0
+    helpful_rate: Optional[float] = None
+
+
+class AnalyticsSiteInteraction(BaseModel):
+    site_id: Optional[int] = None
+    site_name: Optional[str] = None
+    interactions: int
+    visitors: int
+
+
+class AdminAnalyticsResponse(BaseModel):
+    window_days: int
+    total_events: int
+    unique_visitors: int
+    unique_sessions: int
+    map_sessions: int
+    site_detail_sessions: int
+    map_to_site_rate: float
+    daily: List[AnalyticsDailyPoint]
+    event_counts: List[AnalyticsEventCount]
+    top_paths: List[AnalyticsPathCount]
+    trip_planner: AnalyticsFunnel
+    recommendation_feedback: List[AnalyticsFeedbackSurface]
+    top_sites: List[AnalyticsSiteInteraction]
+
+
 class AdminOperation(BaseModel):
     operation: str
     task_id: str
@@ -178,6 +279,12 @@ def _coverage_percent(covered: int, total: int) -> float:
     return round(100 * covered / total, 1)
 
 
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(100 * numerator / denominator, 1)
+
+
 @router.get("/overview", response_model=AdminOverview)
 async def get_overview(
     _: models.User = Depends(require_admin),
@@ -207,6 +314,29 @@ async def get_overview(
         forecast_end_date = row[3].isoformat() if row[3] else None
 
     resource_sites = await _resource_site_count(db)
+    cutoff_30d = datetime.now(timezone.utc) - timedelta(days=30)
+    total_users = int((await db.execute(select(func.count(models.User.user_id)))).scalar_one() or 0)
+    new_users_30d = int(
+        (
+            await db.execute(
+                select(func.count(models.User.user_id)).where(models.User.created_at >= cutoff_30d)
+            )
+        ).scalar_one()
+        or 0
+    )
+    feedback_count = int(
+        (await db.execute(select(func.count(models.FeedbackSubmission.id)))).scalar_one() or 0
+    )
+    analytics_row = (
+        await db.execute(
+            select(
+                func.count(ProductEvent.event_id),
+                func.count(func.distinct(ProductEvent.anonymous_id)),
+                func.count(func.distinct(ProductEvent.session_id)),
+            ).where(ProductEvent.created_at >= cutoff_30d)
+        )
+    ).one()
+
     return AdminOverview(
         total_sites=total_sites,
         latest_gfs_forecast_at=latest_cycle,
@@ -219,6 +349,350 @@ async def get_overview(
         resource_coverage_percent=(
             _coverage_percent(resource_sites, total_sites) if resource_sites is not None else None
         ),
+        total_users=total_users,
+        new_users_30d=new_users_30d,
+        feedback_count=feedback_count,
+        visitors_30d=int(analytics_row[1] or 0),
+        sessions_30d=int(analytics_row[2] or 0),
+    )
+
+
+@router.get("/users", response_model=AdminUsersResponse)
+async def list_users(
+    limit: int = Query(default=100, ge=1, le=500),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    now = datetime.now(timezone.utc)
+    cutoff_7d = now - timedelta(days=7)
+    cutoff_30d = now - timedelta(days=30)
+
+    summary_row = (
+        await db.execute(
+            select(
+                func.count(models.User.user_id),
+                func.count(models.User.user_id).filter(models.User.is_active.is_(True)),
+                func.count(models.User.user_id).filter(models.User.created_at >= cutoff_7d),
+                func.count(models.User.user_id).filter(models.User.created_at >= cutoff_30d),
+            )
+        )
+    ).one()
+    users_with_favorites = int(
+        (
+            await db.execute(select(func.count(func.distinct(models.UserFavorite.user_id))))
+        ).scalar_one()
+        or 0
+    )
+    users_with_notifications = int(
+        (
+            await db.execute(select(func.count(func.distinct(models.UserNotification.user_id))))
+        ).scalar_one()
+        or 0
+    )
+    users_with_push = int(
+        (
+            await db.execute(
+                select(func.count(func.distinct(models.PushSubscription.user_id))).where(
+                    models.PushSubscription.is_active.is_(True)
+                )
+            )
+        ).scalar_one()
+        or 0
+    )
+
+    favorite_counts = (
+        select(
+            models.UserFavorite.user_id.label("user_id"),
+            func.count().label("favorite_count"),
+        )
+        .group_by(models.UserFavorite.user_id)
+        .subquery()
+    )
+    notification_counts = (
+        select(
+            models.UserNotification.user_id.label("user_id"),
+            func.count().label("notification_count"),
+        )
+        .group_by(models.UserNotification.user_id)
+        .subquery()
+    )
+    push_counts = (
+        select(
+            models.PushSubscription.user_id.label("user_id"),
+            func.count().label("push_count"),
+        )
+        .where(models.PushSubscription.is_active.is_(True))
+        .group_by(models.PushSubscription.user_id)
+        .subquery()
+    )
+
+    result = await db.execute(
+        select(
+            models.User,
+            models.UserProfile.display_name,
+            func.coalesce(favorite_counts.c.favorite_count, 0),
+            func.coalesce(notification_counts.c.notification_count, 0),
+            func.coalesce(push_counts.c.push_count, 0),
+        )
+        .outerjoin(models.UserProfile, models.UserProfile.user_id == models.User.user_id)
+        .outerjoin(favorite_counts, favorite_counts.c.user_id == models.User.user_id)
+        .outerjoin(notification_counts, notification_counts.c.user_id == models.User.user_id)
+        .outerjoin(push_counts, push_counts.c.user_id == models.User.user_id)
+        .order_by(models.User.created_at.desc())
+        .limit(limit)
+    )
+
+    items = [
+        AdminUserRow(
+            user_id=user.user_id,
+            email=user.email,
+            display_name=display_name,
+            is_active=user.is_active,
+            role=effective_role(email=user.email, role=user.role),
+            created_at=user.created_at,
+            favorite_count=int(favorite_count or 0),
+            notification_count=int(notification_count or 0),
+            active_push_subscriptions=int(push_count or 0),
+        )
+        for user, display_name, favorite_count, notification_count, push_count in result.all()
+    ]
+
+    return AdminUsersResponse(
+        total_users=int(summary_row[0] or 0),
+        active_users=int(summary_row[1] or 0),
+        new_users_7d=int(summary_row[2] or 0),
+        new_users_30d=int(summary_row[3] or 0),
+        users_with_favorites=users_with_favorites,
+        users_with_notifications=users_with_notifications,
+        users_with_push=users_with_push,
+        items=items,
+    )
+
+
+@router.get("/feedback", response_model=AdminFeedbackResponse)
+async def list_feedback(
+    limit: int = Query(default=100, ge=1, le=500),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    total = int(
+        (await db.execute(select(func.count(models.FeedbackSubmission.id)))).scalar_one() or 0
+    )
+    result = await db.execute(
+        select(
+            models.FeedbackSubmission,
+            models.User.email,
+            models.UserProfile.display_name,
+        )
+        .outerjoin(models.User, models.User.user_id == models.FeedbackSubmission.user_id)
+        .outerjoin(models.UserProfile, models.UserProfile.user_id == models.FeedbackSubmission.user_id)
+        .order_by(models.FeedbackSubmission.created_at.desc())
+        .limit(limit)
+    )
+    return AdminFeedbackResponse(
+        total=total,
+        items=[
+            AdminFeedbackRow(
+                id=feedback.id,
+                message=feedback.message,
+                user_id=feedback.user_id,
+                user_email=email,
+                display_name=display_name,
+                created_at=feedback.created_at,
+            )
+            for feedback, email, display_name in result.all()
+        ],
+    )
+
+
+@router.get("/analytics", response_model=AdminAnalyticsResponse)
+async def get_analytics(
+    days: int = Query(default=30, ge=1, le=365),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    summary = (
+        await db.execute(
+            select(
+                func.count(ProductEvent.event_id),
+                func.count(func.distinct(ProductEvent.anonymous_id)),
+                func.count(func.distinct(ProductEvent.session_id)),
+            ).where(ProductEvent.created_at >= cutoff)
+        )
+    ).one()
+
+    daily_result = await db.execute(
+        text(
+            """
+            SELECT
+                date_trunc('day', created_at)::date AS day,
+                COUNT(DISTINCT anonymous_id) AS visitors,
+                COUNT(DISTINCT session_id) AS sessions,
+                COUNT(*) AS events
+            FROM product_events
+            WHERE created_at >= :cutoff
+            GROUP BY 1
+            ORDER BY 1
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    daily = [
+        AnalyticsDailyPoint(
+            day=row["day"].isoformat(),
+            visitors=int(row["visitors"] or 0),
+            sessions=int(row["sessions"] or 0),
+            events=int(row["events"] or 0),
+        )
+        for row in daily_result.mappings().all()
+    ]
+
+    event_result = await db.execute(
+        text(
+            """
+            SELECT
+                event_name,
+                COUNT(*) AS events,
+                COUNT(DISTINCT anonymous_id) AS visitors
+            FROM product_events
+            WHERE created_at >= :cutoff
+            GROUP BY event_name
+            ORDER BY events DESC, event_name
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    event_counts = [AnalyticsEventCount(**dict(row)) for row in event_result.mappings().all()]
+
+    path_result = await db.execute(
+        text(
+            """
+            SELECT
+                COALESCE(NULLIF(path, ''), '(unknown)') AS path,
+                COUNT(*) AS events,
+                COUNT(DISTINCT anonymous_id) AS visitors
+            FROM product_events
+            WHERE created_at >= :cutoff
+            GROUP BY 1
+            ORDER BY events DESC, path
+            LIMIT 20
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    top_paths = [AnalyticsPathCount(**dict(row)) for row in path_result.mappings().all()]
+
+    engagement_row = (
+        await db.execute(
+            text(
+                """
+                SELECT
+                    COUNT(DISTINCT session_id) FILTER (
+                        WHERE event_name = 'page_view' AND path = '/'
+                    ) AS map_sessions,
+                    COUNT(DISTINCT session_id) FILTER (
+                        WHERE event_name = 'site_detail_viewed'
+                    ) AS site_detail_sessions,
+                    COUNT(DISTINCT session_id) FILTER (
+                        WHERE event_name = 'trip_plan_submitted'
+                    ) AS submitted_sessions,
+                    COUNT(DISTINCT session_id) FILTER (
+                        WHERE event_name = 'trip_plan_results_viewed'
+                    ) AS results_sessions,
+                    COUNT(DISTINCT session_id) FILTER (
+                        WHERE event_name = 'trip_plan_site_opened'
+                    ) AS opened_site_sessions
+                FROM product_events
+                WHERE created_at >= :cutoff
+                """
+            ),
+            {"cutoff": cutoff},
+        )
+    ).mappings().one()
+    map_sessions = int(engagement_row["map_sessions"] or 0)
+    site_detail_sessions = int(engagement_row["site_detail_sessions"] or 0)
+    submitted_sessions = int(engagement_row["submitted_sessions"] or 0)
+    results_sessions = int(engagement_row["results_sessions"] or 0)
+    opened_site_sessions = int(engagement_row["opened_site_sessions"] or 0)
+
+    feedback_result = await db.execute(
+        text(
+            """
+            SELECT
+                COALESCE(NULLIF(properties ->> 'surface', ''), '(unknown)') AS surface,
+                COUNT(*) FILTER (WHERE properties ->> 'rating' = 'helpful') AS helpful,
+                COUNT(*) FILTER (WHERE properties ->> 'rating' = 'not_helpful') AS not_helpful,
+                COUNT(*) AS total
+            FROM product_events
+            WHERE created_at >= :cutoff
+              AND event_name = 'recommendation_feedback_submitted'
+            GROUP BY 1
+            ORDER BY total DESC, surface
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    recommendation_feedback = []
+    for row in feedback_result.mappings().all():
+        helpful = int(row["helpful"] or 0)
+        total = int(row["total"] or 0)
+        recommendation_feedback.append(
+            AnalyticsFeedbackSurface(
+                surface=row["surface"],
+                helpful=helpful,
+                not_helpful=int(row["not_helpful"] or 0),
+                total=total,
+                helpful_rate=_rate(helpful, total) if total else None,
+            )
+        )
+
+    top_sites_result = await db.execute(
+        text(
+            """
+            SELECT
+                NULLIF(e.properties ->> 'site_id', '')::integer AS site_id,
+                MAX(s.name) AS site_name,
+                COUNT(*) AS interactions,
+                COUNT(DISTINCT e.anonymous_id) AS visitors
+            FROM product_events e
+            LEFT JOIN sites s
+              ON s.site_id = NULLIF(e.properties ->> 'site_id', '')::integer
+            WHERE e.created_at >= :cutoff
+              AND e.event_name IN ('site_detail_viewed', 'trip_plan_site_opened')
+              AND NULLIF(e.properties ->> 'site_id', '') IS NOT NULL
+            GROUP BY 1
+            ORDER BY interactions DESC, site_id
+            LIMIT 15
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    top_sites = [
+        AnalyticsSiteInteraction(**dict(row)) for row in top_sites_result.mappings().all()
+    ]
+
+    return AdminAnalyticsResponse(
+        window_days=days,
+        total_events=int(summary[0] or 0),
+        unique_visitors=int(summary[1] or 0),
+        unique_sessions=int(summary[2] or 0),
+        map_sessions=map_sessions,
+        site_detail_sessions=site_detail_sessions,
+        map_to_site_rate=_rate(site_detail_sessions, map_sessions),
+        daily=daily,
+        event_counts=event_counts,
+        top_paths=top_paths,
+        trip_planner=AnalyticsFunnel(
+            submitted_sessions=submitted_sessions,
+            results_sessions=results_sessions,
+            opened_site_sessions=opened_site_sessions,
+            results_rate=_rate(results_sessions, submitted_sessions),
+            site_open_rate=_rate(opened_site_sessions, results_sessions),
+        ),
+        recommendation_feedback=recommendation_feedback,
+        top_sites=top_sites,
     )
 
 

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -59,6 +59,34 @@ def test_database_admin_role_is_always_accepted(monkeypatch):
     assert is_admin_identity(email="anyone@example.com", role="admin") is True
 
 
+def test_admin_rates_are_safe_and_rounded():
+    assert admin._rate(3, 4) == 75.0
+    assert admin._rate(1, 3) == 33.3
+    assert admin._rate(4, 0) == 0.0
+    assert admin._coverage_percent(249, 250) == 99.6
+
+
+def test_analytics_response_accepts_empty_period():
+    response = admin.AdminAnalyticsResponse(
+        window_days=30,
+        total_events=0,
+        unique_visitors=0,
+        unique_sessions=0,
+        map_sessions=0,
+        site_detail_sessions=0,
+        map_to_site_rate=0,
+        daily=[],
+        event_counts=[],
+        top_paths=[],
+        trip_planner=admin.AnalyticsFunnel(),
+        recommendation_feedback=[],
+        top_sites=[],
+    )
+
+    assert response.trip_planner.results_rate == 0
+    assert response.recommendation_feedback == []
+
+
 @pytest.mark.asyncio
 async def test_forecast_check_queues_existing_celery_task(monkeypatch):
     calls = []

--- a/docs/.admin-insights-pr-placeholder
+++ b/docs/.admin-insights-pr-placeholder
@@ -1,0 +1,1 @@
+This file should not exist.

--- a/docs/.admin-insights-pr-placeholder
+++ b/docs/.admin-insights-pr-placeholder
@@ -1,1 +1,0 @@
-This file should not exist.

--- a/docs/admin-dashboard.md
+++ b/docs/admin-dashboard.md
@@ -19,13 +19,16 @@ Log out and back in after changing the variable so `/auth/me` refreshes the effe
 
 ## Included workflows
 
-- **Overview** — latest GFS cycle, publication time, forecast horizon, site coverage, and Ground Crew resource coverage.
+- **Overview** — latest GFS cycle, publication time, forecast horizon, site coverage, registered-user count, 30-day anonymous visitors and written-feedback count.
+- **Product analytics** — anonymous visitors and sessions by day, map-to-site engagement, Trip Planner funnel, top events and paths, most-engaged sites, and contextual helpful/not-helpful feedback by surface.
+- **Registered users** — account growth plus adoption of favorites, notification rules and active push subscriptions, with a recent-user table.
+- **Written feedback** — authenticated feedback messages joined to the submitting account and display name.
 - **Forecast runs** — recent cycles grouped from the existing `predictions` table, including covered sites, horizon, row count, and complete/partial status.
 - **Manual forecast check** — queues the existing `app.celery_app.check_and_trigger_forecast_processing` Celery task.
 - **Site editor** — edits site coordinates, altitude, GFS point, country, information HTML, and tags.
 - **Resource inventory** — shows validated local links, webcam counts, meteostation counts, extraction time, and sites with no resources.
 
-No new database migration is required. Forecast-run state is derived from existing prediction records, while resources use the same bundled JSON or `glideator_ground_crew` SQL source as the public site-resource endpoint.
+No new database migration is required. Analytics are read from the existing `product_events` table, feedback from `feedback_submissions`, and user adoption from existing account, favorite, notification and push-subscription tables. Anonymous analytics remain separate from registered accounts; the analytics event stream does not contain account IDs or email addresses.
 
 ## API
 
@@ -33,6 +36,9 @@ All endpoints require an administrator bearer token:
 
 ```text
 GET   /admin/overview
+GET   /admin/analytics?days=30
+GET   /admin/users
+GET   /admin/feedback
 GET   /admin/forecast-runs
 POST  /admin/forecast/check
 GET   /admin/sites

--- a/frontend/src/adminApi.js
+++ b/frontend/src/adminApi.js
@@ -5,6 +5,21 @@ export const fetchAdminOverview = async () => {
   return response.data;
 };
 
+export const fetchAdminUsers = async (limit = 100) => {
+  const response = await apiClient.get('/admin/users', { params: { limit } });
+  return response.data;
+};
+
+export const fetchAdminFeedback = async (limit = 100) => {
+  const response = await apiClient.get('/admin/feedback', { params: { limit } });
+  return response.data;
+};
+
+export const fetchAdminAnalytics = async (days = 30) => {
+  const response = await apiClient.get('/admin/analytics', { params: { days } });
+  return response.data;
+};
+
 export const fetchAdminForecastRuns = async (limit = 20) => {
   const response = await apiClient.get('/admin/forecast-runs', { params: { limit } });
   return response.data;

--- a/frontend/src/components/admin/AdminInsightPanels.jsx
+++ b/frontend/src/components/admin/AdminInsightPanels.jsx
@@ -1,0 +1,506 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import {
+  fetchAdminAnalytics,
+  fetchAdminFeedback,
+  fetchAdminUsers,
+} from '../../adminApi';
+
+const formatDateTime = (value) => {
+  if (!value) return '—';
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+};
+
+const InsightCard = ({ label, value, detail }) => (
+  <Card variant="outlined" sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="overline" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h4" sx={{ mt: 0.5, fontWeight: 700 }}>
+        {value}
+      </Typography>
+      {detail && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {detail}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const SectionTitle = ({ children, detail }) => (
+  <Box sx={{ mb: 1.5 }}>
+    <Typography variant="h6" sx={{ fontWeight: 700 }}>{children}</Typography>
+    {detail && <Typography variant="body2" color="text.secondary">{detail}</Typography>}
+  </Box>
+);
+
+const ActivityBars = ({ daily }) => {
+  const maxVisitors = useMemo(
+    () => Math.max(1, ...(daily || []).map((point) => point.visitors)),
+    [daily],
+  );
+
+  if (!daily?.length) {
+    return <Typography color="text.secondary">No activity in this period.</Typography>;
+  }
+
+  return (
+    <Stack spacing={1}>
+      {daily.map((point) => (
+        <Stack key={point.day} direction="row" spacing={1.5} alignItems="center">
+          <Typography variant="caption" sx={{ width: 78, flexShrink: 0 }}>
+            {point.day.slice(5)}
+          </Typography>
+          <Box sx={{ flexGrow: 1, height: 10, backgroundColor: 'action.hover', borderRadius: 1 }}>
+            <Box
+              sx={{
+                width: `${Math.max(3, 100 * point.visitors / maxVisitors)}%`,
+                height: '100%',
+                backgroundColor: 'primary.main',
+                borderRadius: 1,
+              }}
+            />
+          </Box>
+          <Typography variant="caption" sx={{ width: 110, textAlign: 'right', flexShrink: 0 }}>
+            {point.visitors} visitors · {point.sessions} sessions
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+};
+
+export const AdminAnalyticsPanel = () => {
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setData(await fetchAdminAnalytics(days));
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load product analytics.');
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={1.5}
+      >
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700 }}>Product analytics</Typography>
+          <Typography variant="body2" color="text.secondary">
+            First-party anonymous visitors, sessions and meaningful product actions.
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={1}>
+          <TextField
+            select
+            size="small"
+            label="Period"
+            value={days}
+            onChange={(event) => setDays(Number(event.target.value))}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value={7}>7 days</MenuItem>
+            <MenuItem value={30}>30 days</MenuItem>
+            <MenuItem value={90}>90 days</MenuItem>
+            <MenuItem value={365}>1 year</MenuItem>
+          </TextField>
+          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={load} disabled={loading}>
+            Refresh
+          </Button>
+        </Stack>
+      </Stack>
+
+      {loading && <LinearProgress />}
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {data && (
+        <>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Anonymous visitors" value={data.unique_visitors} detail={`${data.window_days}-day window`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Sessions" value={data.unique_sessions} detail={`${data.total_events.toLocaleString()} captured events`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Map → site" value={`${data.map_to_site_rate}%`} detail={`${data.site_detail_sessions} of ${data.map_sessions} map sessions`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard
+                label="Planner → results"
+                value={`${data.trip_planner.results_rate}%`}
+                detail={`${data.trip_planner.results_sessions} of ${data.trip_planner.submitted_sessions} sessions`}
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} lg={7}>
+              <Paper variant="outlined" sx={{ p: 2.5, height: '100%' }}>
+                <SectionTitle detail="Distinct anonymous visitors and sessions by day">Daily activity</SectionTitle>
+                <ActivityBars daily={data.daily} />
+              </Paper>
+            </Grid>
+            <Grid item xs={12} lg={5}>
+              <Paper variant="outlined" sx={{ p: 2.5, height: '100%' }}>
+                <SectionTitle detail="Distinct sessions reaching each stage">Trip Planner funnel</SectionTitle>
+                <Stack spacing={1.5}>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography>Submitted criteria</Typography>
+                    <Typography fontWeight={700}>{data.trip_planner.submitted_sessions}</Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography>Viewed results</Typography>
+                    <Typography fontWeight={700}>
+                      {data.trip_planner.results_sessions} ({data.trip_planner.results_rate}%)
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography>Opened a suggested site</Typography>
+                    <Typography fontWeight={700}>
+                      {data.trip_planner.opened_site_sessions} ({data.trip_planner.site_open_rate}%)
+                    </Typography>
+                  </Stack>
+                </Stack>
+              </Paper>
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="What visitors actually do">Top events</SectionTitle>
+                <TableContainer sx={{ maxHeight: 360 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Event</TableCell>
+                        <TableCell align="right">Events</TableCell>
+                        <TableCell align="right">Visitors</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.event_counts.map((row) => (
+                        <TableRow key={row.event_name} hover>
+                          <TableCell>{row.event_name}</TableCell>
+                          <TableCell align="right">{row.events}</TableCell>
+                          <TableCell align="right">{row.visitors}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="Site-detail and planner-result interactions">Most engaged sites</SectionTitle>
+                <TableContainer sx={{ maxHeight: 360 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Site</TableCell>
+                        <TableCell align="right">Interactions</TableCell>
+                        <TableCell align="right">Visitors</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.top_sites.map((row) => (
+                        <TableRow key={row.site_id || row.site_name} hover>
+                          <TableCell>{row.site_name || `Site ${row.site_id}`}</TableCell>
+                          <TableCell align="right">{row.interactions}</TableCell>
+                          <TableCell align="right">{row.visitors}</TableCell>
+                        </TableRow>
+                      ))}
+                      {data.top_sites.length === 0 && (
+                        <TableRow><TableCell colSpan={3}>No site interactions yet.</TableCell></TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="Contextual helpful / not-helpful responses">Recommendation feedback</SectionTitle>
+                <TableContainer>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Surface</TableCell>
+                        <TableCell align="right">Helpful</TableCell>
+                        <TableCell align="right">Not helpful</TableCell>
+                        <TableCell align="right">Rate</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.recommendation_feedback.map((row) => (
+                        <TableRow key={row.surface} hover>
+                          <TableCell>{row.surface}</TableCell>
+                          <TableCell align="right">{row.helpful}</TableCell>
+                          <TableCell align="right">{row.not_helpful}</TableCell>
+                          <TableCell align="right">{row.helpful_rate == null ? '—' : `${row.helpful_rate}%`}</TableCell>
+                        </TableRow>
+                      ))}
+                      {data.recommendation_feedback.length === 0 && (
+                        <TableRow><TableCell colSpan={4}>No contextual feedback yet.</TableCell></TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="Routes receiving the most captured activity">Top paths</SectionTitle>
+                <TableContainer sx={{ maxHeight: 320 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Path</TableCell>
+                        <TableCell align="right">Events</TableCell>
+                        <TableCell align="right">Visitors</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.top_paths.map((row) => (
+                        <TableRow key={row.path} hover>
+                          <TableCell>{row.path}</TableCell>
+                          <TableCell align="right">{row.events}</TableCell>
+                          <TableCell align="right">{row.visitors}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+          </Grid>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export const AdminUsersPanel = () => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setData(await fetchAdminUsers(250));
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load registered users.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Stack spacing={3}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700 }}>Registered users</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Account growth and adoption of favorites, notifications and push delivery.
+          </Typography>
+        </Box>
+        <Button variant="outlined" startIcon={<RefreshIcon />} onClick={load} disabled={loading}>
+          Refresh
+        </Button>
+      </Stack>
+      {loading && <LinearProgress />}
+      {error && <Alert severity="error">{error}</Alert>}
+      {data && (
+        <>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Registered" value={data.total_users} detail={`${data.active_users} active accounts`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="New users" value={data.new_users_30d} detail={`${data.new_users_7d} in the last 7 days`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Using favorites" value={data.users_with_favorites} detail={`${data.total_users ? Math.round(100 * data.users_with_favorites / data.total_users) : 0}% adoption`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Using alerts" value={data.users_with_notifications} detail={`${data.users_with_push} with active push`} />
+            </Grid>
+          </Grid>
+
+          <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: '65vh' }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell>User</TableCell>
+                  <TableCell>Registered</TableCell>
+                  <TableCell>Status</TableCell>
+                  <TableCell align="right">Favorites</TableCell>
+                  <TableCell align="right">Alerts</TableCell>
+                  <TableCell align="right">Push subscriptions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.items.map((user) => (
+                  <TableRow key={user.user_id} hover>
+                    <TableCell>
+                      <Stack spacing={0.25}>
+                        <Typography variant="body2">{user.display_name || user.email}</Typography>
+                        {user.display_name && <Typography variant="caption" color="text.secondary">{user.email}</Typography>}
+                      </Stack>
+                    </TableCell>
+                    <TableCell>{formatDateTime(user.created_at)}</TableCell>
+                    <TableCell>
+                      <Stack direction="row" spacing={0.5}>
+                        <Chip size="small" label={user.is_active ? 'active' : 'inactive'} color={user.is_active ? 'success' : 'default'} />
+                        {user.role === 'admin' && <Chip size="small" label="admin" color="primary" />}
+                      </Stack>
+                    </TableCell>
+                    <TableCell align="right">{user.favorite_count}</TableCell>
+                    <TableCell align="right">{user.notification_count}</TableCell>
+                    <TableCell align="right">{user.active_push_subscriptions}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export const AdminFeedbackPanel = () => {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setData(await fetchAdminFeedback(250));
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load feedback.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Stack spacing={3}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700 }}>Written feedback</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Messages submitted through the authenticated feedback form.
+          </Typography>
+        </Box>
+        <Button variant="outlined" startIcon={<RefreshIcon />} onClick={load} disabled={loading}>
+          Refresh
+        </Button>
+      </Stack>
+      {loading && <LinearProgress />}
+      {error && <Alert severity="error">{error}</Alert>}
+      {data && (
+        <>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Submissions" value={data.total} detail={`Showing latest ${data.items.length}`} />
+            </Grid>
+          </Grid>
+          <TableContainer component={Paper} variant="outlined" sx={{ maxHeight: '65vh' }}>
+            <Table size="small" stickyHeader>
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ width: 170 }}>Submitted</TableCell>
+                  <TableCell sx={{ width: 240 }}>User</TableCell>
+                  <TableCell>Message</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.items.map((feedback) => (
+                  <TableRow key={feedback.id} hover>
+                    <TableCell>{formatDateTime(feedback.created_at)}</TableCell>
+                    <TableCell>
+                      <Stack spacing={0.25}>
+                        <Typography variant="body2">{feedback.display_name || feedback.user_email || 'Deleted user'}</Typography>
+                        {feedback.display_name && feedback.user_email && (
+                          <Typography variant="caption" color="text.secondary">{feedback.user_email}</Typography>
+                        )}
+                      </Stack>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-wrap' }}>
+                        {feedback.message}
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {data.items.length === 0 && (
+                  <TableRow><TableCell colSpan={3} align="center">No written feedback yet.</TableCell></TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Stack>
+  );
+};

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -46,6 +46,11 @@ import {
   triggerAdminForecastCheck,
   updateAdminSite,
 } from '../adminApi';
+import {
+  AdminAnalyticsPanel,
+  AdminFeedbackPanel,
+  AdminUsersPanel,
+} from '../components/admin/AdminInsightPanels';
 
 const formatDateTime = (value) => {
   if (!value) return '—';
@@ -127,7 +132,7 @@ const Admin = () => {
   }, [loadPrimaryData]);
 
   useEffect(() => {
-    if (tab === 3) {
+    if (tab === 6) {
       loadResources();
     }
   }, [tab, loadResources]);
@@ -135,7 +140,7 @@ const Admin = () => {
   const handleRefresh = async () => {
     setNotice('');
     await loadPrimaryData();
-    if (tab === 3) {
+    if (tab === 6) {
       await loadResources();
     }
   };
@@ -215,7 +220,7 @@ const Admin = () => {
             </Typography>
           </Stack>
           <Typography color="text.secondary" sx={{ mt: 0.5 }}>
-            Forecast operations, site data and Ground Crew resources.
+            Product insight, user feedback, forecasts, site data and Ground Crew resources.
           </Typography>
         </Box>
         <Stack direction="row" spacing={1}>
@@ -250,6 +255,9 @@ const Admin = () => {
           sx={{ px: 1, borderBottom: 1, borderColor: 'divider' }}
         >
           <Tab label="Overview" />
+          <Tab label="Analytics" />
+          <Tab label="Users" />
+          <Tab label="Feedback" />
           <Tab label="Forecast runs" />
           <Tab label="Sites" />
           <Tab label="Resources" />
@@ -275,6 +283,20 @@ const Admin = () => {
                 </Grid>
                 <Grid item xs={12} sm={6} lg={3}>
                   <MetricCard
+                    label="Registered users"
+                    value={overview.total_users}
+                    detail={`${overview.new_users_30d} joined in 30 days`}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} lg={3}>
+                  <MetricCard
+                    label="Anonymous visitors"
+                    value={overview.visitors_30d}
+                    detail={`${overview.sessions_30d} sessions in 30 days`}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} lg={3}>
+                  <MetricCard
                     label="Forecast horizon"
                     value={overview.forecast_start_date || '—'}
                     detail={overview.forecast_end_date ? `through ${overview.forecast_end_date}` : null}
@@ -287,6 +309,13 @@ const Admin = () => {
                     detail={overview.resource_coverage_percent == null
                       ? 'Ground Crew data unavailable'
                       : `${overview.resource_coverage_percent}% coverage`}
+                  />
+                </Grid>
+                <Grid item xs={12} sm={6} lg={3}>
+                  <MetricCard
+                    label="Written feedback"
+                    value={overview.feedback_count}
+                    detail="Authenticated submissions"
                   />
                 </Grid>
               </Grid>
@@ -302,7 +331,11 @@ const Admin = () => {
             </Stack>
           )}
 
-          {tab === 1 && (
+          {tab === 1 && <AdminAnalyticsPanel />}
+          {tab === 2 && <AdminUsersPanel />}
+          {tab === 3 && <AdminFeedbackPanel />}
+
+          {tab === 4 && (
             <TableContainer>
               <Table size="small">
                 <TableHead>
@@ -344,7 +377,7 @@ const Admin = () => {
             </TableContainer>
           )}
 
-          {tab === 2 && (
+          {tab === 5 && (
             <TableContainer sx={{ maxHeight: '65vh' }}>
               <Table stickyHeader size="small">
                 <TableHead>
@@ -394,7 +427,7 @@ const Admin = () => {
             </TableContainer>
           )}
 
-          {tab === 3 && (
+          {tab === 6 && (
             <Stack spacing={2}>
               <FormControlLabel
                 control={(


### PR DESCRIPTION
## What changed

- extends the administrator overview with registered users, 30-day anonymous visitors/sessions, and written-feedback counts
- adds a product analytics tab with daily visitors, sessions, map-to-site engagement, Trip Planner funnel, top events and paths, most-engaged sites, and contextual helpfulness by surface
- adds a registered-users tab with account growth and adoption of favorites, alerts, and active push subscriptions
- adds a written-feedback tab joined to the submitting account and display name
- adds admin-only API endpoints for users, feedback, and aggregated analytics
- documents that anonymous analytics remain separate from registered account data

## Data and privacy

The analytics views aggregate the existing `product_events` table. They continue to use anonymous browser/session IDs and do not attempt to identify or join analytics visitors to registered accounts. User and feedback views are sourced separately from existing authenticated account tables.

## Validation

GitHub CI will run backend tests and coverage, frontend tests/build, and Playwright smoke tests.
