### PR TITLE
Expose complete site planning context in SSR

### DIFF
--- a/docs/frontend-ssr.md
+++ b/docs/frontend-ssr.md
@@ -7,12 +7,27 @@ The frontend uses Vite for both the browser bundle and the Node SSR bundle. The 
 Public routes contain useful HTML before JavaScript executes. In particular:
 
 - `/` contains a semantic, screen-reader-only equivalent of the forecast map with normal links to site pages.
-- `/details/:siteId` contains the site heading and a semantic forecast table with dates, XC probabilities, forecast timestamps, site coordinates, and the decision-support caveat.
+- `/details/:siteId` contains the site heading, seven-day forecast probabilities, seasonality, takeoff and landing information, validated local resources, selected-day weather drivers, and similar historical weather days.
 - `/about` is rendered from the existing React page.
 
-The hidden tables are accessibility alternatives to visual maps and charts. They contain the same data and are not selected by user agent.
+The semantic tables and lists are accessibility alternatives to visual maps, charts and collapsed panels. They contain the same planning information and are not selected by user agent.
 
 Only the public information routes above use SSR. Trip Planner, login, registration, profile, favorites, notifications, feedback, and admin receive the client application shell and follow the existing client-side rendering path.
+
+## Site-detail data strategy
+
+A server-rendered site-detail request prefetches the public planning data in parallel and dehydrates it into the normal TanStack Query cache:
+
+- predictions and optional site information;
+- monthly flight statistics;
+- takeoff and landing spots;
+- validated resources, webcams and meteostations;
+- the selected date's 09:00, 12:00 and 15:00 weather forecast;
+- similar historical weather days for the selected date.
+
+The semantic planning component reads those prefetched query keys with disabled queries. This is deliberate: hydration receives the complete SSR markup, while a normal client-side visit does not restore the eager requests removed by the frontend data-loading refactor. Interactive tabs continue to fetch their data only when opened and reuse any SSR cache entries already present.
+
+Optional enrichment failures do not turn a valid forecast site into an error page. Only a missing predictions site produces an HTTP 404.
 
 ## Discovery contract
 
@@ -77,7 +92,8 @@ Rollback is performed by deploying an earlier Render build or reverting the migr
 The Playwright crawler tests disable JavaScript and verify that:
 
 - the homepage exposes a ranked comparison of Raná and Kozákov with normal links to their detail pages;
-- `/details/1` exposes Raná forecast probabilities and timestamps;
+- `/details/1` exposes Raná forecast probabilities and forecast timestamps;
+- site HTML also exposes monthly seasonality, takeoffs and landings, validated links, weather drivers and similar historical days;
 - the two normal detail pages can be compared using XC0;
 - site metadata is canonical and contains structured place data;
 - `robots.txt` advertises the canonical sitemap;
@@ -85,4 +101,4 @@ The Playwright crawler tests disable JavaScript and verify that:
 - representative AI-search user agents receive the same public HTML;
 - none of these flows request MCP.
 
-The JavaScript-enabled Playwright smoke tests run against the hydrated application to guard the normal human experience.
+A focused unit test also verifies that the planning component renders from prefetched cache data without starting browser requests. The JavaScript-enabled Playwright smoke tests continue to guard the normal human experience.

--- a/frontend/e2e/crawler.spec.js
+++ b/frontend/e2e/crawler.spec.js
@@ -60,6 +60,32 @@ test('site forecast is answerable from normal HTML without MCP', async ({ page }
   expect(requestedPaths.some(isMcpPath)).toBe(false);
 });
 
+test('site HTML exposes seasonality, spots, resources, weather drivers and analog days', async ({ page }) => {
+  const response = await page.goto(`/details/1?date=${today}&metric=XC0`);
+  expect(response.status()).toBe(200);
+
+  const context = page.locator('section[aria-label="Raná planning context"]');
+  await expect(context).toHaveCount(1);
+
+  const seasonality = page.locator('table[aria-label="Raná monthly XC0 seasonality"]');
+  await expect(seasonality).toHaveCount(1);
+  expect(await seasonality.textContent()).toContain('April');
+  expect(await seasonality.textContent()).toContain('5.4 days');
+
+  expect(await context.textContent()).toContain('South launch');
+  expect(await context.textContent()).toContain('Main landing');
+  await expect(context.locator('a[href="https://example.com/local-club"]')).toHaveCount(1);
+
+  const weatherDrivers = page.locator(`table[aria-label="Raná weather drivers for ${today}"]`);
+  await expect(weatherDrivers).toHaveCount(1);
+  expect(await weatherDrivers.textContent()).toContain('12:00');
+  expect(await weatherDrivers.textContent()).toContain('4.0 m/s');
+
+  expect(await context.textContent()).toContain('2025-07-15');
+  const xcontestLink = context.getByRole('link', { name: 'View flights near Raná on XContest' }).first();
+  await expect(xcontestLink).toHaveAttribute('href', /2025-07-15/);
+});
+
 test('two sites can be compared from their normal HTML pages', async ({ page }) => {
   const requestedPaths = [];
   page.on('request', (request) => {
@@ -82,11 +108,11 @@ test('crawler-facing metadata uses canonical URLs and structured place data', as
   const response = await page.goto(`/details/1?date=${today}&metric=XC0`);
   expect(response.status()).toBe(200);
 
-  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+  await expect(page.locator('link[rel="canonical"]').last()).toHaveAttribute(
     'href',
     `${baseUrl}/details/1`,
   );
-  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+  await expect(page.locator('meta[property="og:url"]').last()).toHaveAttribute(
     'content',
     `${baseUrl}/details/1`,
   );

--- a/frontend/e2e/ssr-test-server.js
+++ b/frontend/e2e/ssr-test-server.js
@@ -53,10 +53,39 @@ const sites = {
   }),
 };
 
+const flightStats = {
+  0: [0.2, 0.5, 2.1, 5.4, 8.2, 9.1, 8.7, 7.9, 5.8, 2.6, 0.7, 0.2],
+  10: [0.1, 0.2, 1.1, 3.2, 5.4, 6.2, 5.9, 5.1, 3.4, 1.2, 0.2, 0.1],
+  20: [0, 0.1, 0.5, 1.8, 3.7, 4.5, 4.2, 3.6, 2.1, 0.6, 0.1, 0],
+  30: [], 40: [], 50: [], 60: [], 70: [], 80: [], 90: [], 100: [],
+};
+
+const makeForecastValues = (hour) => ({
+  temperature_2m_c: 15 + hour / 6,
+  dewpoint_2m_c: 8 + hour / 12,
+  wind_speed_10m_ms: 3 + hour / 12,
+  wind_direction_10m_dgr: 220 + hour,
+  wind_gust_sfc_ms: 6 + hour / 10,
+  pressure_sfc_pa: 101200 - hour * 10,
+  geopotential_height_sfc_m: 430,
+  geopotential_height_iso_m: [3000, 2500, 2000, 1500, 1000, 500],
+  temperature_iso_c: [-5, -1, 3, 7, 11, 14],
+  dewpoint_iso_c: [-12, -8, -2, 2, 5, 8],
+  wind_speed_iso_ms: [12, 10, 8, 6, 5, 4],
+  wind_direction_iso_dgr: [240, 235, 230, 225, 220, 215],
+  relative_humidity_iso_pct: [40, 45, 50, 55, 60, 65],
+  hpa_lvls: [700, 750, 800, 850, 900, 950],
+});
+
 const backend = http.createServer((request, response) => {
   const url = new URL(request.url, `http://127.0.0.1:${backendPort}`);
   const predictionMatch = url.pathname.match(/^\/sites\/(\d+)\/predictions$/);
   const infoMatch = url.pathname.match(/^\/sites\/(\d+)\/info$/);
+  const statsMatch = url.pathname.match(/^\/sites\/(\d+)\/flight_stats$/);
+  const spotsMatch = url.pathname.match(/^\/sites\/(\d+)\/spots$/);
+  const resourcesMatch = url.pathname.match(/^\/sites\/(\d+)\/resources$/);
+  const forecastMatch = url.pathname.match(/^\/sites\/(\d+)\/forecast$/);
+  const similarDaysMatch = url.pathname.match(/^\/d2d\/similar-days\/(\d+)\/(\d{4}-\d{2}-\d{2})$/);
 
   if (request.method === 'GET' && url.pathname === '/sites/') {
     json(response, 200, Object.values(sites));
@@ -74,7 +103,85 @@ const backend = http.createServer((request, response) => {
       site_id: matchedSite.site_id,
       site_name: matchedSite.name,
       country: 'Czechia',
-      overview: `${matchedSite.name} test overview.`,
+      html: `<p>${matchedSite.name} test overview.</p>`,
+    });
+    return;
+  }
+
+  if (request.method === 'GET' && statsMatch && sites[statsMatch[1]]) {
+    json(response, 200, flightStats);
+    return;
+  }
+
+  if (request.method === 'GET' && spotsMatch && sites[spotsMatch[1]]) {
+    json(response, 200, [
+      {
+        spot_id: Number(spotsMatch[1]) * 10 + 1,
+        site_id: Number(spotsMatch[1]),
+        name: 'South launch',
+        latitude: sites[spotsMatch[1]].latitude,
+        longitude: sites[spotsMatch[1]].longitude,
+        altitude: sites[spotsMatch[1]].altitude,
+        type: 'takeoff',
+        wind_direction: 'S-SW',
+      },
+      {
+        spot_id: Number(spotsMatch[1]) * 10 + 2,
+        site_id: Number(spotsMatch[1]),
+        name: 'Main landing',
+        latitude: sites[spotsMatch[1]].latitude - 0.01,
+        longitude: sites[spotsMatch[1]].longitude + 0.01,
+        altitude: sites[spotsMatch[1]].altitude - 120,
+        type: 'landing',
+        wind_direction: null,
+      },
+    ]);
+    return;
+  }
+
+  if (request.method === 'GET' && resourcesMatch && sites[resourcesMatch[1]]) {
+    json(response, 200, {
+      site_id: Number(resourcesMatch[1]),
+      source_run_id: 42,
+      run_extracted_at: '2026-07-31T18:00:00Z',
+      local_resources: [
+        {
+          candidate_id: 101,
+          name: `${sites[resourcesMatch[1]].name} flying club`,
+          url: 'https://example.com/local-club',
+          host: 'example.com',
+          rules: true,
+          access: true,
+        },
+      ],
+      webcam_urls: ['https://example.com/webcam'],
+      meteostation_urls: ['https://example.com/meteo'],
+    });
+    return;
+  }
+
+  if (request.method === 'GET' && forecastMatch && sites[forecastMatch[1]]) {
+    json(response, 200, {
+      date: url.searchParams.get('query_date') || dates[0],
+      computed_at: '2026-08-01T09:30:00Z',
+      gfs_forecast_at: '2026-08-01T06:00:00Z',
+      lat_gfs: sites[forecastMatch[1]].latitude,
+      lon_gfs: sites[forecastMatch[1]].longitude,
+      forecast_9: makeForecastValues(9),
+      forecast_12: makeForecastValues(12),
+      forecast_15: makeForecastValues(15),
+    });
+    return;
+  }
+
+  if (request.method === 'GET' && similarDaysMatch && sites[similarDaysMatch[1]]) {
+    json(response, 200, {
+      site_id: Number(similarDaysMatch[1]),
+      forecast_date: similarDaysMatch[2],
+      similar_days: [
+        { past_date: '2025-07-15', similarity: 0.91 },
+        { past_date: '2024-08-03', similarity: 0.84 },
+      ],
     });
     return;
   }

--- a/frontend/src/components/AccessibleSitePlanningContext.jsx
+++ b/frontend/src/components/AccessibleSitePlanningContext.jsx
@@ -1,0 +1,268 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Box } from '@mui/material';
+
+import {
+  fetchFlightStats,
+  fetchSimilarDays,
+  fetchSiteForecast,
+  fetchSiteResources,
+  fetchSiteSpots,
+} from '../api';
+
+const MONTHS = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+const SCREEN_READER_ONLY = {
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
+
+const formatNumber = (value, digits = 1) => (
+  Number.isFinite(value) ? Number(value).toFixed(digits) : 'Not available'
+);
+
+const formatPercentage = (value) => (
+  Number.isFinite(value) ? `${Math.round(Number(value) * 100)}%` : 'Not available'
+);
+
+const resourceLinks = (resources) => {
+  const candidates = [
+    ...(resources?.local_resources || []).map((resource) => ({
+      url: resource.url,
+      label: resource.name || resource.host || resource.url,
+      type: 'Local resource',
+    })),
+    ...(resources?.webcam_urls || []).map((url) => ({ url, label: url, type: 'Webcam' })),
+    ...(resources?.meteostation_urls || []).map((url) => ({ url, label: url, type: 'Meteostation' })),
+  ];
+
+  const seen = new Set();
+  return candidates.filter(({ url }) => {
+    if (!url || seen.has(url)) return false;
+    seen.add(url);
+    return true;
+  });
+};
+
+const AccessibleSitePlanningContext = ({
+  siteId,
+  site,
+  siteName,
+  selectedDate,
+  selectedMetric = 'XC0',
+}) => {
+  const numericSiteId = Number(siteId);
+
+  // These disabled queries read SSR-prefetched cache data without restoring the
+  // eager browser requests that the interactive tabs intentionally avoid.
+  const flightStatsQuery = useQuery({
+    queryKey: ['site', numericSiteId, 'flight-stats'],
+    queryFn: () => fetchFlightStats(siteId),
+    enabled: false,
+  });
+  const spotsQuery = useQuery({
+    queryKey: ['site', numericSiteId, 'spots'],
+    queryFn: () => fetchSiteSpots(siteId),
+    enabled: false,
+  });
+  const resourcesQuery = useQuery({
+    queryKey: ['site', numericSiteId, 'resources'],
+    queryFn: () => fetchSiteResources(siteId),
+    enabled: false,
+  });
+  const forecastQuery = useQuery({
+    queryKey: ['site', numericSiteId, 'forecast', selectedDate],
+    queryFn: () => fetchSiteForecast(siteId, selectedDate),
+    enabled: false,
+  });
+  const similarDaysQuery = useQuery({
+    queryKey: ['site', numericSiteId, 'similar-days', selectedDate],
+    queryFn: () => fetchSimilarDays(siteId, selectedDate, 3),
+    enabled: false,
+  });
+
+  const threshold = Number(selectedMetric.replace('XC', '')) || 0;
+  const monthlyValues = flightStatsQuery.data?.[threshold]
+    || flightStatsQuery.data?.[String(threshold)]
+    || [];
+  const spots = spotsQuery.data || [];
+  const takeoffs = spots.filter((spot) => spot.type?.toLowerCase() === 'takeoff');
+  const landings = spots.filter((spot) => spot.type?.toLowerCase() === 'landing');
+  const links = resourceLinks(resourcesQuery.data);
+  const forecast = forecastQuery.data;
+  const similarDays = similarDaysQuery.data?.similar_days || [];
+  const displayName = siteName || site?.name || `Site ${siteId}`;
+
+  const hasContent = monthlyValues.length || spots.length || links.length || forecast || similarDays.length;
+  if (!hasContent) return null;
+
+  const xcontestLink = (pastDate) => (
+    `https://www.xcontest.org/world/cs/vyhledavani-preletu/` +
+    `?list[sort]=pts&filter[point]=${site.longitude}+${site.latitude}` +
+    `&filter[radius]=5000&filter[date]=${pastDate}`
+  );
+
+  return (
+    <Box
+      component="section"
+      sx={SCREEN_READER_ONLY}
+      aria-label={`${displayName} planning context`}
+    >
+      <h2>{displayName} planning context</h2>
+      <p>
+        The following tables and links are semantic alternatives to the interactive season chart,
+        site map, resource tabs, atmospheric profile and similar-days panels.
+      </p>
+
+      {monthlyValues.length > 0 && (
+        <section aria-labelledby={`seasonality-${siteId}`}>
+          <h3 id={`seasonality-${siteId}`}>{selectedMetric} monthly seasonality</h3>
+          <table aria-label={`${displayName} monthly ${selectedMetric} seasonality`}>
+            <caption>
+              Average number of days per month with recorded flights exceeding the {selectedMetric} threshold
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Month</th>
+                <th scope="col">Average qualifying days</th>
+              </tr>
+            </thead>
+            <tbody>
+              {monthlyValues.map((value, index) => (
+                <tr key={MONTHS[index] || index}>
+                  <th scope="row">{MONTHS[index] || `Month ${index + 1}`}</th>
+                  <td>{formatNumber(value)} days</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {spots.length > 0 && (
+        <section aria-labelledby={`spots-${siteId}`}>
+          <h3 id={`spots-${siteId}`}>{displayName} takeoff and landing spots</h3>
+          {takeoffs.length > 0 && (
+            <>
+              <h4>Takeoffs</h4>
+              <ul>
+                {takeoffs.map((spot) => (
+                  <li key={spot.spot_id}>
+                    {spot.name}: {spot.latitude}, {spot.longitude}; altitude {spot.altitude} m
+                    {spot.wind_direction ? `; suitable wind ${spot.wind_direction}` : ''}.
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          {landings.length > 0 && (
+            <>
+              <h4>Landings</h4>
+              <ul>
+                {landings.map((spot) => (
+                  <li key={spot.spot_id}>
+                    {spot.name}: {spot.latitude}, {spot.longitude}; altitude {spot.altitude} m.
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </section>
+      )}
+
+      {links.length > 0 && (
+        <section aria-labelledby={`resources-${siteId}`}>
+          <h3 id={`resources-${siteId}`}>Validated local resources</h3>
+          <ul>
+            {links.map((resource) => (
+              <li key={resource.url}>
+                {resource.type}: <a href={resource.url}>{resource.label}</a>
+              </li>
+            ))}
+          </ul>
+          {resourcesQuery.data?.run_extracted_at && (
+            <p>Resource extraction updated: {resourcesQuery.data.run_extracted_at}.</p>
+          )}
+        </section>
+      )}
+
+      {forecast && selectedDate && (
+        <section aria-labelledby={`weather-${siteId}-${selectedDate}`}>
+          <h3 id={`weather-${siteId}-${selectedDate}`}>
+            Selected-day weather drivers for {selectedDate}
+          </h3>
+          <p>
+            Forecast computed {forecast.computed_at || 'at an unspecified time'} from GFS cycle{' '}
+            {forecast.gfs_forecast_at || 'not provided'}.
+          </p>
+          <table aria-label={`${displayName} weather drivers for ${selectedDate}`}>
+            <caption>Surface forecast values behind the atmospheric profile</caption>
+            <thead>
+              <tr>
+                <th scope="col">Time</th>
+                <th scope="col">Temperature</th>
+                <th scope="col">Dew point</th>
+                <th scope="col">10 m wind</th>
+                <th scope="col">Gust</th>
+                <th scope="col">Pressure</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[9, 12, 15].map((hour) => {
+                const values = forecast[`forecast_${hour}`] || {};
+                return (
+                  <tr key={hour}>
+                    <th scope="row">{hour}:00</th>
+                    <td>{formatNumber(values.temperature_2m_c)} °C</td>
+                    <td>{formatNumber(values.dewpoint_2m_c)} °C</td>
+                    <td>
+                      {formatNumber(values.wind_speed_10m_ms)} m/s at{' '}
+                      {formatNumber(values.wind_direction_10m_dgr, 0)}°
+                    </td>
+                    <td>{formatNumber(values.wind_gust_sfc_ms)} m/s</td>
+                    <td>
+                      {Number.isFinite(values.pressure_sfc_pa)
+                        ? `${Math.round(values.pressure_sfc_pa / 100)} hPa`
+                        : 'Not available'}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </section>
+      )}
+
+      {similarDays.length > 0 && site && selectedDate && (
+        <section aria-labelledby={`similar-${siteId}-${selectedDate}`}>
+          <h3 id={`similar-${siteId}-${selectedDate}`}>Similar historical weather days</h3>
+          <ul>
+            {similarDays.map((day) => (
+              <li key={day.past_date}>
+                {day.past_date}, similarity {formatPercentage(day.similarity)}.{' '}
+                <a href={xcontestLink(day.past_date)}>View flights near {displayName} on XContest</a>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <p>
+        This information supports planning and historical comparison. It is not a safety guarantee;
+        verify current conditions, airspace and local rules before flying.
+      </p>
+    </Box>
+  );
+};
+
+export default AccessibleSitePlanningContext;

--- a/frontend/src/components/AccessibleSitePlanningContext.test.jsx
+++ b/frontend/src/components/AccessibleSitePlanningContext.test.jsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { vi } from 'vitest';
+
+import {
+  fetchFlightStats,
+  fetchSimilarDays,
+  fetchSiteForecast,
+  fetchSiteResources,
+  fetchSiteSpots,
+} from '../api';
+import AccessibleSitePlanningContext from './AccessibleSitePlanningContext';
+
+vi.mock('../api', () => ({
+  fetchFlightStats: vi.fn(),
+  fetchSimilarDays: vi.fn(),
+  fetchSiteForecast: vi.fn(),
+  fetchSiteResources: vi.fn(),
+  fetchSiteSpots: vi.fn(),
+}));
+
+const site = {
+  site_id: 1,
+  name: 'Raná',
+  latitude: 50.403,
+  longitude: 13.764,
+  altitude: 457,
+};
+
+const selectedDate = '2026-08-02';
+
+const renderFromCache = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+    },
+  });
+
+  queryClient.setQueryData(['site', 1, 'flight-stats'], {
+    0: [0.2, 0.5, 2.1, 5.4],
+  });
+  queryClient.setQueryData(['site', 1, 'spots'], [
+    {
+      spot_id: 11,
+      name: 'South launch',
+      latitude: 50.403,
+      longitude: 13.764,
+      altitude: 457,
+      type: 'takeoff',
+      wind_direction: 'S-SW',
+    },
+    {
+      spot_id: 12,
+      name: 'Main landing',
+      latitude: 50.393,
+      longitude: 13.774,
+      altitude: 337,
+      type: 'landing',
+    },
+  ]);
+  queryClient.setQueryData(['site', 1, 'resources'], {
+    run_extracted_at: '2026-08-01T12:00:00Z',
+    local_resources: [
+      {
+        candidate_id: 101,
+        name: 'Raná flying club',
+        url: 'https://example.com/club',
+      },
+    ],
+    webcam_urls: ['https://example.com/webcam'],
+    meteostation_urls: [],
+  });
+  queryClient.setQueryData(['site', 1, 'forecast', selectedDate], {
+    computed_at: '2026-08-01T09:30:00Z',
+    gfs_forecast_at: '2026-08-01T06:00:00Z',
+    forecast_9: {
+      temperature_2m_c: 16,
+      dewpoint_2m_c: 8,
+      wind_speed_10m_ms: 3.5,
+      wind_direction_10m_dgr: 220,
+      wind_gust_sfc_ms: 6.2,
+      pressure_sfc_pa: 101200,
+    },
+    forecast_12: {
+      temperature_2m_c: 19,
+      dewpoint_2m_c: 9,
+      wind_speed_10m_ms: 4,
+      wind_direction_10m_dgr: 230,
+      wind_gust_sfc_ms: 7.1,
+      pressure_sfc_pa: 101100,
+    },
+    forecast_15: {},
+  });
+  queryClient.setQueryData(['site', 1, 'similar-days', selectedDate], {
+    similar_days: [{ past_date: '2025-07-15', similarity: 0.91 }],
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AccessibleSitePlanningContext
+        siteId="1"
+        site={site}
+        siteName="Raná"
+        selectedDate={selectedDate}
+        selectedMetric="XC0"
+      />
+    </QueryClientProvider>,
+  );
+
+  return queryClient;
+};
+
+describe('AccessibleSitePlanningContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the SSR-prefetched planning context without starting browser requests', () => {
+    const queryClient = renderFromCache();
+
+    const context = screen.getByRole('region', { name: 'Raná planning context' });
+    const seasonality = within(context).getByRole('table', {
+      name: 'Raná monthly XC0 seasonality',
+    });
+    expect(within(seasonality).getByText('April')).toBeInTheDocument();
+    expect(within(seasonality).getByText('5.4 days')).toBeInTheDocument();
+
+    expect(within(context).getByText(/South launch/)).toHaveTextContent('suitable wind S-SW');
+    expect(within(context).getByText(/Main landing/)).toBeInTheDocument();
+    expect(within(context).getByRole('link', { name: 'Raná flying club' })).toHaveAttribute(
+      'href',
+      'https://example.com/club',
+    );
+
+    const weather = within(context).getByRole('table', {
+      name: `Raná weather drivers for ${selectedDate}`,
+    });
+    expect(within(weather).getByText('4.0 m/s at 230°')).toBeInTheDocument();
+    expect(within(context).getByText(/2025-07-15, similarity 91%/)).toBeInTheDocument();
+
+    expect(fetchFlightStats).not.toHaveBeenCalled();
+    expect(fetchSiteSpots).not.toHaveBeenCalled();
+    expect(fetchSiteResources).not.toHaveBeenCalled();
+    expect(fetchSiteForecast).not.toHaveBeenCalled();
+    expect(fetchSimilarDays).not.toHaveBeenCalled();
+
+    queryClient.clear();
+  });
+});

--- a/frontend/src/entry-server.jsx
+++ b/frontend/src/entry-server.jsx
@@ -9,7 +9,16 @@ import {
 } from '@tanstack/react-query';
 import { HelmetProvider } from 'react-helmet-async';
 
-import api, { fetchSiteInfo, fetchSitePredictions, fetchSites } from './api';
+import api, {
+  fetchFlightStats,
+  fetchSimilarDays,
+  fetchSiteForecast,
+  fetchSiteInfo,
+  fetchSitePredictions,
+  fetchSiteResources,
+  fetchSiteSpots,
+  fetchSites,
+} from './api';
 import { AppContent, AppProviders } from './App.jsx';
 import { createQueryClient } from './queryClient';
 
@@ -109,7 +118,8 @@ const prefetchPageData = async (url, queryClient) => {
 
   const siteId = detailMatch[1];
   const numericSiteId = Number(siteId);
-  const [predictionsResult] = await Promise.allSettled([
+  const selectedDate = url.searchParams.get('date');
+  const tasks = [
     queryClient.fetchQuery({
       queryKey: ['site', numericSiteId, 'predictions'],
       queryFn: () => fetchSitePredictions(siteId),
@@ -125,7 +135,34 @@ const prefetchPageData = async (url, queryClient) => {
         }
       },
     }),
-  ]);
+    queryClient.prefetchQuery({
+      queryKey: ['site', numericSiteId, 'flight-stats'],
+      queryFn: () => fetchFlightStats(siteId),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ['site', numericSiteId, 'spots'],
+      queryFn: () => fetchSiteSpots(siteId),
+    }),
+    queryClient.prefetchQuery({
+      queryKey: ['site', numericSiteId, 'resources'],
+      queryFn: () => fetchSiteResources(siteId),
+    }),
+  ];
+
+  if (selectedDate) {
+    tasks.push(
+      queryClient.prefetchQuery({
+        queryKey: ['site', numericSiteId, 'forecast', selectedDate],
+        queryFn: () => fetchSiteForecast(siteId, selectedDate),
+      }),
+      queryClient.prefetchQuery({
+        queryKey: ['site', numericSiteId, 'similar-days', selectedDate],
+        queryFn: () => fetchSimilarDays(siteId, selectedDate, 3),
+      }),
+    );
+  }
+
+  const [predictionsResult] = await Promise.allSettled(tasks);
 
   if (predictionsResult.status === 'rejected' && isNotFoundError(predictionsResult.reason)) {
     return 404;

--- a/frontend/src/pages/DetailsRoute.jsx
+++ b/frontend/src/pages/DetailsRoute.jsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { trackEvent } from '../analytics';
 import { fetchSiteInfo, fetchSitePredictions } from '../api';
 import AccessibleSiteForecast from '../components/AccessibleSiteForecast';
+import AccessibleSitePlanningContext from '../components/AccessibleSitePlanningContext';
 import LoadingSpinner from '../components/LoadingSpinner';
 import QuickFeedback from '../components/QuickFeedback';
 import SiteMetadata from '../components/SiteMetadata';
@@ -130,10 +131,18 @@ const DetailsRoute = () => {
   }
 
   const site = predictionsQuery.data[0];
+  const displayName = siteInfoQuery.data?.site_name || site.name;
 
   return (
     <>
       <AccessibleSiteForecast siteId={siteId} selectedDate={date} />
+      <AccessibleSitePlanningContext
+        siteId={siteId}
+        site={site}
+        siteName={displayName}
+        selectedDate={date}
+        selectedMetric={metric}
+      />
       <Details />
       <SiteMetadata siteId={siteId} site={site} siteInfo={siteInfoQuery.data} />
       {tab === 'forecast' && date && (

--- a/frontend/src/pages/DetailsRoute.test.jsx
+++ b/frontend/src/pages/DetailsRoute.test.jsx
@@ -14,6 +14,7 @@ vi.mock('../api', () => ({
 
 vi.mock('../analytics', () => ({ trackEvent: vi.fn() }));
 vi.mock('../components/AccessibleSiteForecast', () => ({ default: () => null }));
+vi.mock('../components/AccessibleSitePlanningContext', () => ({ default: () => null }));
 vi.mock('../components/QuickFeedback', () => ({ default: () => null }));
 vi.mock('../components/SiteMetadata', () => ({ default: () => null }));
 vi.mock('./Details', () => ({ default: () => <div>Rendered site details</div> }));


### PR DESCRIPTION
## What changed

- add a semantic site-planning section to server-rendered detail pages
- expose monthly seasonality for the selected XC metric
- expose takeoff and landing coordinates, altitude, and launch wind direction
- expose validated local resources, webcams, and meteostations as ordinary links
- expose selected-day 09:00, 12:00, and 15:00 surface weather drivers and forecast provenance
- expose similar historical weather days with direct XContest links
- prefetch the corresponding existing public endpoints during site-detail SSR
- extend the deterministic no-JavaScript crawler test backend and acceptance tests
- add a unit test proving the component reads prefetched cache data without starting browser requests

## Why

After the initial SSR work, generic agents could read and compare forecast probabilities but still saw only a small part of the site-detail product. Seasonality, launches, landings, local resources, atmospheric drivers, and analog days remained behind JavaScript-driven tabs and panels. This PR makes the normal site page represent the full public planning surface.

## Performance and browser behavior

The semantic component uses disabled TanStack Query observers. During SSR it reads data prefetched into the request-scoped cache and hydrates identical markup in the browser. A normal client-side navigation does not eagerly fetch these datasets; the interactive tabs retain their existing on-demand loading behavior and reuse any SSR cache entries already available.

Optional enrichment failures are nonfatal. A valid forecast site still renders even when seasonality, resources, spots, detailed weather, or analog days are unavailable.

## Validation

CI run #91 is green:

- focused cache-only component test
- frontend tests and production build
- backend tests
- JavaScript-enabled Playwright smoke tests
- JavaScript-disabled tests for seasonality, spots, resources, weather drivers, analog days, discovery metadata, status codes, and representative AI-search user agents

PRs #91 and #92 have merged. This PR now targets `main` directly.