### PR TITLE
Add shareable site forecast links

### DIFF
--- a/frontend/e2e/smoke-share.spec.js
+++ b/frontend/e2e/smoke-share.spec.js
@@ -31,7 +31,11 @@ test('copies a clean dated forecast URL that restores the shared state', async (
   await expect(page).toHaveTitle(/Raná: 52% for XC20/);
   await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
     'content',
-    `http://127.0.0.1:4173/details/1?date=${date}&metric=XC20`,
+    'http://127.0.0.1:4173/details/1',
+  );
+  await expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+    'content',
+    /52% probability for XC20 activity at Raná/,
   );
 
   await page.getByRole('button', { name: 'Share forecast for Raná' }).click();

--- a/frontend/e2e/smoke-share.spec.js
+++ b/frontend/e2e/smoke-share.spec.js
@@ -29,11 +29,11 @@ test('copies a clean dated forecast URL that restores the shared state', async (
 
   await expect(page.getByRole('heading', { name: 'Raná', level: 1 })).toBeVisible();
   await expect(page).toHaveTitle(/Raná: 52% for XC20/);
-  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+  await expect(page.locator('meta[property="og:url"]').last()).toHaveAttribute(
     'content',
     'http://127.0.0.1:4173/details/1',
   );
-  await expect(page.locator('meta[property="og:description"]')).toHaveAttribute(
+  await expect(page.locator('meta[property="og:description"]').last()).toHaveAttribute(
     'content',
     /52% probability for XC20 activity at Raná/,
   );

--- a/frontend/e2e/smoke-share.spec.js
+++ b/frontend/e2e/smoke-share.spec.js
@@ -1,0 +1,47 @@
+const { test, expect } = require('@playwright/test');
+
+const todayUtc = () => new Date().toISOString().slice(0, 10);
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('disclaimerAccepted', 'true');
+    window.__copiedForecastLink = null;
+
+    Object.defineProperty(window.navigator, 'share', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window.navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (value) => {
+          window.__copiedForecastLink = value;
+        },
+      },
+    });
+  });
+});
+
+test('copies a clean dated forecast URL that restores the shared state', async ({ page }) => {
+  const date = todayUtc();
+
+  await page.goto(`/details/1?date=${date}&metric=XC20&campaign=pilot`);
+
+  await expect(page.getByRole('heading', { name: 'Raná', level: 1 })).toBeVisible();
+  await expect(page).toHaveTitle(/Raná: 52% for XC20/);
+  await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+    'content',
+    `http://127.0.0.1:4173/details/1?date=${date}&metric=XC20`,
+  );
+
+  await page.getByRole('button', { name: 'Share forecast for Raná' }).click();
+  await expect(page.getByText('Forecast link copied')).toBeVisible();
+
+  const copiedUrl = await page.evaluate(() => window.__copiedForecastLink);
+  expect(copiedUrl).toBe(`http://127.0.0.1:4173/details/1?date=${date}&metric=XC20`);
+
+  await page.goto(copiedUrl);
+  await expect(page).toHaveURL(new RegExp(`/details/1\\?date=${date}&metric=XC20(?:&tab=forecast)?$`));
+  await expect(page).toHaveTitle(/Raná: 52% for XC20/);
+  await expect(page.getByRole('button', { name: 'Share forecast for Raná' })).toBeVisible();
+});

--- a/frontend/src/components/ShareForecastButton.jsx
+++ b/frontend/src/components/ShareForecastButton.jsx
@@ -1,0 +1,164 @@
+import React, { useMemo, useState } from 'react';
+import { Alert, Fab, Snackbar } from '@mui/material';
+import ShareIcon from '@mui/icons-material/Share';
+
+import { trackEvent } from '../analytics';
+
+const METRICS = ['XC0', 'XC10', 'XC20', 'XC30', 'XC40', 'XC50', 'XC60', 'XC70', 'XC80', 'XC90', 'XC100'];
+const CONFIGURED_PUBLIC_ORIGIN = process.env.REACT_APP_PUBLIC_ORIGIN || 'https://www.parra-glideator.com';
+
+export const buildForecastShareUrl = ({ origin, siteId, selectedDate, selectedMetric }) => {
+  const normalizedOrigin = String(origin || CONFIGURED_PUBLIC_ORIGIN).replace(/\/$/, '');
+  const params = new URLSearchParams();
+
+  if (selectedDate) params.set('date', selectedDate);
+  if (METRICS.includes(selectedMetric)) params.set('metric', selectedMetric);
+
+  const query = params.toString();
+  return `${normalizedOrigin}/details/${encodeURIComponent(siteId)}${query ? `?${query}` : ''}`;
+};
+
+export const getForecastProbability = ({ predictions, selectedDate, selectedMetric }) => {
+  const metricIndex = METRICS.indexOf(selectedMetric);
+  if (metricIndex < 0 || !selectedDate || !Array.isArray(predictions)) return null;
+
+  const prediction = predictions.find((item) => item?.date === selectedDate);
+  const value = prediction?.values?.[metricIndex];
+  return Number.isFinite(value) ? value : null;
+};
+
+const formatDate = (date) => {
+  if (!date) return 'the selected date';
+
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return date;
+
+  return new Intl.DateTimeFormat('en', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(parsed);
+};
+
+const copyText = async (text) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  if (!copied) throw new Error('Copy command failed');
+};
+
+const ShareForecastButton = ({
+  siteId,
+  siteName,
+  selectedDate,
+  selectedMetric,
+  predictions,
+}) => {
+  const [message, setMessage] = useState(null);
+  const [severity, setSeverity] = useState('success');
+
+  const probability = useMemo(() => getForecastProbability({
+    predictions,
+    selectedDate,
+    selectedMetric,
+  }), [predictions, selectedDate, selectedMetric]);
+
+  const handleShare = async () => {
+    const origin = typeof window !== 'undefined' && window.location?.origin
+      ? window.location.origin
+      : CONFIGURED_PUBLIC_ORIGIN;
+    const url = buildForecastShareUrl({
+      origin,
+      siteId,
+      selectedDate,
+      selectedMetric,
+    });
+    const percentage = probability == null ? null : Math.round(probability * 100);
+    const title = `${siteName} forecast – Parra-Glideator`;
+    const text = percentage == null
+      ? `${siteName}: Glideator forecast for ${selectedMetric} on ${formatDate(selectedDate)}. Decision support, not a safety forecast.`
+      : `${siteName}: ${percentage}% Glideator probability for ${selectedMetric} on ${formatDate(selectedDate)}. Decision support, not a safety forecast.`;
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, text, url });
+        void trackEvent('forecast_shared', {
+          site_id: Number(siteId),
+          date: selectedDate,
+          metric: selectedMetric,
+          probability,
+          method: 'native',
+        });
+        return;
+      } catch (error) {
+        if (error?.name === 'AbortError') return;
+      }
+    }
+
+    try {
+      await copyText(url);
+      setSeverity('success');
+      setMessage('Forecast link copied');
+      void trackEvent('forecast_shared', {
+        site_id: Number(siteId),
+        date: selectedDate,
+        metric: selectedMetric,
+        probability,
+        method: 'clipboard',
+      });
+    } catch {
+      setSeverity('error');
+      setMessage('Could not copy the forecast link');
+    }
+  };
+
+  return (
+    <>
+      <Fab
+        variant="extended"
+        color="primary"
+        size="medium"
+        onClick={handleShare}
+        aria-label={`Share forecast for ${siteName}`}
+        sx={(theme) => ({
+          position: 'fixed',
+          right: { xs: 16, sm: 24 },
+          bottom: { xs: 72, sm: 24 },
+          zIndex: theme.zIndex.speedDial,
+          textTransform: 'none',
+          fontWeight: 600,
+        })}
+      >
+        <ShareIcon sx={{ mr: 1 }} />
+        Share forecast
+      </Fab>
+
+      <Snackbar
+        open={Boolean(message)}
+        autoHideDuration={3500}
+        onClose={() => setMessage(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={severity} onClose={() => setMessage(null)} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default ShareForecastButton;

--- a/frontend/src/components/ShareForecastButton.test.jsx
+++ b/frontend/src/components/ShareForecastButton.test.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import ShareForecastButton, {
+  buildForecastShareUrl,
+  getForecastProbability,
+} from './ShareForecastButton';
+import { trackEvent } from '../analytics';
+
+vi.mock('../analytics', () => ({
+  trackEvent: vi.fn(() => Promise.resolve(null)),
+}));
+
+const date = '2026-08-03';
+const predictions = [{
+  date,
+  values: [0.82, 0.76, 0.7, 0.64, 0.58, 0.52, 0.46, 0.4, 0.34, 0.28, 0.22],
+}];
+
+const setNavigatorProperty = (name, value) => {
+  Object.defineProperty(window.navigator, name, {
+    configurable: true,
+    value,
+  });
+};
+
+describe('ShareForecastButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, '', `/details/1?date=${date}&metric=XC20&tab=resources`);
+  });
+
+  afterEach(() => {
+    cleanup();
+    setNavigatorProperty('share', undefined);
+    setNavigatorProperty('clipboard', undefined);
+  });
+
+  it('builds a deterministic forecast URL with only date and metric state', () => {
+    expect(buildForecastShareUrl({
+      origin: 'https://www.parra-glideator.com/',
+      siteId: 1,
+      selectedDate: date,
+      selectedMetric: 'XC20',
+    })).toBe(`https://www.parra-glideator.com/details/1?date=${date}&metric=XC20`);
+  });
+
+  it('selects the probability for the requested metric and date', () => {
+    expect(getForecastProbability({
+      predictions,
+      selectedDate: date,
+      selectedMetric: 'XC20',
+    })).toBe(0.7);
+  });
+
+  it('uses the native share sheet when available', async () => {
+    const share = vi.fn().mockResolvedValue(undefined);
+    setNavigatorProperty('share', share);
+
+    render(
+      <ShareForecastButton
+        siteId={1}
+        siteName="Raná"
+        selectedDate={date}
+        selectedMetric="XC20"
+        predictions={predictions}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share forecast for Raná' }));
+
+    await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
+    expect(share).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'Raná forecast – Parra-Glideator',
+      text: expect.stringContaining('70% Glideator probability for XC20'),
+      url: `${window.location.origin}/details/1?date=${date}&metric=XC20`,
+    }));
+    expect(trackEvent).toHaveBeenCalledWith('forecast_shared', expect.objectContaining({
+      site_id: 1,
+      date,
+      metric: 'XC20',
+      probability: 0.7,
+      method: 'native',
+    }));
+  });
+
+  it('copies the clean link when native sharing is unavailable', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setNavigatorProperty('share', undefined);
+    setNavigatorProperty('clipboard', { writeText });
+
+    render(
+      <ShareForecastButton
+        siteId={1}
+        siteName="Raná"
+        selectedDate={date}
+        selectedMetric="XC20"
+        predictions={predictions}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share forecast for Raná' }));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}/details/1?date=${date}&metric=XC20`,
+    ));
+    expect(await screen.findByText('Forecast link copied')).toBeInTheDocument();
+    expect(trackEvent).toHaveBeenCalledWith('forecast_shared', expect.objectContaining({
+      site_id: 1,
+      date,
+      metric: 'XC20',
+      probability: 0.7,
+      method: 'clipboard',
+    }));
+  });
+});

--- a/frontend/src/components/SiteMetadata.jsx
+++ b/frontend/src/components/SiteMetadata.jsx
@@ -44,16 +44,6 @@ const SiteMetadata = ({
   const validMetric = METRICS.includes(selectedMetric) ? selectedMetric : 'XC0';
   const probability = getProbability(site, selectedDate, validMetric);
   const formattedDate = formatDate(selectedDate);
-  const shareParams = new URLSearchParams();
-
-  if (selectedDate) {
-    shareParams.set('date', selectedDate);
-    shareParams.set('metric', validMetric);
-  }
-
-  const shareUrl = shareParams.size
-    ? `${canonicalUrl}?${shareParams.toString()}`
-    : canonicalUrl;
   const percentage = probability == null ? null : Math.round(probability * 100);
   const title = selectedDate
     ? `${displayName}: ${percentage == null ? validMetric : `${percentage}% for ${validMetric}`} on ${formattedDate} – Parra-Glideator`
@@ -108,7 +98,7 @@ const SiteMetadata = ({
       <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:type" content="article" />
-      <meta property="og:url" content={shareUrl} />
+      <meta property="og:url" content={canonicalUrl} />
       <meta property="og:image" content={imageUrl} />
       <meta property="og:image:alt" content="Parra-Glideator paragliding forecast" />
       <meta name="twitter:card" content="summary_large_image" />

--- a/frontend/src/components/SiteMetadata.jsx
+++ b/frontend/src/components/SiteMetadata.jsx
@@ -2,8 +2,38 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 const CONFIGURED_PUBLIC_ORIGIN = process.env.REACT_APP_PUBLIC_ORIGIN || 'https://www.parra-glideator.com';
+const METRICS = ['XC0', 'XC10', 'XC20', 'XC30', 'XC40', 'XC50', 'XC60', 'XC70', 'XC80', 'XC90', 'XC100'];
 
-const SiteMetadata = ({ siteId, site, siteInfo }) => {
+const formatDate = (date) => {
+  if (!date) return null;
+
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return date;
+
+  return new Intl.DateTimeFormat('en', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(parsed);
+};
+
+const getProbability = (site, selectedDate, selectedMetric) => {
+  const metricIndex = METRICS.indexOf(selectedMetric);
+  if (metricIndex < 0 || !selectedDate) return null;
+
+  const prediction = site?.predictions?.find((item) => item?.date === selectedDate);
+  const value = prediction?.values?.[metricIndex];
+  return Number.isFinite(value) ? value : null;
+};
+
+const SiteMetadata = ({
+  siteId,
+  site,
+  siteInfo,
+  selectedDate = null,
+  selectedMetric = 'XC0',
+}) => {
   if (!site) return null;
 
   const publicOrigin = typeof window !== 'undefined' && window.location?.origin
@@ -11,7 +41,27 @@ const SiteMetadata = ({ siteId, site, siteInfo }) => {
     : CONFIGURED_PUBLIC_ORIGIN;
   const displayName = siteInfo?.site_name || site.name || `Site ${siteId}`;
   const canonicalUrl = `${publicOrigin}/details/${siteId}`;
-  const description = `Paragliding activity forecasts, seasonality and site information for ${displayName}.`;
+  const validMetric = METRICS.includes(selectedMetric) ? selectedMetric : 'XC0';
+  const probability = getProbability(site, selectedDate, validMetric);
+  const formattedDate = formatDate(selectedDate);
+  const shareParams = new URLSearchParams();
+
+  if (selectedDate) shareParams.set('date', selectedDate);
+  if (validMetric) shareParams.set('metric', validMetric);
+
+  const shareUrl = shareParams.size
+    ? `${canonicalUrl}?${shareParams.toString()}`
+    : canonicalUrl;
+  const percentage = probability == null ? null : Math.round(probability * 100);
+  const title = selectedDate
+    ? `${displayName}: ${percentage == null ? validMetric : `${percentage}% for ${validMetric}`} on ${formattedDate} – Parra-Glideator`
+    : `${displayName} – Parra-Glideator`;
+  const description = selectedDate
+    ? percentage == null
+      ? `Glideator activity forecast for ${validMetric} at ${displayName} on ${formattedDate}. Decision support, not a safety forecast.`
+      : `Glideator estimates a ${percentage}% probability for ${validMetric} activity at ${displayName} on ${formattedDate}. Decision support, not a safety forecast.`
+    : `Paragliding activity forecasts, seasonality and site information for ${displayName}.`;
+  const imageUrl = `${publicOrigin}/logo512.png`;
   const country = siteInfo?.country || site.tags?.find((tag) => typeof tag === 'string') || undefined;
 
   const structuredData = {
@@ -50,14 +100,19 @@ const SiteMetadata = ({ siteId, site, siteInfo }) => {
 
   return (
     <Helmet>
-      <title>{`${displayName} – Parra-Glideator`}</title>
+      <title>{title}</title>
       <meta name="description" content={description} />
       <link rel="canonical" href={canonicalUrl} />
-      <meta property="og:title" content={`${displayName} – Parra-Glideator`} />
+      <meta property="og:title" content={title} />
       <meta property="og:description" content={description} />
       <meta property="og:type" content="article" />
-      <meta property="og:url" content={canonicalUrl} />
+      <meta property="og:url" content={shareUrl} />
+      <meta property="og:image" content={imageUrl} />
+      <meta property="og:image:alt" content="Parra-Glideator paragliding forecast" />
       <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={imageUrl} />
       <script type="application/ld+json">{JSON.stringify(structuredData)}</script>
     </Helmet>
   );

--- a/frontend/src/components/SiteMetadata.jsx
+++ b/frontend/src/components/SiteMetadata.jsx
@@ -46,8 +46,10 @@ const SiteMetadata = ({
   const formattedDate = formatDate(selectedDate);
   const shareParams = new URLSearchParams();
 
-  if (selectedDate) shareParams.set('date', selectedDate);
-  if (validMetric) shareParams.set('metric', validMetric);
+  if (selectedDate) {
+    shareParams.set('date', selectedDate);
+    shareParams.set('metric', validMetric);
+  }
 
   const shareUrl = shareParams.size
     ? `${canonicalUrl}?${shareParams.toString()}`

--- a/frontend/src/components/SiteMetadata.test.jsx
+++ b/frontend/src/components/SiteMetadata.test.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import SiteMetadata from './SiteMetadata';
+
+const site = {
+  site_id: 1,
+  name: 'Raná',
+  latitude: 50.4,
+  longitude: 13.8,
+  altitude: 457,
+  predictions: [{
+    date: '2026-08-03',
+    values: [0.82, 0.76, 0.7, 0.64, 0.58, 0.52, 0.46, 0.4, 0.34, 0.28, 0.22],
+  }],
+};
+
+const renderMetadata = (props = {}) => render(
+  <HelmetProvider>
+    <SiteMetadata
+      siteId="1"
+      site={site}
+      siteInfo={{ site_name: 'Raná', country: 'Czechia' }}
+      {...props}
+    />
+  </HelmetProvider>,
+);
+
+describe('SiteMetadata', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    window.history.replaceState({}, '', '/details/1');
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.head.innerHTML = '';
+  });
+
+  it('keeps the canonical URL stable while exposing selected forecast state to social previews', async () => {
+    renderMetadata({ selectedDate: '2026-08-03', selectedMetric: 'XC20' });
+
+    await waitFor(() => expect(document.title).toContain('70% for XC20'));
+
+    expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href'))
+      .toBe(`${window.location.origin}/details/1`);
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content'))
+      .toBe(`${window.location.origin}/details/1?date=2026-08-03&metric=XC20`);
+    expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content'))
+      .toContain('70% probability for XC20 activity at Raná');
+    expect(document.querySelector('meta[property="og:image"]')?.getAttribute('content'))
+      .toBe(`${window.location.origin}/logo512.png`);
+  });
+
+  it('uses generic site metadata when no forecast date is selected', async () => {
+    renderMetadata();
+
+    await waitFor(() => expect(document.title).toBe('Raná – Parra-Glideator'));
+
+    expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content'))
+      .toBe(`${window.location.origin}/details/1?metric=XC0`);
+    expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content'))
+      .toContain('Paragliding activity forecasts, seasonality and site information');
+  });
+});

--- a/frontend/src/components/SiteMetadata.test.jsx
+++ b/frontend/src/components/SiteMetadata.test.jsx
@@ -60,7 +60,7 @@ describe('SiteMetadata', () => {
     await waitFor(() => expect(document.title).toBe('Raná – Parra-Glideator'));
 
     expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content'))
-      .toBe(`${window.location.origin}/details/1?metric=XC0`);
+      .toBe(`${window.location.origin}/details/1`);
     expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content'))
       .toContain('Paragliding activity forecasts, seasonality and site information');
   });

--- a/frontend/src/components/SiteMetadata.test.jsx
+++ b/frontend/src/components/SiteMetadata.test.jsx
@@ -39,7 +39,7 @@ describe('SiteMetadata', () => {
     document.head.innerHTML = '';
   });
 
-  it('keeps the canonical URL stable while exposing selected forecast state to social previews', async () => {
+  it('keeps canonical URLs stable while exposing selected forecast context in preview text', async () => {
     renderMetadata({ selectedDate: '2026-08-03', selectedMetric: 'XC20' });
 
     await waitFor(() => expect(document.title).toContain('70% for XC20'));
@@ -47,7 +47,7 @@ describe('SiteMetadata', () => {
     expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href'))
       .toBe(`${window.location.origin}/details/1`);
     expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content'))
-      .toBe(`${window.location.origin}/details/1?date=2026-08-03&metric=XC20`);
+      .toBe(`${window.location.origin}/details/1`);
     expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content'))
       .toContain('70% probability for XC20 activity at Raná');
     expect(document.querySelector('meta[property="og:image"]')?.getAttribute('content'))

--- a/frontend/src/pages/DetailsRoute.jsx
+++ b/frontend/src/pages/DetailsRoute.jsx
@@ -9,6 +9,7 @@ import AccessibleSiteForecast from '../components/AccessibleSiteForecast';
 import AccessibleSitePlanningContext from '../components/AccessibleSitePlanningContext';
 import LoadingSpinner from '../components/LoadingSpinner';
 import QuickFeedback from '../components/QuickFeedback';
+import ShareForecastButton from '../components/ShareForecastButton';
 import SiteMetadata from '../components/SiteMetadata';
 import Details from './Details';
 
@@ -144,7 +145,22 @@ const DetailsRoute = () => {
         selectedMetric={metric}
       />
       <Details />
-      <SiteMetadata siteId={siteId} site={site} siteInfo={siteInfoQuery.data} />
+      <SiteMetadata
+        siteId={siteId}
+        site={site}
+        siteInfo={siteInfoQuery.data}
+        selectedDate={date}
+        selectedMetric={metric}
+      />
+      {tab === 'forecast' && date && (
+        <ShareForecastButton
+          siteId={siteId}
+          siteName={displayName}
+          selectedDate={date}
+          selectedMetric={metric}
+          predictions={site.predictions}
+        />
+      )}
       {tab === 'forecast' && date && (
         <Box sx={{ maxWidth: '1200px', mx: 'auto', px: 2, pb: 2 }}>
           <QuickFeedback

--- a/frontend/src/pages/DetailsRoute.jsx
+++ b/frontend/src/pages/DetailsRoute.jsx
@@ -22,6 +22,7 @@ const DetailsRoute = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const previousSelection = useRef(null);
+  const hasExplicitForecastDate = useRef(searchParams.has('date')).current;
   const numericSiteId = Number(siteId);
 
   const date = searchParams.get('date') || null;
@@ -149,7 +150,7 @@ const DetailsRoute = () => {
         siteId={siteId}
         site={site}
         siteInfo={siteInfoQuery.data}
-        selectedDate={date}
+        selectedDate={hasExplicitForecastDate ? date : null}
         selectedMetric={metric}
       />
       {tab === 'forecast' && date && (


### PR DESCRIPTION
## What changed

- add a visible Share forecast action to dated site forecast pages
- use the native mobile share sheet when available and fall back to copying a clean link
- keep shared links limited to site ID, forecast date, and XC metric
- track native and clipboard shares through the existing first-party analytics pipeline
- make server-rendered Open Graph and Twitter titles/descriptions reflect the selected date, metric, and probability
- preserve query-free canonical and Open Graph URLs for the underlying site page
- add a static branded preview image
- add unit tests for URL construction, probability selection, native sharing, clipboard fallback, and metadata
- add a Playwright smoke journey proving the copied URL strips unrelated parameters and restores the same forecast

## Why

Glideator already persisted most forecast state in the URL, but users had to discover that by manually copying the address bar. Shared site pages also produced generic social preview text that omitted the selected date, XC threshold, and probability.

This turns the existing URL state into an explicit product capability without introducing saved share records or backend state.

## User impact

A pilot can share one concrete site forecast from mobile or desktop. The recipient opens the same site, date, and XC threshold, while preview text explains the actual estimate and retains the safety boundary.

## Validation

GitHub CI runs:

- frontend Vitest suite and coverage gates
- client and SSR production builds
- backend tests and coverage gate
- Playwright smoke tests, including the new forecast sharing journey
