### PR TITLE
Fix atmospheric profile on first expansion

### DIFF
--- a/frontend/e2e/playwright.config.js
+++ b/frontend/e2e/playwright.config.js
@@ -2,7 +2,7 @@ const { defineConfig, devices } = require('@playwright/test');
 
 module.exports = defineConfig({
   testDir: '.',
-  testMatch: ['smoke.spec.js', 'crawler.spec.js'],
+  testMatch: ['smoke*.spec.js', 'crawler.spec.js'],
   timeout: 30_000,
   expect: {
     timeout: 7_000,

--- a/frontend/e2e/smoke.atmospheric-profile.spec.js
+++ b/frontend/e2e/smoke.atmospheric-profile.spec.js
@@ -1,0 +1,46 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({
+  viewport: { width: 390, height: 844 },
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('disclaimerAccepted', 'true');
+  });
+});
+
+test('atmospheric profile has full height on its first expansion', async ({ page }) => {
+  await page.route('**/api/sites/1/forecast**', async (route) => {
+    // Keep the loading state visible while the MUI Collapse measures its first expansion.
+    // The regression only appeared when the chart replaced that shorter content.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const response = await route.fetch();
+    await route.fulfill({ response });
+  });
+
+  await page.goto('/?lat=50.4&lng=13.8&zoom=8');
+
+  const marker = page.locator('.glowing-marker').first();
+  await expect(marker).toBeVisible();
+  await marker.click({ force: true });
+  await page.getByRole('button', { name: 'View Details' }).click();
+
+  await expect(page).toHaveURL(/\/details\/1/);
+  await expect(page.getByRole('heading', { name: 'Raná', level: 1 })).toBeVisible();
+
+  await page.getByRole('button', { name: /see what's driving this/i }).click();
+
+  const chart = page.locator('svg[aria-label="Atmospheric profile"]');
+  await expect(chart).toBeVisible();
+
+  await expect.poll(async () => {
+    const box = await chart.boundingBox();
+    return box?.height || 0;
+  }).toBeGreaterThan(250);
+
+  const box = await chart.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.width / box.height).toBeGreaterThan(0.95);
+  expect(box.width / box.height).toBeLessThan(1.05);
+});

--- a/frontend/src/components/D3Forecast.jsx
+++ b/frontend/src/components/D3Forecast.jsx
@@ -519,10 +519,8 @@ const D3Forecast = ({ forecast, selectedHour, date, gfs_forecast_at, computed_at
       ref={containerRef}
       style={{
         width: 'min(100%, 1000px, calc(100vh - 300px))',
-        height: 'auto',
         aspectRatio: '1 / 1',
         maxWidth: '100%',
-        maxHeight: '100%',
         margin: '0 auto',
         position: 'relative',
         overflow: 'hidden',


### PR DESCRIPTION
## What changed

- let the atmospheric chart's width and aspect ratio establish its square height
- remove the percentage `max-height` that could resolve against the temporary loading height of the animated collapse
- add a mobile Playwright regression that cold-loads the forecast during the first expansion and verifies the SVG is a full-sized square

## Why

After the macOS overflow fix, the chart container combined `aspect-ratio` with `max-height: 100%`. When the detailed forecast was fetched lazily inside the MUI collapse, that percentage could resolve against the collapse's short loading-state height. The chart then rendered as a thin strip until the panel was closed and reopened.

## Validation

CI run #94 is green:

- frontend tests and production client/SSR builds
- backend tests and coverage gate
- Playwright smoke suite, including the new first-expansion mobile regression