### PR TITLE
Fix first admin drawer close

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -29,6 +29,12 @@ export const RouteFallback = () => (
   </Box>
 );
 
+const LazyRoute = ({ children }) => (
+  <Suspense fallback={<RouteFallback />}>
+    {children}
+  </Suspense>
+);
+
 export const AppProviders = ({ children }) => (
   <AuthProvider>
     <NotificationProvider>{children}</NotificationProvider>
@@ -42,9 +48,25 @@ export const AppRoutes = () => (
     <Route path="/register" element={<Register />} />
     <Route path="/" element={<Layout />}>
       <Route index element={<Home />} />
-      <Route path="trip-planner" element={<TripPlannerPage />} />
+      <Route
+        path="trip-planner"
+        element={(
+          <LazyRoute>
+            <TripPlannerPage />
+          </LazyRoute>
+        )}
+      />
       <Route path="about" element={<About />} />
-      <Route path="admin" element={<RequireAdmin><Admin /></RequireAdmin>} />
+      <Route
+        path="admin"
+        element={(
+          <RequireAdmin>
+            <LazyRoute>
+              <Admin />
+            </LazyRoute>
+          </RequireAdmin>
+        )}
+      />
       <Route path="feedback" element={<RequireAuth><Feedback /></RequireAuth>} />
       <Route path="details/:siteId" element={<DetailsRoute />} />
       <Route path="profile" element={<RequireAuth><Profile /></RequireAuth>} />
@@ -58,9 +80,7 @@ export const AppRoutes = () => (
 export const AppContent = () => (
   <>
     <AnalyticsRouteTracker />
-    <Suspense fallback={<RouteFallback />}>
-      <AppRoutes />
-    </Suspense>
+    <AppRoutes />
   </>
 );
 


### PR DESCRIPTION
## What changed

- moves Suspense boundaries from around the entire route tree to the individual lazy routes
- keeps the shared `Layout` mounted while the Admin cockpit or Trip Planner chunk loads for the first time

## Root cause

`Admin` is loaded with `React.lazy`. On the first navigation to `/admin`, the outer Suspense boundary replaced the complete `AppRoutes` subtree, including the mobile drawer layout. This interrupted the drawer close transition. Once the Admin chunk was cached, later navigations no longer suspended, which explains why closing worked from the second visit onward.

## User impact

The mobile sidebar can close normally during the first-ever navigation to the Admin cockpit, while the cockpit content shows its loading fallback inside the existing layout.

## Validation

- reviewed the route structure and confirmed both lazy pages now have local loading boundaries
- the normal frontend tests and build should run in CI
