### PR TITLE
Fix mobile drawer close controls

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -11,3 +11,8 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* Temporary drawers must remain above app bars so their close controls and backdrop stay interactive. */
+.MuiDrawer-root.MuiModal-root {
+  z-index: 1202 !important;
+}


### PR DESCRIPTION
## What changed

- raises temporary MUI drawers above the application header and footer
- scopes the override to modal-backed drawers, leaving persistent drawers unaffected

## Why

The layout sets both app bars to `theme.zIndex.drawer + 1`. The mobile navigation drawer kept MUI's default drawer layer, so the app header covered the drawer header and its close button. On narrow screens, the remaining backdrop was also difficult to tap.

## User impact

The sidebar close button and backdrop are interactive again, including when opening the Admin cockpit from mobile navigation.

## Validation

- verified the change on the branch and confirmed the selector only targets temporary drawers (`.MuiDrawer-root.MuiModal-root`)
- frontend CI should run the normal tests and build for this PR
