### PR TITLE
Move contextual sharing into the app bar

### DIFF
--- a/frontend/e2e/crawler.spec.js
+++ b/frontend/e2e/crawler.spec.js
@@ -52,7 +52,9 @@ test('site forecast is answerable from normal HTML without MCP', async ({ page }
 
   const forecastTable = page.locator('table[aria-label="Raná seven-day forecast probabilities"]');
   const forecastText = await forecastTable.textContent();
-  expect(forecastText).toContain('XC0');
+  expect(forecastText).toContain('Chance of a flight');
+  expect(forecastText).toContain('Chance of a 20+ point flight');
+  expect(forecastText).not.toContain('XC20');
   expect(forecastText).toContain('72%');
   expect(forecastText).toContain('2026-08-01T09:30:00Z');
   expect(forecastText).toContain('2026-08-01T06:00:00Z');

--- a/frontend/e2e/smoke-share.spec.js
+++ b/frontend/e2e/smoke-share.spec.js
@@ -1,6 +1,11 @@
 const { test, expect } = require('@playwright/test');
 
 const todayUtc = () => new Date().toISOString().slice(0, 10);
+const addDays = (date, days) => {
+  const value = new Date(`${date}T00:00:00Z`);
+  value.setUTCDate(value.getUTCDate() + days);
+  return value.toISOString().slice(0, 10);
+};
 
 test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
@@ -19,16 +24,25 @@ test.beforeEach(async ({ page }) => {
         },
       },
     });
+    Object.defineProperty(window.navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: (success) => success({
+          coords: { latitude: 50.0875, longitude: 14.4213 },
+          timestamp: Date.now(),
+        }),
+      },
+    });
   });
 });
 
-test('copies a clean dated forecast URL that restores the shared state', async ({ page }) => {
+test('copies a clean dated forecast URL from the global app bar', async ({ page }) => {
   const date = todayUtc();
 
   await page.goto(`/details/1?date=${date}&metric=XC20&campaign=pilot`);
 
   await expect(page.getByRole('heading', { name: 'Raná', level: 1 })).toBeVisible();
-  await expect(page).toHaveTitle(/Raná: 52% for XC20/);
+  await expect(page).toHaveTitle(/Raná: 52% chance of a 20\+ point flight/);
   await expect(page.getByText(`Chances of a Flight on ${date}`, { exact: true })).toBeVisible();
   await expect(page.locator('meta[property="og:url"]').last()).toHaveAttribute(
     'content',
@@ -36,12 +50,11 @@ test('copies a clean dated forecast URL that restores the shared state', async (
   );
   await expect(page.locator('meta[property="og:description"]').last()).toHaveAttribute(
     'content',
-    /52% probability for XC20 activity at Raná/,
+    /52% chance of a 20\+ point flight at Raná/,
   );
 
   const shareButton = page.getByRole('button', { name: 'Share forecast for Raná' });
   await expect(shareButton).toBeVisible();
-  await expect(shareButton).toHaveText('Share');
   await shareButton.click();
   await expect(page.getByText('Forecast link copied')).toBeVisible();
 
@@ -50,6 +63,41 @@ test('copies a clean dated forecast URL that restores the shared state', async (
 
   await page.goto(copiedUrl);
   await expect(page).toHaveURL(new RegExp(`/details/1\\?date=${date}&metric=XC20(?:&tab=forecast)?$`));
-  await expect(page).toHaveTitle(/Raná: 52% for XC20/);
+  await expect(page).toHaveTitle(/Raná: 52% chance of a 20\+ point flight/);
   await expect(page.getByRole('button', { name: 'Share forecast for Raná' })).toBeVisible();
+});
+
+test('shares a privacy-rounded forecast map state', async ({ page }) => {
+  const date = todayUtc();
+  await page.goto(`/?date=${date}&metric=XC20&lat=50.12345&lng=14.98765&zoom=7.8&mapType=topographic&campaign=pilot`);
+
+  const shareButton = page.getByRole('button', { name: 'Share forecast map' });
+  await expect(shareButton).toBeVisible();
+  await shareButton.click();
+  await expect(page.getByText('Forecast map link copied')).toBeVisible();
+
+  const copiedUrl = await page.evaluate(() => window.__copiedForecastLink);
+  expect(copiedUrl).toBe(
+    `http://127.0.0.1:4173/?date=${date}&metric=XC20&lat=50.12&lng=14.99&zoom=8&mapType=topographic`,
+  );
+});
+
+test('offers a coarse shared origin for distance-filtered trip plans', async ({ page }) => {
+  const startDate = todayUtc();
+  const endDate = addDays(startDate, 1);
+  await page.goto(
+    `/trip-planner?startDate=${startDate}&endDate=${endDate}&distEnabled=true&distKm=200&metric=XC20&sortBy=distance`,
+  );
+
+  await page.getByRole('button', { name: 'Share trip plan' }).click();
+  await expect(page.getByRole('heading', { name: 'Share starting area?' })).toBeVisible();
+  await page.getByRole('button', { name: 'Include area' }).click();
+  await expect(page.getByText('Trip plan link copied')).toBeVisible();
+
+  const copiedUrl = await page.evaluate(() => window.__copiedForecastLink);
+  expect(copiedUrl).toContain(`startDate=${startDate}`);
+  expect(copiedUrl).toContain(`endDate=${endDate}`);
+  expect(copiedUrl).toContain('metric=XC20');
+  expect(copiedUrl).toContain('originLat=50.1');
+  expect(copiedUrl).toContain('originLng=14.4');
 });

--- a/frontend/src/components/AccessibleSiteForecast.jsx
+++ b/frontend/src/components/AccessibleSiteForecast.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Box } from '@mui/material';
-import { fetchSiteInfo, fetchSitePredictions } from '../api';
 
-const METRICS = ['XC0', 'XC10', 'XC20', 'XC30', 'XC40', 'XC50', 'XC60', 'XC70', 'XC80', 'XC90', 'XC100'];
+import { fetchSiteInfo, fetchSitePredictions } from '../api';
+import { getChanceLabel, METRICS } from '../utils/shareUtils';
 
 const SCREEN_READER_ONLY = {
   position: 'absolute',
@@ -48,9 +48,9 @@ const AccessibleSiteForecast = ({ siteId, selectedDate = null }) => {
       </p>
       {site.tags?.length > 0 && <p>Site tags: {site.tags.join(', ')}.</p>}
       <p>
-        XC0 is the probability of any recorded flying activity. XC10 through XC100 are probabilities of
-        exceeding progressively higher XC-point thresholds. Higher values indicate more promising historical
-        flight patterns, not guaranteed safe flying conditions. Always verify current weather and local rules.
+        The forecast shows the chance of any recorded flying activity and the chance of flights reaching
+        progressively higher point thresholds. Higher values indicate more promising historical flight patterns,
+        not guaranteed flying conditions.
       </p>
       <table aria-label={`${displayName} seven-day forecast probabilities`}>
         <caption>
@@ -59,9 +59,11 @@ const AccessibleSiteForecast = ({ siteId, selectedDate = null }) => {
         <thead>
           <tr>
             <th scope="col">Date</th>
-            {METRICS.map((metric) => <th scope="col" key={metric}>{metric}</th>)}
+            {METRICS.map((metric) => (
+              <th scope="col" key={metric}>{getChanceLabel(metric)}</th>
+            ))}
             <th scope="col">Forecast computed</th>
-            <th scope="col">GFS forecast cycle</th>
+            <th scope="col">Weather forecast cycle</th>
           </tr>
         </thead>
         <tbody>

--- a/frontend/src/components/GlobalShareAction.jsx
+++ b/frontend/src/components/GlobalShareAction.jsx
@@ -1,0 +1,466 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { useQuery } from '@tanstack/react-query';
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  IconButton,
+  Snackbar,
+  Tooltip,
+} from '@mui/material';
+import ShareIcon from '@mui/icons-material/Share';
+import { useLocation } from 'react-router-dom';
+
+import { fetchSiteInfo, fetchSitePredictions } from '../api';
+import { trackEvent } from '../analytics';
+import { useAuth } from '../context/AuthContext';
+import { useDefaultMetric } from '../hooks/useDefaultMetric';
+import {
+  buildAboutShareUrl,
+  buildDetailsShareUrl,
+  buildMapShareUrl,
+  buildTripPlanShareUrl,
+  formatShareDate,
+  formatShareDateRange,
+  getChanceLabel,
+  getFlightPhrase,
+  getForecastProbability,
+  getPluralFlightPhrase,
+  normalizeMetric,
+} from '../utils/shareUtils';
+
+const PUBLIC_ORIGIN = process.env.REACT_APP_PUBLIC_ORIGIN || 'https://www.parra-glideator.com';
+const useIsomorphicLayoutEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const copyText = async (text) => {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  document.body.removeChild(textarea);
+  if (!copied) throw new Error('Copy command failed');
+};
+
+const isValidOrigin = (latitude, longitude) => (
+  Number.isFinite(latitude)
+  && Number.isFinite(longitude)
+  && latitude >= -90
+  && latitude <= 90
+  && longitude >= -180
+  && longitude <= 180
+);
+
+const getBrowserOrigin = () => (
+  typeof window !== 'undefined' && window.location?.origin
+    ? window.location.origin
+    : PUBLIC_ORIGIN
+);
+
+const getGeolocation = () => new Promise((resolve, reject) => {
+  if (!navigator.geolocation) {
+    reject(new Error('Location is not available in this browser'));
+    return;
+  }
+
+  navigator.geolocation.getCurrentPosition(
+    (position) => resolve({
+      latitude: position.coords.latitude,
+      longitude: position.coords.longitude,
+    }),
+    () => reject(new Error('Could not get your starting area')),
+    { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 },
+  );
+});
+
+const GlobalShareAction = () => {
+  const location = useLocation();
+  const { profile } = useAuth();
+  const { preferredMetric } = useDefaultMetric();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [resolvingLocation, setResolvingLocation] = useState(false);
+  const [message, setMessage] = useState(null);
+  const [severity, setSeverity] = useState('success');
+
+  const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
+  const detailMatch = location.pathname.match(/^\/details\/(\d+)$/);
+  const siteId = detailMatch ? Number(detailMatch[1]) : null;
+
+  const predictionsQuery = useQuery({
+    queryKey: ['site', siteId, 'predictions'],
+    queryFn: ({ signal }) => fetchSitePredictions(siteId, { signal }),
+    enabled: Number.isFinite(siteId),
+  });
+
+  const siteInfoQuery = useQuery({
+    queryKey: ['site', siteId, 'info'],
+    queryFn: async ({ signal }) => {
+      try {
+        return await fetchSiteInfo(siteId, { signal });
+      } catch (error) {
+        if (error?.response?.status === 404) return null;
+        throw error;
+      }
+    },
+    enabled: Number.isFinite(siteId),
+  });
+
+  const sharedLatitude = Number(params.get('originLat'));
+  const sharedLongitude = Number(params.get('originLng'));
+  const hasSharedOrigin = location.pathname === '/trip-planner'
+    && isValidOrigin(sharedLatitude, sharedLongitude);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!hasSharedOrigin || typeof navigator === 'undefined' || !navigator.geolocation) {
+      return undefined;
+    }
+
+    const geolocation = navigator.geolocation;
+    const original = geolocation.getCurrentPosition;
+    const sharedGetCurrentPosition = (success) => {
+      window.setTimeout(() => success({
+        coords: {
+          latitude: sharedLatitude,
+          longitude: sharedLongitude,
+          accuracy: 10000,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      }), 0);
+    };
+
+    try {
+      geolocation.getCurrentPosition = sharedGetCurrentPosition;
+    } catch {
+      return undefined;
+    }
+
+    return () => {
+      try {
+        geolocation.getCurrentPosition = original;
+      } catch {
+        // Nothing else to restore when the browser exposes a read-only implementation.
+      }
+    };
+  }, [hasSharedOrigin, sharedLatitude, sharedLongitude]);
+
+  useEffect(() => {
+    if (hasSharedOrigin) {
+      setSeverity('info');
+      setMessage('Using the approximate starting area from the shared trip plan');
+    }
+  }, [hasSharedOrigin]);
+
+  const pageConfig = useMemo(() => {
+    const origin = getBrowserOrigin();
+
+    if (location.pathname === '/') {
+      const selectedDate = params.get('date');
+      const metric = normalizeMetric(params.get('metric') || preferredMetric);
+      const formattedDate = formatShareDate(selectedDate);
+      return {
+        tooltip: 'Share forecast map',
+        ariaLabel: 'Share forecast map',
+        eventName: 'forecast_map_shared',
+        eventProperties: { date: selectedDate, metric },
+        copiedMessage: 'Forecast map link copied',
+        payload: {
+          title: `Paragliding forecast for ${formattedDate}`,
+          text: `Compare sites by chance of ${getFlightPhrase(metric)} on ${formattedDate}.`,
+          url: buildMapShareUrl({
+            origin,
+            search: params,
+            selectedDate,
+            selectedMetric: metric,
+          }),
+        },
+      };
+    }
+
+    if (Number.isFinite(siteId)) {
+      const site = predictionsQuery.data?.[0];
+      if (!site) return null;
+
+      const displayName = siteInfoQuery.data?.site_name || site.name || `Site ${siteId}`;
+      const tab = params.get('tab') || 'forecast';
+      const selectedDate = params.get('date');
+      const metric = normalizeMetric(params.get('metric') || 'XC0');
+      const formattedDate = formatShareDate(selectedDate);
+      const probability = getForecastProbability({
+        predictions: site.predictions,
+        selectedDate,
+        selectedMetric: metric,
+      });
+      const percentage = probability == null ? null : Math.round(probability * 100);
+      const url = buildDetailsShareUrl({
+        origin,
+        siteId,
+        tab,
+        selectedDate,
+        selectedMetric: metric,
+      });
+
+      if (tab === 'season') {
+        const text = metric === 'XC0'
+          ? `See ${displayName}’s typical flying season, based on historical activity.`
+          : `See when ${displayName} is typically active for ${getPluralFlightPhrase(metric)}, based on historical activity.`;
+        return {
+          tooltip: 'Share flying season',
+          ariaLabel: `Share flying season for ${displayName}`,
+          eventName: 'site_section_shared',
+          eventProperties: { site_id: siteId, tab, metric },
+          copiedMessage: 'Flying season link copied',
+          payload: { title: `${displayName} flying season`, text, url },
+        };
+      }
+
+      if (tab === 'map') {
+        return {
+          tooltip: 'Share site map',
+          ariaLabel: `Share site map for ${displayName}`,
+          eventName: 'site_section_shared',
+          eventProperties: { site_id: siteId, tab },
+          copiedMessage: 'Site map link copied',
+          payload: {
+            title: `${displayName} site map`,
+            text: `See takeoffs and landings for ${displayName}.`,
+            url,
+          },
+        };
+      }
+
+      if (tab === 'resources') {
+        return {
+          tooltip: 'Share flying resources',
+          ariaLabel: `Share flying resources for ${displayName}`,
+          eventName: 'site_section_shared',
+          eventProperties: { site_id: siteId, tab },
+          copiedMessage: 'Flying resources link copied',
+          payload: {
+            title: `${displayName} flying resources`,
+            text: `Local clubs, weather links, webcams and other flying resources for ${displayName}.`,
+            url,
+          },
+        };
+      }
+
+      const estimate = percentage == null
+        ? `${getChanceLabel(metric)} at ${displayName}`
+        : `${percentage}% chance of ${getFlightPhrase(metric)} at ${displayName}`;
+      return {
+        tooltip: 'Share forecast',
+        ariaLabel: `Share forecast for ${displayName}`,
+        eventName: 'forecast_shared',
+        eventProperties: {
+          site_id: siteId,
+          date: selectedDate,
+          metric,
+          probability,
+        },
+        copiedMessage: 'Forecast link copied',
+        payload: {
+          title: `${displayName} forecast for ${formattedDate}`,
+          text: `Glideator estimates a ${estimate.charAt(0).toLowerCase()}${estimate.slice(1)} on ${formattedDate}.`,
+          url,
+        },
+      };
+    }
+
+    if (location.pathname === '/trip-planner') {
+      const startDate = params.get('startDate');
+      const endDate = params.get('endDate');
+      const metric = normalizeMetric(params.get('metric') || preferredMetric);
+      const formattedRange = formatShareDateRange(startDate, endDate);
+      const distanceEnabled = params.get('distEnabled') === 'true';
+      const base = {
+        tooltip: 'Share trip plan',
+        ariaLabel: 'Share trip plan',
+        eventName: 'trip_plan_shared',
+        eventProperties: { start_date: startDate, end_date: endDate, metric },
+        copiedMessage: 'Trip plan link copied',
+        requiresLocationChoice: distanceEnabled,
+      };
+
+      return {
+        ...base,
+        buildPayload: ({ includeDistance = false, approximateOrigin = null } = {}) => ({
+          title: `Paragliding trip plan for ${formattedRange}`,
+          text: `Explore sites for ${formattedRange}, ranked by chance of ${getFlightPhrase(metric)}.`,
+          url: buildTripPlanShareUrl({
+            origin,
+            search: params,
+            selectedMetric: metric,
+            includeDistance,
+            approximateOrigin,
+          }),
+        }),
+      };
+    }
+
+    if (location.pathname === '/about') {
+      return {
+        tooltip: 'Share how it works',
+        ariaLabel: 'Share how Parra-Glideator works',
+        eventName: 'how_it_works_shared',
+        eventProperties: { section: location.hash || null },
+        copiedMessage: 'How it works link copied',
+        payload: {
+          title: 'How Parra-Glideator works',
+          text: 'See how Parra-Glideator combines weather forecasts and flight history to estimate flying activity.',
+          url: buildAboutShareUrl({ origin, hash: location.hash }),
+        },
+      };
+    }
+
+    return null;
+  }, [
+    location.hash,
+    location.pathname,
+    params,
+    predictionsQuery.data,
+    preferredMetric,
+    siteId,
+    siteInfoQuery.data,
+  ]);
+
+  const performShare = useCallback(async (payload) => {
+    if (!payload || !pageConfig) return;
+
+    if (navigator.share) {
+      try {
+        await navigator.share(payload);
+        void trackEvent(pageConfig.eventName, {
+          ...pageConfig.eventProperties,
+          method: 'native',
+        });
+        return;
+      } catch (error) {
+        if (error?.name === 'AbortError') return;
+      }
+    }
+
+    try {
+      await copyText(payload.url);
+      setSeverity('success');
+      setMessage(pageConfig.copiedMessage);
+      void trackEvent(pageConfig.eventName, {
+        ...pageConfig.eventProperties,
+        method: 'clipboard',
+      });
+    } catch {
+      setSeverity('error');
+      setMessage('Could not copy the link');
+    }
+  }, [pageConfig]);
+
+  const handleShare = useCallback(() => {
+    if (!pageConfig) return;
+    if (pageConfig.requiresLocationChoice) {
+      setDialogOpen(true);
+      return;
+    }
+    const payload = pageConfig.payload || pageConfig.buildPayload?.();
+    void performShare(payload);
+  }, [pageConfig, performShare]);
+
+  const resolveApproximateOrigin = useCallback(async () => {
+    if (hasSharedOrigin) {
+      return { latitude: sharedLatitude, longitude: sharedLongitude };
+    }
+
+    const latitude = Number(profile?.home_lat);
+    const longitude = Number(profile?.home_lon);
+    if (params.get('locSrc') === 'home' && isValidOrigin(latitude, longitude)) {
+      return { latitude, longitude };
+    }
+
+    return getGeolocation();
+  }, [hasSharedOrigin, params, profile, sharedLatitude, sharedLongitude]);
+
+  const handleIncludeArea = useCallback(async () => {
+    if (!pageConfig?.buildPayload) return;
+    setResolvingLocation(true);
+    try {
+      const approximateOrigin = await resolveApproximateOrigin();
+      setDialogOpen(false);
+      await performShare(pageConfig.buildPayload({
+        includeDistance: true,
+        approximateOrigin,
+      }));
+    } catch (error) {
+      setSeverity('error');
+      setMessage(error?.message || 'Could not get the starting area');
+    } finally {
+      setResolvingLocation(false);
+    }
+  }, [pageConfig, performShare, resolveApproximateOrigin]);
+
+  const handleWithoutLocation = useCallback(() => {
+    if (!pageConfig?.buildPayload) return;
+    setDialogOpen(false);
+    void performShare(pageConfig.buildPayload({ includeDistance: false }));
+  }, [pageConfig, performShare]);
+
+  if (!pageConfig) return null;
+
+  return (
+    <>
+      <Tooltip title={pageConfig.tooltip}>
+        <IconButton color="inherit" aria-label={pageConfig.ariaLabel} onClick={handleShare}>
+          <ShareIcon />
+        </IconButton>
+      </Tooltip>
+
+      <Dialog open={dialogOpen} onClose={() => !resolvingLocation && setDialogOpen(false)}>
+        <DialogTitle>Share starting area?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            This trip uses a distance filter. Include an approximate starting area, about 10 km across,
+            so other pilots see comparable results?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setDialogOpen(false)} disabled={resolvingLocation}>Cancel</Button>
+          <Button onClick={handleWithoutLocation} disabled={resolvingLocation}>Share without location</Button>
+          <Button onClick={handleIncludeArea} variant="contained" disabled={resolvingLocation}>
+            {resolvingLocation ? 'Getting area…' : 'Include area'}
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      <Snackbar
+        open={Boolean(message)}
+        autoHideDuration={4000}
+        onClose={() => setMessage(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+      >
+        <Alert severity={severity} onClose={() => setMessage(null)} sx={{ width: '100%' }}>
+          {message}
+        </Alert>
+      </Snackbar>
+    </>
+  );
+};
+
+export default GlobalShareAction;

--- a/frontend/src/components/GlobalShareAction.jsx
+++ b/frontend/src/components/GlobalShareAction.jsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useQuery } from '@tanstack/react-query';
@@ -99,6 +100,7 @@ const GlobalShareAction = () => {
   const [resolvingLocation, setResolvingLocation] = useState(false);
   const [message, setMessage] = useState(null);
   const [severity, setSeverity] = useState('success');
+  const sharedOriginRef = useRef(null);
 
   const params = useMemo(() => new URLSearchParams(location.search), [location.search]);
   const detailMatch = location.pathname.match(/^\/details\/(\d+)$/);
@@ -125,8 +127,20 @@ const GlobalShareAction = () => {
 
   const sharedLatitude = Number(params.get('originLat'));
   const sharedLongitude = Number(params.get('originLng'));
-  const hasSharedOrigin = location.pathname === '/trip-planner'
-    && isValidOrigin(sharedLatitude, sharedLongitude);
+  if (
+    location.pathname === '/trip-planner'
+    && isValidOrigin(sharedLatitude, sharedLongitude)
+  ) {
+    sharedOriginRef.current = {
+      latitude: sharedLatitude,
+      longitude: sharedLongitude,
+    };
+  }
+
+  const effectiveSharedOrigin = location.pathname === '/trip-planner'
+    ? sharedOriginRef.current
+    : null;
+  const hasSharedOrigin = Boolean(effectiveSharedOrigin);
 
   useIsomorphicLayoutEffect(() => {
     if (!hasSharedOrigin || typeof navigator === 'undefined' || !navigator.geolocation) {
@@ -138,8 +152,8 @@ const GlobalShareAction = () => {
     const sharedGetCurrentPosition = (success) => {
       window.setTimeout(() => success({
         coords: {
-          latitude: sharedLatitude,
-          longitude: sharedLongitude,
+          latitude: effectiveSharedOrigin.latitude,
+          longitude: effectiveSharedOrigin.longitude,
           accuracy: 10000,
           altitude: null,
           altitudeAccuracy: null,
@@ -163,7 +177,20 @@ const GlobalShareAction = () => {
         // Nothing else to restore when the browser exposes a read-only implementation.
       }
     };
-  }, [hasSharedOrigin, sharedLatitude, sharedLongitude]);
+  }, [effectiveSharedOrigin, hasSharedOrigin]);
+
+  useEffect(() => {
+    if (!hasSharedOrigin || typeof window === 'undefined') return;
+
+    // TripPlannerPage rebuilds its own query string. Keep the coarse shared
+    // origin in the address bar so a refresh or second share stays reproducible.
+    const currentUrl = new URL(window.location.href);
+    if (!currentUrl.searchParams.has('originLat')) {
+      currentUrl.searchParams.set('originLat', effectiveSharedOrigin.latitude.toFixed(1));
+      currentUrl.searchParams.set('originLng', effectiveSharedOrigin.longitude.toFixed(1));
+      window.history.replaceState(window.history.state, '', currentUrl.toString());
+    }
+  }, [effectiveSharedOrigin, hasSharedOrigin, location.search]);
 
   useEffect(() => {
     if (hasSharedOrigin) {
@@ -385,9 +412,7 @@ const GlobalShareAction = () => {
   }, [pageConfig, performShare]);
 
   const resolveApproximateOrigin = useCallback(async () => {
-    if (hasSharedOrigin) {
-      return { latitude: sharedLatitude, longitude: sharedLongitude };
-    }
+    if (effectiveSharedOrigin) return effectiveSharedOrigin;
 
     const latitude = Number(profile?.home_lat);
     const longitude = Number(profile?.home_lon);
@@ -396,7 +421,7 @@ const GlobalShareAction = () => {
     }
 
     return getGeolocation();
-  }, [hasSharedOrigin, params, profile, sharedLatitude, sharedLongitude]);
+  }, [effectiveSharedOrigin, params, profile]);
 
   const handleIncludeArea = useCallback(async () => {
     if (!pageConfig?.buildPayload) return;

--- a/frontend/src/components/GlobalShareAction.jsx
+++ b/frontend/src/components/GlobalShareAction.jsx
@@ -125,10 +125,12 @@ const GlobalShareAction = () => {
     enabled: Number.isFinite(siteId),
   });
 
-  const sharedLatitude = Number(params.get('originLat'));
-  const sharedLongitude = Number(params.get('originLng'));
+  const hasSharedCoordinates = params.has('originLat') && params.has('originLng');
+  const sharedLatitude = hasSharedCoordinates ? Number(params.get('originLat')) : Number.NaN;
+  const sharedLongitude = hasSharedCoordinates ? Number(params.get('originLng')) : Number.NaN;
   if (
     location.pathname === '/trip-planner'
+    && hasSharedCoordinates
     && isValidOrigin(sharedLatitude, sharedLongitude)
   ) {
     sharedOriginRef.current = {
@@ -191,13 +193,6 @@ const GlobalShareAction = () => {
       window.history.replaceState(window.history.state, '', currentUrl.toString());
     }
   }, [effectiveSharedOrigin, hasSharedOrigin, location.search]);
-
-  useEffect(() => {
-    if (hasSharedOrigin) {
-      setSeverity('info');
-      setMessage('Using the approximate starting area from the shared trip plan');
-    }
-  }, [hasSharedOrigin]);
 
   const pageConfig = useMemo(() => {
     const origin = getBrowserOrigin();

--- a/frontend/src/components/ShareForecastButton.jsx
+++ b/frontend/src/components/ShareForecastButton.jsx
@@ -1,168 +1,43 @@
-import React, { useMemo, useState } from 'react';
-import { Alert, Button, Snackbar } from '@mui/material';
-import ShareIcon from '@mui/icons-material/Share';
+import React, { useEffect, useRef } from 'react';
 
-import { trackEvent } from '../analytics';
+import {
+  buildDetailsShareUrl,
+  getForecastProbability,
+} from '../utils/shareUtils';
 
-const METRICS = ['XC0', 'XC10', 'XC20', 'XC30', 'XC40', 'XC50', 'XC60', 'XC70', 'XC80', 'XC90', 'XC100'];
-const CONFIGURED_PUBLIC_ORIGIN = process.env.REACT_APP_PUBLIC_ORIGIN || 'https://www.parra-glideator.com';
-
-export const buildForecastShareUrl = ({ origin, siteId, selectedDate, selectedMetric }) => {
-  const normalizedOrigin = String(origin || CONFIGURED_PUBLIC_ORIGIN).replace(/\/$/, '');
-  const params = new URLSearchParams();
-
-  if (selectedDate) params.set('date', selectedDate);
-  if (METRICS.includes(selectedMetric)) params.set('metric', selectedMetric);
-
-  const query = params.toString();
-  return `${normalizedOrigin}/details/${encodeURIComponent(siteId)}${query ? `?${query}` : ''}`;
-};
-
-export const getForecastProbability = ({ predictions, selectedDate, selectedMetric }) => {
-  const metricIndex = METRICS.indexOf(selectedMetric);
-  if (metricIndex < 0 || !selectedDate || !Array.isArray(predictions)) return null;
-
-  const prediction = predictions.find((item) => item?.date === selectedDate);
-  const value = prediction?.values?.[metricIndex];
-  return Number.isFinite(value) ? value : null;
-};
-
-const formatDate = (date) => {
-  if (!date) return 'the selected date';
-
-  const parsed = new Date(`${date}T00:00:00Z`);
-  if (Number.isNaN(parsed.getTime())) return date;
-
-  return new Intl.DateTimeFormat('en', {
-    weekday: 'short',
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-    timeZone: 'UTC',
-  }).format(parsed);
-};
-
-const copyText = async (text) => {
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return;
-  }
-
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  textarea.setAttribute('readonly', '');
-  textarea.style.position = 'fixed';
-  textarea.style.opacity = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-
-  const copied = document.execCommand('copy');
-  document.body.removeChild(textarea);
-  if (!copied) throw new Error('Copy command failed');
-};
-
-const ShareForecastButton = ({
-  siteId,
-  siteName,
-  selectedDate,
-  selectedMetric,
-  predictions,
-}) => {
-  const [message, setMessage] = useState(null);
-  const [severity, setSeverity] = useState('success');
-
-  const probability = useMemo(() => getForecastProbability({
-    predictions,
+export const buildForecastShareUrl = ({ origin, siteId, selectedDate, selectedMetric }) => (
+  buildDetailsShareUrl({
+    origin,
+    siteId,
+    tab: 'forecast',
     selectedDate,
     selectedMetric,
-  }), [predictions, selectedDate, selectedMetric]);
+  })
+);
 
-  const handleShare = async () => {
-    const origin = typeof window !== 'undefined' && window.location?.origin
-      ? window.location.origin
-      : CONFIGURED_PUBLIC_ORIGIN;
-    const url = buildForecastShareUrl({
-      origin,
-      siteId,
-      selectedDate,
-      selectedMetric,
-    });
-    const percentage = probability == null ? null : Math.round(probability * 100);
-    const title = `${siteName} forecast – Parra-Glideator`;
-    const text = percentage == null
-      ? `${siteName}: Glideator forecast for ${selectedMetric} on ${formatDate(selectedDate)}. Decision support, not a safety forecast.`
-      : `${siteName}: ${percentage}% Glideator probability for ${selectedMetric} on ${formatDate(selectedDate)}. Decision support, not a safety forecast.`;
+export { getForecastProbability };
 
-    if (navigator.share) {
-      try {
-        await navigator.share({ title, text, url });
-        void trackEvent('forecast_shared', {
-          site_id: Number(siteId),
-          date: selectedDate,
-          metric: selectedMetric,
-          probability,
-          method: 'native',
-        });
-        return;
-      } catch (error) {
-        if (error?.name === 'AbortError') return;
-      }
-    }
+// Kept temporarily so the existing Details layout can remove its old slot without
+// leaving an empty row. Sharing now lives in the global application bar.
+const ShareForecastButton = () => {
+  const markerRef = useRef(null);
 
-    try {
-      await copyText(url);
-      setSeverity('success');
-      setMessage('Forecast link copied');
-      void trackEvent('forecast_shared', {
-        site_id: Number(siteId),
-        date: selectedDate,
-        metric: selectedMetric,
-        probability,
-        method: 'clipboard',
-      });
-    } catch {
-      setSeverity('error');
-      setMessage('Could not copy the forecast link');
-    }
-  };
+  useEffect(() => {
+    const container = markerRef.current?.parentElement;
+    if (!container) return undefined;
 
-  return (
-    <>
-      <Button
-        variant="text"
-        size="small"
-        startIcon={<ShareIcon fontSize="small" />}
-        onClick={handleShare}
-        aria-label={`Share forecast for ${siteName}`}
-        sx={{
-          minWidth: 0,
-          px: 1,
-          py: 0.5,
-          color: 'text.secondary',
-          borderRadius: 1.5,
-          textTransform: 'none',
-          fontWeight: 500,
-          '&:hover': {
-            bgcolor: 'action.hover',
-            color: 'text.primary',
-          },
-        }}
-      >
-        Share
-      </Button>
+    const previousDisplay = container.style.display;
+    const previousMinHeight = container.style.minHeight;
+    container.style.display = 'none';
+    container.style.minHeight = '0';
 
-      <Snackbar
-        open={Boolean(message)}
-        autoHideDuration={3500}
-        onClose={() => setMessage(null)}
-        anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-      >
-        <Alert severity={severity} onClose={() => setMessage(null)} sx={{ width: '100%' }}>
-          {message}
-        </Alert>
-      </Snackbar>
-    </>
-  );
+    return () => {
+      container.style.display = previousDisplay;
+      container.style.minHeight = previousMinHeight;
+    };
+  }, []);
+
+  return <span ref={markerRef} hidden aria-hidden="true" />;
 };
 
 export default ShareForecastButton;

--- a/frontend/src/components/ShareForecastButton.test.jsx
+++ b/frontend/src/components/ShareForecastButton.test.jsx
@@ -41,6 +41,6 @@ describe('ShareForecastButton compatibility helpers', () => {
     );
 
     await waitFor(() => expect(container.firstChild.style.display).toBe('none'));
-    expect(container.firstChild.style.minHeight).toBe('0');
+    expect(container.firstChild.style.minHeight).toBe('0px');
   });
 });

--- a/frontend/src/components/ShareForecastButton.test.jsx
+++ b/frontend/src/components/ShareForecastButton.test.jsx
@@ -1,16 +1,11 @@
 import React from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import ShareForecastButton, {
   buildForecastShareUrl,
   getForecastProbability,
 } from './ShareForecastButton';
-import { trackEvent } from '../analytics';
-
-vi.mock('../analytics', () => ({
-  trackEvent: vi.fn(() => Promise.resolve(null)),
-}));
 
 const date = '2026-08-03';
 const predictions = [{
@@ -18,24 +13,8 @@ const predictions = [{
   values: [0.82, 0.76, 0.7, 0.64, 0.58, 0.52, 0.46, 0.4, 0.34, 0.28, 0.22],
 }];
 
-const setNavigatorProperty = (name, value) => {
-  Object.defineProperty(window.navigator, name, {
-    configurable: true,
-    value,
-  });
-};
-
-describe('ShareForecastButton', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    window.history.replaceState({}, '', `/details/1?date=${date}&metric=XC20&tab=resources`);
-  });
-
-  afterEach(() => {
-    cleanup();
-    setNavigatorProperty('share', undefined);
-    setNavigatorProperty('clipboard', undefined);
-  });
+describe('ShareForecastButton compatibility helpers', () => {
+  afterEach(() => cleanup());
 
   it('builds a deterministic forecast URL with only date and metric state', () => {
     expect(buildForecastShareUrl({
@@ -54,64 +33,14 @@ describe('ShareForecastButton', () => {
     })).toBe(0.7);
   });
 
-  it('uses the native share sheet when available', async () => {
-    const share = vi.fn().mockResolvedValue(undefined);
-    setNavigatorProperty('share', share);
-
-    render(
-      <ShareForecastButton
-        siteId={1}
-        siteName="Raná"
-        selectedDate={date}
-        selectedMetric="XC20"
-        predictions={predictions}
-      />,
+  it('collapses the obsolete inline share row', async () => {
+    const { container } = render(
+      <div style={{ display: 'flex', minHeight: '32px' }}>
+        <ShareForecastButton />
+      </div>,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Share forecast for Raná' }));
-
-    await waitFor(() => expect(share).toHaveBeenCalledTimes(1));
-    expect(share).toHaveBeenCalledWith(expect.objectContaining({
-      title: 'Raná forecast – Parra-Glideator',
-      text: expect.stringContaining('70% Glideator probability for XC20'),
-      url: `${window.location.origin}/details/1?date=${date}&metric=XC20`,
-    }));
-    expect(trackEvent).toHaveBeenCalledWith('forecast_shared', expect.objectContaining({
-      site_id: 1,
-      date,
-      metric: 'XC20',
-      probability: 0.7,
-      method: 'native',
-    }));
-  });
-
-  it('copies the clean link when native sharing is unavailable', async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    setNavigatorProperty('share', undefined);
-    setNavigatorProperty('clipboard', { writeText });
-
-    render(
-      <ShareForecastButton
-        siteId={1}
-        siteName="Raná"
-        selectedDate={date}
-        selectedMetric="XC20"
-        predictions={predictions}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole('button', { name: 'Share forecast for Raná' }));
-
-    await waitFor(() => expect(writeText).toHaveBeenCalledWith(
-      `${window.location.origin}/details/1?date=${date}&metric=XC20`,
-    ));
-    expect(await screen.findByText('Forecast link copied')).toBeInTheDocument();
-    expect(trackEvent).toHaveBeenCalledWith('forecast_shared', expect.objectContaining({
-      site_id: 1,
-      date,
-      metric: 'XC20',
-      probability: 0.7,
-      method: 'clipboard',
-    }));
+    await waitFor(() => expect(container.firstChild.style.display).toBe('none'));
+    expect(container.firstChild.style.minHeight).toBe('0');
   });
 });

--- a/frontend/src/components/SiteMetadata.jsx
+++ b/frontend/src/components/SiteMetadata.jsx
@@ -1,31 +1,16 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
+import {
+  formatShareDate,
+  getChanceLabel,
+  getFlightPhrase,
+  getForecastProbability,
+  getPluralFlightPhrase,
+  normalizeMetric,
+} from '../utils/shareUtils';
+
 const CONFIGURED_PUBLIC_ORIGIN = process.env.REACT_APP_PUBLIC_ORIGIN || 'https://www.parra-glideator.com';
-const METRICS = ['XC0', 'XC10', 'XC20', 'XC30', 'XC40', 'XC50', 'XC60', 'XC70', 'XC80', 'XC90', 'XC100'];
-
-const formatDate = (date) => {
-  if (!date) return null;
-
-  const parsed = new Date(`${date}T00:00:00Z`);
-  if (Number.isNaN(parsed.getTime())) return date;
-
-  return new Intl.DateTimeFormat('en', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-    timeZone: 'UTC',
-  }).format(parsed);
-};
-
-const getProbability = (site, selectedDate, selectedMetric) => {
-  const metricIndex = METRICS.indexOf(selectedMetric);
-  if (metricIndex < 0 || !selectedDate) return null;
-
-  const prediction = site?.predictions?.find((item) => item?.date === selectedDate);
-  const value = prediction?.values?.[metricIndex];
-  return Number.isFinite(value) ? value : null;
-};
 
 const SiteMetadata = ({
   siteId,
@@ -33,6 +18,7 @@ const SiteMetadata = ({
   siteInfo,
   selectedDate = null,
   selectedMetric = 'XC0',
+  selectedTab = 'forecast',
 }) => {
   if (!site) return null;
 
@@ -41,21 +27,43 @@ const SiteMetadata = ({
     : CONFIGURED_PUBLIC_ORIGIN;
   const displayName = siteInfo?.site_name || site.name || `Site ${siteId}`;
   const canonicalUrl = `${publicOrigin}/details/${siteId}`;
-  const validMetric = METRICS.includes(selectedMetric) ? selectedMetric : 'XC0';
-  const probability = getProbability(site, selectedDate, validMetric);
-  const formattedDate = formatDate(selectedDate);
+  const metric = normalizeMetric(selectedMetric);
+  const tab = ['forecast', 'season', 'map', 'resources'].includes(selectedTab)
+    ? selectedTab
+    : 'forecast';
+  const probability = getForecastProbability({
+    predictions: site.predictions,
+    selectedDate,
+    selectedMetric: metric,
+  });
   const percentage = probability == null ? null : Math.round(probability * 100);
-  const title = selectedDate
-    ? `${displayName}: ${percentage == null ? validMetric : `${percentage}% for ${validMetric}`} on ${formattedDate} – Parra-Glideator`
-    : `${displayName} – Parra-Glideator`;
-  const description = selectedDate
-    ? percentage == null
-      ? `Glideator activity forecast for ${validMetric} at ${displayName} on ${formattedDate}. Decision support, not a safety forecast.`
-      : `Glideator estimates a ${percentage}% probability for ${validMetric} activity at ${displayName} on ${formattedDate}. Decision support, not a safety forecast.`
-    : `Paragliding activity forecasts, seasonality and site information for ${displayName}.`;
+  const formattedDate = selectedDate ? formatShareDate(selectedDate, { includeYear: true }) : null;
+
+  let title = `${displayName} – Parra-Glideator`;
+  let description = `Paragliding activity forecasts, seasonality and site information for ${displayName}.`;
+
+  if (tab === 'forecast' && selectedDate) {
+    title = percentage == null
+      ? `${displayName}: ${getChanceLabel(metric)} – Parra-Glideator`
+      : `${displayName}: ${percentage}% chance of ${getFlightPhrase(metric)} – Parra-Glideator`;
+    description = percentage == null
+      ? `${getChanceLabel(metric)} at ${displayName} on ${formattedDate}.`
+      : `Glideator estimates a ${percentage}% chance of ${getFlightPhrase(metric)} at ${displayName} on ${formattedDate}.`;
+  } else if (tab === 'season') {
+    title = `${displayName} flying season – Parra-Glideator`;
+    description = metric === 'XC0'
+      ? `See ${displayName}’s typical flying season, based on historical activity.`
+      : `See when ${displayName} is typically active for ${getPluralFlightPhrase(metric)}, based on historical activity.`;
+  } else if (tab === 'map') {
+    title = `${displayName} site map – Parra-Glideator`;
+    description = `See takeoffs and landings for ${displayName}.`;
+  } else if (tab === 'resources') {
+    title = `${displayName} flying resources – Parra-Glideator`;
+    description = `Local clubs, weather links, webcams and other flying resources for ${displayName}.`;
+  }
+
   const imageUrl = `${publicOrigin}/logo512.png`;
   const country = siteInfo?.country || site.tags?.find((tag) => typeof tag === 'string') || undefined;
-
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'Place',

--- a/frontend/src/components/SiteMetadata.test.jsx
+++ b/frontend/src/components/SiteMetadata.test.jsx
@@ -39,19 +39,28 @@ describe('SiteMetadata', () => {
     document.head.innerHTML = '';
   });
 
-  it('keeps canonical URLs stable while exposing selected forecast context in preview text', async () => {
+  it('uses human forecast wording while keeping canonical URLs stable', async () => {
     renderMetadata({ selectedDate: '2026-08-03', selectedMetric: 'XC20' });
 
-    await waitFor(() => expect(document.title).toContain('70% for XC20'));
+    await waitFor(() => expect(document.title).toContain('70% chance of a 20+ point flight'));
 
+    expect(document.title).not.toContain('XC20');
     expect(document.querySelector('link[rel="canonical"]')?.getAttribute('href'))
       .toBe(`${window.location.origin}/details/1`);
     expect(document.querySelector('meta[property="og:url"]')?.getAttribute('content'))
       .toBe(`${window.location.origin}/details/1`);
     expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content'))
-      .toContain('70% probability for XC20 activity at Raná');
+      .toContain('70% chance of a 20+ point flight at Raná');
     expect(document.querySelector('meta[property="og:image"]')?.getAttribute('content'))
       .toBe(`${window.location.origin}/logo512.png`);
+  });
+
+  it('describes the selected site section', async () => {
+    renderMetadata({ selectedTab: 'season', selectedMetric: 'XC20' });
+
+    await waitFor(() => expect(document.title).toBe('Raná flying season – Parra-Glideator'));
+    expect(document.querySelector('meta[property="og:description"]')?.getAttribute('content'))
+      .toContain('20+ point flights');
   });
 
   it('uses generic site metadata when no forecast date is selected', async () => {

--- a/frontend/src/pages/DetailsRoute.jsx
+++ b/frontend/src/pages/DetailsRoute.jsx
@@ -151,6 +151,7 @@ const DetailsRoute = () => {
         siteInfo={siteInfoQuery.data}
         selectedDate={hasExplicitForecastDate ? date : null}
         selectedMetric={metric}
+        selectedTab={tab}
       />
       {tab === 'forecast' && date && (
         <Box sx={{ maxWidth: '1200px', mx: 'auto', px: 2, pb: 2 }}>

--- a/frontend/src/pages/Layout.jsx
+++ b/frontend/src/pages/Layout.jsx
@@ -1,48 +1,49 @@
-import React, { useState, useEffect } from 'react';
-import { Outlet } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { Link as RouterLink, Outlet, useNavigate } from 'react-router-dom';
 import {
   AppBar,
-  Toolbar,
-  Typography,
   Box,
+  Divider,
+  Drawer,
   IconButton,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
   Menu,
   MenuItem,
-  Drawer,
-  List,
-  ListItemText,
-  ListItemIcon,
+  Toolbar,
+  Tooltip,
+  Typography,
   useMediaQuery,
   useTheme,
-  Divider,
-  ListItemButton,
-  Tooltip,
 } from '@mui/material';
 import AccountCircle from '@mui/icons-material/AccountCircle';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
 import CloseIcon from '@mui/icons-material/Close';
 import ExploreIcon from '@mui/icons-material/Explore';
+import FavoriteIcon from '@mui/icons-material/Favorite';
 import HomeIcon from '@mui/icons-material/Home';
 import InfoIcon from '@mui/icons-material/Info';
 import LogoutIcon from '@mui/icons-material/Logout';
 import MenuIcon from '@mui/icons-material/Menu';
-import FavoriteIcon from '@mui/icons-material/Favorite';
 import PersonIcon from '@mui/icons-material/Person';
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
-import SearchBar from '../components/SearchBar';
-import DisclaimerModal from '../components/DisclaimerModal';
-import NotificationDropdown from '../components/NotificationDropdown';
-import useDisclaimer from '../hooks/useDisclaimer';
+
 import { fetchSitesList } from '../api';
+import DisclaimerModal from '../components/DisclaimerModal';
+import GlobalShareAction from '../components/GlobalShareAction';
+import NotificationDropdown from '../components/NotificationDropdown';
+import SearchBar from '../components/SearchBar';
 import { useAuth } from '../context/AuthContext';
+import useDisclaimer from '../hooks/useDisclaimer';
 
 const Layout = () => {
   const [selectedSite, setSelectedSite] = useState(null);
   const [sites, setSites] = useState([]);
-  const { showDisclaimer, handleAccept, handleDecline } = useDisclaimer();
-  const { isAuthenticated, logout, user, profile } = useAuth();
   const [anchorEl, setAnchorEl] = useState(null);
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false);
+  const { showDisclaimer, handleAccept, handleDecline } = useDisclaimer();
+  const { isAuthenticated, logout, user, profile } = useAuth();
   const navigate = useNavigate();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -58,32 +59,20 @@ const Layout = () => {
   useEffect(() => {
     const loadSites = async () => {
       try {
-        const sitesData = await fetchSitesList();
-        setSites(sitesData);
+        setSites(await fetchSitesList());
       } catch (error) {
         console.error('Error loading sites:', error);
       }
     };
-
-    loadSites();
+    void loadSites();
   }, []);
 
-  const handleMenuOpen = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-  };
+  const handleMenuClose = () => setAnchorEl(null);
 
   const handleLogout = async () => {
     await logout();
     handleMenuClose();
     navigate('/');
-  };
-
-  const handleMobileDrawerToggle = () => {
-    setMobileDrawerOpen(!mobileDrawerOpen);
   };
 
   const handleMobileMenuClick = (path) => {
@@ -136,18 +125,15 @@ const Layout = () => {
       </Box>
 
       <Divider />
-
       <List sx={{ py: 1 }}>
         <ListItemButton onClick={() => handleMobileMenuClick('/')}>
           <ListItemIcon><HomeIcon /></ListItemIcon>
           <ListItemText primary="Home" />
         </ListItemButton>
-
         <ListItemButton onClick={() => handleMobileMenuClick('/trip-planner')}>
           <ListItemIcon><ExploreIcon /></ListItemIcon>
           <ListItemText primary="Plan a Trip" />
         </ListItemButton>
-
         <ListItemButton onClick={() => handleMobileMenuClick('/about')}>
           <ListItemIcon><InfoIcon /></ListItemIcon>
           <ListItemText primary="How It Works" />
@@ -155,7 +141,6 @@ const Layout = () => {
       </List>
 
       <Divider />
-
       <List sx={{ py: 1 }}>
         {isAuthenticated ? (
           <>
@@ -204,11 +189,7 @@ const Layout = () => {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
-      <DisclaimerModal
-        open={showDisclaimer}
-        onAccept={handleAccept}
-        onDecline={handleDecline}
-      />
+      <DisclaimerModal open={showDisclaimer} onAccept={handleAccept} onDecline={handleDecline} />
 
       <Drawer
         anchor="left"
@@ -233,7 +214,7 @@ const Layout = () => {
               color="inherit"
               aria-label="open menu"
               edge="start"
-              onClick={handleMobileDrawerToggle}
+              onClick={() => setMobileDrawerOpen((open) => !open)}
             >
               <MenuIcon />
             </IconButton>
@@ -256,10 +237,7 @@ const Layout = () => {
               style={{ height: 32, marginRight: isMobile ? 0 : 8 }}
             />
             {!isMobile && (
-              <Typography
-                variant="h6"
-                sx={{ color: 'white', fontWeight: 'bold' }}
-              >
+              <Typography variant="h6" sx={{ color: 'white', fontWeight: 'bold' }}>
                 Parra-Glideator
               </Typography>
             )}
@@ -267,10 +245,7 @@ const Layout = () => {
 
           {!isMobile && (
             <Box sx={{ ml: 3, flexGrow: 1, maxWidth: 400 }}>
-              <SearchBar
-                sites={sites}
-                onSiteSelect={setSelectedSite}
-              />
+              <SearchBar sites={sites} onSiteSelect={setSelectedSite} />
             </Box>
           )}
 
@@ -279,46 +254,33 @@ const Layout = () => {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
             {!isMobile && (
               <Tooltip title="Plan a Trip">
-                <IconButton
-                  component={RouterLink}
-                  to="/trip-planner"
-                  color="inherit"
-                >
+                <IconButton component={RouterLink} to="/trip-planner" color="inherit">
                   <ExploreIcon />
                 </IconButton>
               </Tooltip>
             )}
-
             {!isMobile && (
               <Tooltip title="How It Works">
-                <IconButton
-                  component={RouterLink}
-                  to="/about"
-                  color="inherit"
-                >
+                <IconButton component={RouterLink} to="/about" color="inherit">
                   <InfoIcon />
                 </IconButton>
               </Tooltip>
             )}
-
             {!isMobile && isAuthenticated && (
               <Tooltip title="Favorites">
-                <IconButton
-                  component={RouterLink}
-                  to="/favorites"
-                  color="inherit"
-                >
+                <IconButton component={RouterLink} to="/favorites" color="inherit">
                   <FavoriteIcon />
                 </IconButton>
               </Tooltip>
             )}
 
+            <GlobalShareAction />
             <NotificationDropdown iconColor="inherit" />
 
             {isAuthenticated ? (
               <>
                 <Tooltip title="Account">
-                  <IconButton color="inherit" onClick={handleMenuOpen}>
+                  <IconButton color="inherit" onClick={(event) => setAnchorEl(event.currentTarget)}>
                     <AccountCircle />
                   </IconButton>
                 </Tooltip>
@@ -330,9 +292,7 @@ const Layout = () => {
                   transformOrigin={{ vertical: 'top', horizontal: 'right' }}
                 >
                   <MenuItem disabled sx={{ opacity: 1 }}>
-                    <Typography variant="body2" color="text.secondary">
-                      {displayLabel}
-                    </Typography>
+                    <Typography variant="body2" color="text.secondary">{displayLabel}</Typography>
                   </MenuItem>
                   <Divider />
                   {isAdmin && (
@@ -354,11 +314,7 @@ const Layout = () => {
             ) : (
               !isMobile && (
                 <Tooltip title="Log In">
-                  <IconButton
-                    component={RouterLink}
-                    to="/login"
-                    color="inherit"
-                  >
+                  <IconButton component={RouterLink} to="/login" color="inherit">
                     <PersonIcon />
                   </IconButton>
                 </Tooltip>
@@ -422,11 +378,7 @@ const Layout = () => {
             to="/feedback"
             variant={isMobile ? 'caption' : 'body2'}
             color="inherit"
-            sx={{
-              color: 'white',
-              textDecoration: 'none',
-              '&:hover': { textDecoration: 'underline' },
-            }}
+            sx={{ color: 'white', textDecoration: 'none', '&:hover': { textDecoration: 'underline' } }}
           >
             Feedback
           </Typography>

--- a/frontend/src/utils/shareUtils.js
+++ b/frontend/src/utils/shareUtils.js
@@ -1,0 +1,193 @@
+export const METRICS = [
+  'XC0',
+  'XC10',
+  'XC20',
+  'XC30',
+  'XC40',
+  'XC50',
+  'XC60',
+  'XC70',
+  'XC80',
+  'XC90',
+  'XC100',
+];
+
+const PUBLIC_ORIGIN = process.env.REACT_APP_PUBLIC_ORIGIN || 'https://www.parra-glideator.com';
+
+export const normalizeMetric = (metric) => (METRICS.includes(metric) ? metric : 'XC0');
+
+export const getMetricThreshold = (metric) => {
+  const normalized = normalizeMetric(metric);
+  return normalized === 'XC0' ? 0 : Number.parseInt(normalized.replace('XC', ''), 10);
+};
+
+const indefiniteArticle = (threshold) => (threshold === 80 ? 'an' : 'a');
+
+export const getFlightPhrase = (metric, { article = true } = {}) => {
+  const threshold = getMetricThreshold(metric);
+  if (threshold === 0) return article ? 'a flight' : 'flight';
+  const noun = `${threshold}+ point flight`;
+  return article ? `${indefiniteArticle(threshold)} ${noun}` : noun;
+};
+
+export const getPluralFlightPhrase = (metric) => {
+  const threshold = getMetricThreshold(metric);
+  return threshold === 0 ? 'flights' : `${threshold}+ point flights`;
+};
+
+export const getChanceLabel = (metric, { plural = false, capitalize = true } = {}) => {
+  const prefix = plural ? 'Chances' : 'Chance';
+  const label = `${prefix} of ${getFlightPhrase(metric)}`;
+  return capitalize ? label : `${label.charAt(0).toLowerCase()}${label.slice(1)}`;
+};
+
+export const formatShareDate = (value, { includeYear = false } = {}) => {
+  if (!value) return 'the selected date';
+  const parsed = value instanceof Date ? value : new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) return String(value);
+
+  return new Intl.DateTimeFormat('en', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    ...(includeYear ? { year: 'numeric' } : {}),
+    timeZone: 'UTC',
+  }).format(parsed);
+};
+
+const formatRangePart = (date, options) => new Intl.DateTimeFormat('en', {
+  day: 'numeric',
+  month: options.month,
+  ...(options.year ? { year: 'numeric' } : {}),
+  timeZone: 'UTC',
+}).format(date);
+
+export const formatShareDateRange = (startValue, endValue) => {
+  if (!startValue || !endValue) return 'the selected dates';
+  const start = new Date(`${startValue}T00:00:00Z`);
+  const end = new Date(`${endValue}T00:00:00Z`);
+  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+    return `${startValue}–${endValue}`;
+  }
+
+  if (start.getTime() === end.getTime()) return formatShareDate(startValue);
+
+  const sameMonth = start.getUTCFullYear() === end.getUTCFullYear()
+    && start.getUTCMonth() === end.getUTCMonth();
+  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
+
+  if (sameMonth) {
+    const monthYear = new Intl.DateTimeFormat('en', {
+      month: 'long',
+      ...(start.getUTCFullYear() !== new Date().getUTCFullYear() ? { year: 'numeric' } : {}),
+      timeZone: 'UTC',
+    }).format(end);
+    return `${start.getUTCDate()}–${end.getUTCDate()} ${monthYear}`;
+  }
+
+  return `${formatRangePart(start, { month: 'long', year: !sameYear })}–${formatRangePart(end, {
+    month: 'long',
+    year: !sameYear || end.getUTCFullYear() !== new Date().getUTCFullYear(),
+  })}`;
+};
+
+const normalizeOrigin = (origin) => String(origin || PUBLIC_ORIGIN).replace(/\/$/, '');
+
+const validCoordinate = (value, min, max) => Number.isFinite(value) && value >= min && value <= max;
+
+export const buildMapShareUrl = ({ origin, search, selectedDate, selectedMetric }) => {
+  const source = search instanceof URLSearchParams ? search : new URLSearchParams(search || '');
+  const params = new URLSearchParams();
+
+  if (selectedDate) params.set('date', selectedDate);
+  params.set('metric', normalizeMetric(selectedMetric));
+
+  const latitude = Number(source.get('lat'));
+  const longitude = Number(source.get('lng'));
+  if (validCoordinate(latitude, -90, 90) && validCoordinate(longitude, -180, 180)) {
+    params.set('lat', latitude.toFixed(2));
+    params.set('lng', longitude.toFixed(2));
+  }
+
+  const zoom = Number(source.get('zoom'));
+  if (Number.isFinite(zoom)) params.set('zoom', String(Math.round(zoom)));
+
+  const mapType = source.get('mapType');
+  if (mapType) params.set('mapType', mapType);
+
+  return `${normalizeOrigin(origin)}/?${params.toString()}`;
+};
+
+export const buildDetailsShareUrl = ({ origin, siteId, tab = 'forecast', selectedDate, selectedMetric }) => {
+  const params = new URLSearchParams();
+  const normalizedTab = ['forecast', 'season', 'map', 'resources'].includes(tab) ? tab : 'forecast';
+
+  if (normalizedTab === 'forecast') {
+    if (selectedDate) params.set('date', selectedDate);
+    params.set('metric', normalizeMetric(selectedMetric));
+  } else if (normalizedTab === 'season') {
+    params.set('metric', normalizeMetric(selectedMetric));
+    params.set('tab', 'season');
+  } else {
+    params.set('tab', normalizedTab);
+  }
+
+  const query = params.toString();
+  return `${normalizeOrigin(origin)}/details/${encodeURIComponent(siteId)}${query ? `?${query}` : ''}`;
+};
+
+const TRIP_PARAMS = [
+  'startDate',
+  'endDate',
+  'fqEnabled',
+  'altEnabled',
+  'altMin',
+  'altMax',
+  'view',
+  'sortBy',
+  'tags',
+  'distEnabled',
+  'distKm',
+  'locSrc',
+];
+
+export const buildTripPlanShareUrl = ({
+  origin,
+  search,
+  selectedMetric,
+  approximateOrigin = null,
+  includeDistance = true,
+}) => {
+  const source = search instanceof URLSearchParams ? search : new URLSearchParams(search || '');
+  const params = new URLSearchParams();
+
+  TRIP_PARAMS.forEach((key) => {
+    const value = source.get(key);
+    if (value != null && value !== '') params.set(key, value);
+  });
+  params.set('metric', normalizeMetric(selectedMetric));
+
+  if (!includeDistance) {
+    ['distEnabled', 'distKm', 'locSrc', 'originLat', 'originLng'].forEach((key) => params.delete(key));
+    if (params.get('sortBy') === 'distance') params.delete('sortBy');
+  } else if (approximateOrigin) {
+    params.set('distEnabled', 'true');
+    params.set('locSrc', 'current');
+    params.set('originLat', Number(approximateOrigin.latitude).toFixed(2));
+    params.set('originLng', Number(approximateOrigin.longitude).toFixed(2));
+  }
+
+  return `${normalizeOrigin(origin)}/trip-planner?${params.toString()}`;
+};
+
+export const buildAboutShareUrl = ({ origin, hash = '' }) => (
+  `${normalizeOrigin(origin)}/about${hash && hash.startsWith('#') ? hash : ''}`
+);
+
+export const getForecastProbability = ({ predictions, selectedDate, selectedMetric }) => {
+  const index = METRICS.indexOf(normalizeMetric(selectedMetric));
+  if (!selectedDate || !Array.isArray(predictions)) return null;
+  const prediction = predictions.find((item) => item?.date === selectedDate);
+  const value = prediction?.values?.[index];
+  return Number.isFinite(value) ? value : null;
+};

--- a/frontend/src/utils/shareUtils.js
+++ b/frontend/src/utils/shareUtils.js
@@ -173,8 +173,8 @@ export const buildTripPlanShareUrl = ({
   } else if (approximateOrigin) {
     params.set('distEnabled', 'true');
     params.set('locSrc', 'current');
-    params.set('originLat', Number(approximateOrigin.latitude).toFixed(2));
-    params.set('originLng', Number(approximateOrigin.longitude).toFixed(2));
+    params.set('originLat', Number(approximateOrigin.latitude).toFixed(1));
+    params.set('originLng', Number(approximateOrigin.longitude).toFixed(1));
   }
 
   return `${normalizeOrigin(origin)}/trip-planner?${params.toString()}`;

--- a/frontend/src/utils/shareUtils.test.js
+++ b/frontend/src/utils/shareUtils.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDetailsShareUrl,
+  buildMapShareUrl,
+  buildTripPlanShareUrl,
+  formatShareDateRange,
+  getChanceLabel,
+  getFlightPhrase,
+} from './shareUtils';
+
+describe('shareUtils', () => {
+  it('turns internal metric keys into pilot-facing language', () => {
+    expect(getChanceLabel('XC0')).toBe('Chance of a flight');
+    expect(getChanceLabel('XC20')).toBe('Chance of a 20+ point flight');
+    expect(getFlightPhrase('XC80')).toBe('an 80+ point flight');
+  });
+
+  it('creates clean links for each details section', () => {
+    expect(buildDetailsShareUrl({
+      origin: 'https://example.test/',
+      siteId: 1,
+      tab: 'forecast',
+      selectedDate: '2026-08-03',
+      selectedMetric: 'XC20',
+    })).toBe('https://example.test/details/1?date=2026-08-03&metric=XC20');
+
+    expect(buildDetailsShareUrl({
+      origin: 'https://example.test',
+      siteId: 1,
+      tab: 'season',
+      selectedMetric: 'XC20',
+    })).toBe('https://example.test/details/1?metric=XC20&tab=season');
+
+    expect(buildDetailsShareUrl({
+      origin: 'https://example.test',
+      siteId: 1,
+      tab: 'resources',
+    })).toBe('https://example.test/details/1?tab=resources');
+  });
+
+  it('rounds map coordinates and strips unrelated state', () => {
+    expect(buildMapShareUrl({
+      origin: 'https://example.test',
+      search: '?date=2026-08-03&metric=XC20&lat=50.12345&lng=14.98765&zoom=7.8&mapType=topographic&campaign=pilot',
+      selectedDate: '2026-08-03',
+      selectedMetric: 'XC20',
+    })).toBe('https://example.test/?date=2026-08-03&metric=XC20&lat=50.12&lng=14.99&zoom=8&mapType=topographic');
+  });
+
+  it('shares a coarse trip origin or removes the location-dependent filters', () => {
+    const search = '?startDate=2026-08-03&endDate=2026-08-05&distEnabled=true&distKm=200&locSrc=current&sortBy=distance&tags=ridge';
+
+    expect(buildTripPlanShareUrl({
+      origin: 'https://example.test',
+      search,
+      selectedMetric: 'XC20',
+      includeDistance: true,
+      approximateOrigin: { latitude: 50.0875, longitude: 14.4213 },
+    })).toBe('https://example.test/trip-planner?startDate=2026-08-03&endDate=2026-08-05&sortBy=distance&tags=ridge&distEnabled=true&distKm=200&locSrc=current&metric=XC20&originLat=50.1&originLng=14.4');
+
+    expect(buildTripPlanShareUrl({
+      origin: 'https://example.test',
+      search,
+      selectedMetric: 'XC20',
+      includeDistance: false,
+    })).toBe('https://example.test/trip-planner?startDate=2026-08-03&endDate=2026-08-05&tags=ridge&metric=XC20');
+  });
+
+  it('formats compact ranges for share copy', () => {
+    expect(formatShareDateRange('2026-08-03', '2026-08-05')).toBe('3–5 August 2026');
+  });
+});

--- a/frontend/src/utils/shareUtils.test.js
+++ b/frontend/src/utils/shareUtils.test.js
@@ -68,6 +68,6 @@ describe('shareUtils', () => {
   });
 
   it('formats compact ranges for share copy', () => {
-    expect(formatShareDateRange('2026-08-03', '2026-08-05')).toBe('3–5 August 2026');
+    expect(formatShareDateRange('2030-08-03', '2030-08-05')).toBe('3–5 August 2030');
   });
 });


### PR DESCRIPTION
## What changed

- move sharing into the global top bar, immediately before notifications, on mobile and desktop
- expose sharing only on public shareable pages: forecast map, site details, trip planner, and How It Works
- tailor the tooltip, title, message, URL, and analytics event to the current page and Details tab
- replace internal metric keys in user-facing share copy and social previews with phrases such as `chance of a 20+ point flight`
- support Details sharing for Forecast, Season, Site Map, and Resources
- preserve map date, threshold, map type, zoom, and privacy-rounded map center
- let distance-filtered trip plans be shared with a coarse starting area or without location
- make shared trip origins reproducible when the recipient opens or refreshes the link
- retire the old inline Details share button
- update metadata, assistive forecast labels, unit tests, crawler expectations, and Playwright sharing journeys

## Copy

No safety disclaimer is added to shared text. Internal values such as `XC20` remain in URLs and analytics only; user-facing copy uses the same flight-language as the charts.

## Validation

CI run #114 is green:

- frontend tests and coverage
- client and SSR production builds
- backend tests and coverage
- complete Playwright smoke and crawler suite