### PR TITLE
Fix public logo URLs after Vite migration

### DIFF
--- a/frontend/src/pages/Details.test.jsx
+++ b/frontend/src/pages/Details.test.jsx
@@ -139,6 +139,7 @@ describe('Details data loading', () => {
     const queryClient = renderDetails();
 
     expect(await screen.findByRole('heading', { name: 'Raná' })).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Glideator' })).toHaveAttribute('src', '/logo192.png');
     expect(fetchSitePredictions).toHaveBeenCalledTimes(1);
     expect(fetchSiteInfo).toHaveBeenCalledTimes(1);
     expect(fetchSiteForecast).not.toHaveBeenCalled();

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -17,6 +17,7 @@ export default defineConfig(({ mode, isSsrBuild }) => {
     envPrefix: ['VITE_', 'REACT_APP_'],
     define: {
       'process.env.NODE_ENV': JSON.stringify(mode === 'production' ? 'production' : 'development'),
+      'process.env.PUBLIC_URL': JSON.stringify(readFirst(env, 'VITE_PUBLIC_URL', 'PUBLIC_URL')),
       'process.env.REACT_APP_API_BASE_URL': JSON.stringify(
         readFirst(env, 'VITE_API_BASE_URL', 'REACT_APP_API_BASE_URL'),
       ),


### PR DESCRIPTION
## What changed

- define CRA-compatible `process.env.PUBLIC_URL` in Vite
- default it to the site root while allowing `VITE_PUBLIC_URL` or `PUBLIC_URL` overrides
- add a Details-page regression assertion for the Glideator logo URL

## Why

Several pages still construct image paths with `process.env.PUBLIC_URL`. CRA injected that value automatically, but Vite did not, producing paths such as `undefined/logo192.png` after PR #89.

## Validation

GitHub CI will run the Vitest suite, client and SSR builds, backend tests, and Playwright smoke tests.