### PR TITLE
Prevent async forecast panel clipping

### DIFF
--- a/frontend/e2e/smoke.atmospheric-profile.spec.js
+++ b/frontend/e2e/smoke.atmospheric-profile.spec.js
@@ -10,10 +10,10 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
-test('atmospheric profile has full height on its first expansion', async ({ page }) => {
+test('atmospheric profile is not clipped on its first expansion', async ({ page }) => {
   await page.route('**/api/sites/1/forecast**', async (route) => {
-    // Keep the loading state visible while the MUI Collapse measures its first expansion.
-    // The regression only appeared when the chart replaced that shorter content.
+    // Reproduce the production sequence: the details panel opens with a short
+    // loading state, then asynchronously receives the much taller chart.
     await new Promise((resolve) => setTimeout(resolve, 200));
     const response = await route.fetch();
     await route.fulfill({ response });
@@ -31,7 +31,9 @@ test('atmospheric profile has full height on its first expansion', async ({ page
 
   await page.getByRole('button', { name: /see what's driving this/i }).click();
 
+  const panel = page.getByTestId('weather-details-panel');
   const chart = page.locator('svg[aria-label="Atmospheric profile"]');
+  await expect(panel).toBeVisible();
   await expect(chart).toBeVisible();
 
   await expect.poll(async () => {
@@ -39,8 +41,18 @@ test('atmospheric profile has full height on its first expansion', async ({ page
     return box?.height || 0;
   }).toBeGreaterThan(250);
 
-  const box = await chart.boundingBox();
-  expect(box).not.toBeNull();
-  expect(box.width / box.height).toBeGreaterThan(0.95);
-  expect(box.width / box.height).toBeLessThan(1.05);
+  const similarDaysHeading = page.getByText('Similar Days in the Past', { exact: true }).last();
+  await expect(similarDaysHeading).toBeVisible();
+
+  await expect.poll(async () => {
+    const chartBox = await chart.boundingBox();
+    const headingBox = await similarDaysHeading.boundingBox();
+    if (!chartBox || !headingBox) return -1;
+    return headingBox.y - (chartBox.y + chartBox.height);
+  }).toBeGreaterThan(20);
+
+  const chartBox = await chart.boundingBox();
+  expect(chartBox).not.toBeNull();
+  expect(chartBox.width / chartBox.height).toBeGreaterThan(0.95);
+  expect(chartBox.width / chartBox.height).toBeLessThan(1.05);
 });

--- a/frontend/src/pages/Details.jsx
+++ b/frontend/src/pages/Details.jsx
@@ -5,7 +5,7 @@ import {
   Box,
   Button,
   ButtonGroup,
-  Collapse,
+  Fade,
   IconButton,
   Link,
   Paper,
@@ -222,9 +222,8 @@ const Details = () => {
 
         <Box sx={{
           width: '100%',
-          aspectRatio: '1/1',
-          maxHeight: 'calc(100vh - 300px)',
-          maxWidth: '1000px',
+          display: 'flex',
+          justifyContent: 'center',
           position: 'relative',
         }}>
           <D3Forecast
@@ -542,9 +541,11 @@ const Details = () => {
               </Button>
             </Box>
 
-            <Collapse in={showWeatherDetails} timeout="auto">
-              <Box sx={{ mt: 2, pt: 1 }}>{renderForecastContent()}</Box>
-            </Collapse>
+            <Fade in={showWeatherDetails} timeout={200} unmountOnExit>
+              <Box data-testid="weather-details-panel" sx={{ mt: 2, pt: 1 }}>
+                {renderForecastContent()}
+              </Box>
+            </Fade>
 
             {selectedDate && (
               <SimilarDaysPanel


### PR DESCRIPTION
## What changed

- replace the height-animating MUI `Collapse` around the lazily loaded forecast with a `Fade`
- let `D3Forecast` be the sole owner of the chart's square dimensions instead of nesting it inside a second aspect-ratio box
- strengthen the mobile Playwright regression to verify that Similar Days is laid out below the chart, not merely that the SVG has a large intrinsic bounding box

## Why the previous fix was insufficient

PR #94 corrected the SVG container dimensions, but the parent `Collapse` could still retain the height measured from the short loading state and clip the correctly sized chart. The previous test only measured the SVG itself, so it passed even when an ancestor showed only a thin strip.

This change removes the height-clipping transition entirely while retaining a short opacity transition.

## Validation

CI run #96 is green:

- frontend tests and production client/SSR builds
- backend tests and coverage gate
- Playwright smoke suite, including the strengthened mobile clipping regression