### PR TITLE
Prepare Glideator MCP for public ChatGPT plugin

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,31 @@
+{
+  "name": "parra-glideator",
+  "version": "0.1.0",
+  "description": "Read-only paragliding planning tools powered by Parra-Glideator forecast-derived XC potential and site data.",
+  "homepage": "https://www.parra-glideator.com/about#mcp",
+  "repository": "https://github.com/janhelcl/glideator",
+  "license": "MIT",
+  "keywords": [
+    "paragliding",
+    "weather",
+    "forecast",
+    "xc",
+    "trip-planning"
+  ],
+  "interface": {
+    "displayName": "Parra-Glideator",
+    "shortDescription": "Compare paragliding sites and forecast-derived XC potential.",
+    "longDescription": "Use Parra-Glideator's read-only MCP tools to compare paragliding sites for specific dates, inspect forecast-derived XC potential and historical seasonality, find takeoffs and landings, and discover curated local resources. Decision support only: verify current conditions, local rules, airspace, access, and pilot suitability before flying.",
+    "capabilities": [
+      "Read"
+    ],
+    "websiteURL": "https://www.parra-glideator.com",
+    "privacyPolicyURL": "https://www.parra-glideator.com/privacy",
+    "termsOfServiceURL": "https://www.parra-glideator.com/terms",
+    "defaultPrompt": [
+      "Use Parra-Glideator to find the most promising paragliding sites for this weekend.",
+      "Use Parra-Glideator to compare 50-point XC potential for paragliding sites near me next week."
+    ],
+    "brandColor": "#2E7D32"
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -16,6 +16,7 @@
     "displayName": "Parra-Glideator",
     "shortDescription": "Compare paragliding sites and forecast-derived XC potential.",
     "longDescription": "Use Parra-Glideator's read-only MCP tools to compare paragliding sites for specific dates, inspect forecast-derived XC potential and historical seasonality, find takeoffs and landings, and discover curated local resources. Decision support only: verify current conditions, local rules, airspace, access, and pilot suitability before flying.",
+    "category": "Travel",
     "capabilities": [
       "Read"
     ],

--- a/backend/app/mcp.py
+++ b/backend/app/mcp.py
@@ -1,115 +1,128 @@
-from typing import List, Dict, Optional
 from datetime import datetime
+from typing import Dict, List, Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 from pydantic import TypeAdapter
-from app import crud
+
+from app import crud, schemas
 from app.database import AsyncSessionLocal
-from app import schemas
 from app.services import trip_planner_service
 
 
-mcp = FastMCP("Glideator-MCP")
+READ_ONLY_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    openWorldHint=False,
+)
+
+mcp = FastMCP(
+    "Parra-Glideator",
+    instructions=(
+        "Read-only paragliding planning data from Parra-Glideator. Use these tools to compare "
+        "forecast-derived flight and XC potential, historical seasonality, launch/landing data, "
+        "and curated local resources. The results are decision support, not a determination that "
+        "conditions are safe or legal to fly. Users must verify current weather, local rules, "
+        "airspace, site access, and suitability for their skills and equipment before flying."
+    ),
+)
 
 
-@mcp.tool()
+@mcp.tool(title="Find paragliding sites", annotations=READ_ONLY_ANNOTATIONS)
+async def find_sites(query: str, limit: int = 10) -> List[schemas.SiteListItem]:
+    """Use this when the user names or searches for a paragliding site and you need its site ID.
+
+    Performs a case-insensitive name match against Parra-Glideator's site directory. Prefer this
+    over list_sites when the user already supplied a site or place name.
+
+    Args:
+        query: Full or partial site name, for example "Bassano", "Rana", or "Annecy".
+        limit: Maximum matches to return. Must be between 1 and 50.
+    """
+    cleaned_query = query.strip().casefold()
+    if not cleaned_query:
+        raise ValueError("query must not be empty")
+    if limit < 1 or limit > 50:
+        raise ValueError("limit must be between 1 and 50")
+
+    async with AsyncSessionLocal() as db:
+        sites_raw = await crud.get_site_list(db)
+
+    matches = [
+        {"site_id": row.site_id, "name": row.name}
+        for row in sites_raw
+        if cleaned_query in row.name.casefold()
+    ]
+    matches.sort(
+        key=lambda site: (
+            not site["name"].casefold().startswith(cleaned_query),
+            len(site["name"]),
+            site["name"].casefold(),
+        )
+    )
+
+    adapter = TypeAdapter(List[schemas.SiteListItem])
+    return adapter.validate_python(matches[:limit])
+
+
+@mcp.tool(title="List paragliding sites", annotations=READ_ONLY_ANNOTATIONS)
 async def list_sites() -> List[schemas.SiteListItem]:
-    """Get a complete list of all available paragliding sites with their IDs and names.
-    
-    This tool provides a directory of all paragliding sites in the database. Use this
-    when users want to browse available sites, need to find a specific site by name,
-    or want to get site IDs for use with other tools.
-    
-    Returns:
-        List of sites with site_id and name. Use the site_id with other tools to get
-        detailed information, forecasts, or statistics for specific sites.
-    
-    Use this when users ask about:
-    - "What paragliding sites are available?"
-    - "Show me all flying sites"
-    - "List paragliding locations"
-    - "What sites do you have data for?"
+    """Use this when the user wants to browse all paragliding sites covered by Parra-Glideator.
+
+    Returns the complete site directory with stable site IDs and names. If the user already named
+    a specific site, prefer find_sites to avoid returning the full directory.
     """
     async with AsyncSessionLocal() as db:
         sites_raw = await crud.get_site_list(db)
-    
-    # Use TypeAdapter to convert SQLAlchemy Row objects to Pydantic schemas
+
     adapter = TypeAdapter(List[schemas.SiteListItem])
     sites_data = [{"site_id": row.site_id, "name": row.name} for row in sites_raw]
-    sites = adapter.validate_python(sites_data)
-    return sites
+    return adapter.validate_python(sites_data)
 
 
-@mcp.tool()
+@mcp.tool(title="Get site resources", annotations=READ_ONLY_ANNOTATIONS)
 async def get_site_resources(site_id: int) -> dict:
-    """Get local resources for a paragliding site — club pages, webcams, and meteostations.
+    """Use this when the user wants practical local links for a known paragliding site.
 
-    Returns curated links discovered and validated by our ground-crew agents.
-    Useful when a user wants practical links for planning a visit: live webcams to
-    check current conditions, nearby meteostations for real-time wind/weather data,
-    and local club or site pages with rules, fees, and access information.
+    Returns curated club/site pages, webcams, and meteostation links already stored by
+    Parra-Glideator. This tool does not browse those external sites or change external state.
 
     Args:
-        site_id: Unique identifier of the site (get from list_sites tool)
-
-    Returns:
-        SiteResourcesResponse containing:
-        - local_resources: list of validated club/site pages (name, url, and what
-          info each page covers such as rules, fees, access, webcams, meteostation)
-        - webcam_urls: live webcam links near the site
-        - meteostation_urls: nearby meteostation pages
-
-    Use this when users ask about:
-    - "Are there webcams at [site]?"
-    - "Where can I check live wind at [site]?"
-    - "Is there a local club page for [site]?"
-    - "Meteostation near [site]?"
-    - "Local resources for [site]"
+        site_id: Parra-Glideator site ID. Use find_sites when the ID is unknown.
     """
     async with AsyncSessionLocal() as db:
         resources = await crud.get_site_resources(db, site_id)
     return resources.model_dump(exclude={"source_run_id", "run_extracted_at"})
 
 
-@mcp.tool()
+@mcp.tool(title="Get site seasonal statistics", annotations=READ_ONLY_ANNOTATIONS)
 async def get_site_seasonal_stats(site_id: int) -> Dict[str, Dict[str, float]]:
-    """Get historical flying statistics showing seasonal patterns for a paragliding site.
-    
-    This tool provides historical data showing how many flyable days each month typically
-    has at a specific site, broken down by different XC (cross-country) performance levels.
-    Perfect for understanding the best months to visit a site or comparing seasonal patterns.
-    
+    """Use this when the user asks when a paragliding site historically performs best.
+
+    Returns average days per month reaching XC activity thresholds from 0 through 100 points.
+    These are historical flight-activity statistics, not a safety assessment or future forecast.
+
     Args:
-        site_id: Unique identifier of the site (get from list_sites tool)
-    
-    Returns:
-        Dictionary with month names as keys ("January" to "December"), each containing
-        XC threshold statistics:
-        - 'days_over_0XC_points_or_more': average days with any flyable conditions
-        - 'days_over_10XC_points_or_more': average days suitable for 10+ XC point flights  
-        - 'days_over_20XC_points_or_more': average days for 20+ XC point flights
-        - ... up to 'days_over_100XC_points_or_more' for exceptional conditions
-        
-        Higher XC thresholds indicate better thermal/soaring conditions for longer flights.
-    
-    Use this when users ask about:
-    - "What's the best season to fly at [site]?"
-    - "When is [site] most flyable?"
-    - "How many flying days per month at [site]?"
-    - "Compare seasonal conditions at [site]"
-    - "Is [site] good in winter/summer?"
+        site_id: Parra-Glideator site ID. Use find_sites when the ID is unknown.
     """
     async with AsyncSessionLocal() as db:
         site_seasonal_stats = await crud.get_flight_stats_by_site_id(db, site_id)
-    
-    # Month mapping
+
     month_names = {
-        1: "January", 2: "February", 3: "March", 4: "April",
-        5: "May", 6: "June", 7: "July", 8: "August", 
-        9: "September", 10: "October", 11: "November", 12: "December"
+        1: "January",
+        2: "February",
+        3: "March",
+        4: "April",
+        5: "May",
+        6: "June",
+        7: "July",
+        8: "August",
+        9: "September",
+        10: "October",
+        11: "November",
+        12: "December",
     }
-    
-    # Build the result dictionary
+
     result = {}
     for stats in site_seasonal_stats:
         month_name = month_names[stats.month]
@@ -126,115 +139,91 @@ async def get_site_seasonal_stats(site_id: int) -> Dict[str, Dict[str, float]]:
             "days_over_90XC_points_or_more": stats.avg_days_over_90,
             "days_over_100XC_points_or_more": stats.avg_days_over_100,
         }
-    
+
     return result
 
 
-@mcp.tool()
-async def get_site_predictions(site_id: int, query_date: Optional[str] = None) -> Dict[str, Dict[str, float]]:
-    """Get weather-based flying forecasts for a specific paragliding site.
-    
-    This tool provides ML-powered predictions of flyability conditions based on weather
-    forecasts. Shows probability of different flight performance levels for upcoming days.
-    Forecasts are typically available for the next 7 days from today.
-    
+@mcp.tool(title="Get site flight-potential forecast", annotations=READ_ONLY_ANNOTATIONS)
+async def get_site_predictions(
+    site_id: int,
+    query_date: Optional[str] = None,
+) -> Dict[str, Dict[str, float]]:
+    """Use this when the user asks about forecast-derived paragliding potential at one site.
+
+    Returns modelled probabilities for XC activity thresholds from 0 through 100 points. Forecasts
+    are typically available for the next seven days. A high probability means the forecast looks
+    similar to weather associated with that level of past flight activity; it does not mean the
+    site is safe, legal, or suitable for a particular pilot.
+
     Args:
-        site_id: Unique identifier of the site (get from list_sites tool)
-        query_date: Optional specific date to get forecast for, in 'YYYY-MM-DD' format
-                   (e.g., '2024-03-15'). If not provided, returns all available forecasts.
-    
-    Returns:
-        Dictionary with ISO dates ('YYYY-MM-DD') as keys, each containing probability
-        predictions for different XC performance thresholds:
-        - 'probability_of_flight_over_0XC_points_or_more': probability of any flyable conditions
-        - 'probability_of_flight_over_10XC_points_or_more': probability of 10+ XC point flights
-        - 'probability_of_flight_over_20XC_points_or_more': probability of 20+ XC point flights  
-        - ... up to 'probability_of_flight_over_100XC_points_or_more'
-        
-        Probabilities range from 0.0 (impossible) to 1.0 (certain). Higher XC thresholds
-        indicate better thermal conditions for cross-country flying.
-    
-    Use this when users ask about:
-    - "What's the weather forecast for [site]?"
-    - "Will it be flyable at [site] tomorrow?"
-    - "Flying conditions for [site] this week"
-    - "Probability of good thermals at [site]"
-    - "Should I go to [site] on [specific date]?"
+        site_id: Parra-Glideator site ID. Use find_sites when the ID is unknown.
+        query_date: Optional date in YYYY-MM-DD format. Omit to return all available forecast dates.
     """
     async with AsyncSessionLocal() as db:
-        # Convert string date to date object if provided
         date_filter = None
         if query_date:
             try:
                 date_filter = datetime.strptime(query_date, "%Y-%m-%d").date()
-            except ValueError:
-                raise ValueError("Date must be in YYYY-MM-DD format")
-        
+            except ValueError as exc:
+                raise ValueError("query_date must be in YYYY-MM-DD format") from exc
+
         predictions = await crud.get_predictions(db, site_id, query_date=date_filter)
-    
+
     if not predictions:
         return {}
-    
-    # Group predictions by date
+
     result = {}
     for pred in predictions:
         date_str = pred.date.strftime("%Y-%m-%d")
         if date_str not in result:
             result[date_str] = {}
-        
-        # Transform metric name to more descriptive key
-        # Extract the number from metric like "XC0", "XC10", etc.
+
         if pred.metric.startswith("XC"):
-            points = pred.metric[2:]  # Remove "XC" prefix
+            points = pred.metric[2:]
             descriptive_key = f"probability_of_flight_over_{points}XC_points_or_more"
         else:
-            # Fallback for any non-XC metrics
             descriptive_key = pred.metric
-            
+
         result[date_str][descriptive_key] = pred.value
-    
+
     return result
 
 
-@mcp.tool()
+@mcp.tool(title="Get site takeoffs and landings", annotations=READ_ONLY_ANNOTATIONS)
 async def get_site_takeoffs_and_landings(site_id: int) -> List[schemas.Spot]:
-    """Get all takeoff and landing locations associated with a paragliding site.
-    
-    This tool provides detailed information about all launch and landing spots at a site,
-    including their exact coordinates, elevation, directions, and characteristics.
-    Essential for flight planning and understanding site layout.
-    
+    """Use this when the user asks where launches or landings are at a known paragliding site.
+
+    Returns stored coordinates, elevation, spot type, and suitable wind-direction metadata where
+    available. Treat this as orientation data only; users must verify current site rules, access,
+    obstacles, and local conditions before use.
+
     Args:
-        site_id: Unique identifier of the site (get from list_sites tool)
-    
-    Returns:
-        List of Spot objects containing detailed information for each takeoff/landing:
-        - Coordinates (latitude/longitude) 
-        - Elevation
-        - Spot type (takeoff/landing)
-        - Suitable wind direction
-    
-    Use this when users ask about:
-    - "Where are the takeoffs at [site]?"
-    - "Show me landing options for [site]"
-    - "What are the coordinates of [site] launch points?"
-    - "Which direction does [site] face?"
-    - "How many takeoffs does [site] have?"
-    - "Where can I land at [site]?"
+        site_id: Parra-Glideator site ID. Use find_sites when the ID is unknown.
     """
     async with AsyncSessionLocal() as db:
         spots_models = await crud.get_spots_by_site_id(db, site_id)
-    
+
     adapter = TypeAdapter(List[schemas.Spot])
-    spots = adapter.validate_python(spots_models)
-    return spots
+    return adapter.validate_python(spots_models)
 
 
-@mcp.tool()
+@mcp.tool(title="Plan a paragliding trip", annotations=READ_ONLY_ANNOTATIONS)
 async def plan_trip(
     start_date: str,
     end_date: str,
-    metric: str = 'XC0',
+    metric: Literal[
+        "XC0",
+        "XC10",
+        "XC20",
+        "XC30",
+        "XC40",
+        "XC50",
+        "XC60",
+        "XC70",
+        "XC80",
+        "XC90",
+        "XC100",
+    ] = "XC0",
     user_latitude: Optional[float] = None,
     user_longitude: Optional[float] = None,
     max_distance_km: Optional[float] = None,
@@ -242,55 +231,55 @@ async def plan_trip(
     max_altitude_m: Optional[int] = None,
     required_tags: Optional[List[str]] = None,
     offset: int = 0,
-    limit: int = 10
+    limit: int = 10,
 ) -> schemas.TripPlanResponse:
-    """Find the best paragliding sites for a trip over a specific date range.
-    
-    This tool analyzes both weather forecasts (next 7 days) and historical flight data 
-    to recommend paragliding sites with the highest flyability probability. Perfect for 
-    planning paragliding trips, finding good flying conditions, or comparing sites.
-    
+    """Use this when the user wants to compare or rank paragliding sites for specific dates.
+
+    Combines forecast-derived flight/XC potential for near-term dates with historical fallback data
+    and ranks matching sites. This is the primary tool for questions such as "Where should I look
+    at flying this weekend?" or "Which sites have the strongest 50-point XC signal next week?"
+
+    Do not present the ranking as a safety or go/no-go recommendation. The user must still verify
+    current weather, airspace, local rules, access, and suitability for their skills and equipment.
+
     Args:
-        start_date: Trip start date in 'YYYY-MM-DD' format (e.g., '2024-03-15')
-        end_date: Trip end date in 'YYYY-MM-DD' format (e.g., '2024-03-20')
-        metric: XC points threshold - 'XC0' for any flyable day, 'XC10' for 10+ XC points,
-                up to 'XC100'. Higher thresholds = better/longer flight conditions.
-        user_latitude: Your latitude in decimal degrees (e.g., 46.8182) to calculate distances
-        user_longitude: Your longitude in decimal degrees (e.g., 8.2275) to calculate distances  
-        max_distance_km: Only show sites within this distance from your location (kilometers)
-        min_altitude_m: Minimum site altitude in meters (useful for avoiding low valleys)
-        max_altitude_m: Maximum site altitude in meters (useful for avoiding extreme elevations)
-        required_tags: List of required site characteristics. Common tags include:
-                - 'car': takeoff accessible by car
-                - 'lift': takeoff accessible by lift/chair or cable car  
-                - 'shuttle': official shuttle service available
-                - 'Alps': site located in the Alps
-                - 'Pyrenees': site located in the Pyrenees
-                - 'Appennines': site located in the Apennines
-                - 'flats': site located in flatlands
-                - 'mountaines': site located in mountains
-        offset: Skip this many results (for pagination)
-        limit: Maximum number of sites to return (default 10)
-    
-    Returns:
-        Ranked list of sites with their average flyability probability, daily forecasts,
-        coordinates, altitude, and distance from user location if provided. Sites are 
-        sorted by flyability score (highest probability first).
-    
-    Use this when users ask about:
-    - "Where should I fly next week?"
-    - "Best sites for a 3-day paragliding trip"  
-    - "Flying spots near [location] with good weather"
-    - "Compare sites for specific dates"
+        start_date: Trip start date in YYYY-MM-DD format.
+        end_date: Trip end date in YYYY-MM-DD format.
+        metric: XC activity threshold to optimize, from XC0 through XC100 in 10-point steps.
+        user_latitude: Optional origin latitude used for distance filtering/ranking.
+        user_longitude: Optional origin longitude used for distance filtering/ranking.
+        max_distance_km: Optional maximum straight-line distance from the supplied origin.
+        min_altitude_m: Optional minimum site altitude in metres.
+        max_altitude_m: Optional maximum site altitude in metres.
+        required_tags: Optional site tags such as "car", "lift", "shuttle", "Alps", or "flats".
+        offset: Number of ranked results to skip for pagination.
+        limit: Maximum number of ranked sites to return.
     """
     try:
         start = datetime.strptime(start_date, "%Y-%m-%d").date()
         end = datetime.strptime(end_date, "%Y-%m-%d").date()
-    except ValueError:
-        raise ValueError("Dates must be in YYYY-MM-DD format")
+    except ValueError as exc:
+        raise ValueError("start_date and end_date must be in YYYY-MM-DD format") from exc
+
+    if start > end:
+        raise ValueError("start_date must be on or before end_date")
+    if (user_latitude is None) != (user_longitude is None):
+        raise ValueError("user_latitude and user_longitude must be supplied together")
+    if user_latitude is not None and not -90 <= user_latitude <= 90:
+        raise ValueError("user_latitude must be between -90 and 90")
+    if user_longitude is not None and not -180 <= user_longitude <= 180:
+        raise ValueError("user_longitude must be between -180 and 180")
+    if max_distance_km is not None and max_distance_km <= 0:
+        raise ValueError("max_distance_km must be greater than 0")
+    if min_altitude_m is not None and max_altitude_m is not None and min_altitude_m > max_altitude_m:
+        raise ValueError("min_altitude_m must be on or below max_altitude_m")
+    if offset < 0:
+        raise ValueError("offset must be 0 or greater")
+    if limit < 1 or limit > 100:
+        raise ValueError("limit must be between 1 and 100")
 
     async with AsyncSessionLocal() as db:
-        response = await trip_planner_service.plan_trip_service(
+        return await trip_planner_service.plan_trip_service(
             db=db,
             start_date=start,
             end_date=end,
@@ -302,7 +291,5 @@ async def plan_trip(
             max_altitude_m=max_altitude_m,
             required_tags=required_tags,
             offset=offset,
-            limit=limit
+            limit=limit,
         )
-
-    return response

--- a/backend/tests/test_mcp_metadata.py
+++ b/backend/tests/test_mcp_metadata.py
@@ -1,0 +1,56 @@
+import os
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
+
+from app.mcp import mcp
+
+
+EXPECTED_TOOLS = {
+    "find_sites",
+    "list_sites",
+    "get_site_resources",
+    "get_site_seasonal_stats",
+    "get_site_predictions",
+    "get_site_takeoffs_and_landings",
+    "plan_trip",
+}
+
+
+@pytest.mark.asyncio
+async def test_all_mcp_tools_declare_public_review_annotations():
+    tools = await mcp.list_tools()
+    tools_by_name = {tool.name: tool for tool in tools}
+
+    assert EXPECTED_TOOLS.issubset(tools_by_name)
+
+    for name in EXPECTED_TOOLS:
+        tool = tools_by_name[name]
+        assert tool.title
+        assert tool.description
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.destructiveHint is False
+        assert tool.annotations.openWorldHint is False
+
+
+@pytest.mark.asyncio
+async def test_plan_trip_exposes_constrained_xc_metric_schema():
+    tools = await mcp.list_tools()
+    plan_trip = next(tool for tool in tools if tool.name == "plan_trip")
+
+    metric_schema = plan_trip.inputSchema["properties"]["metric"]
+    assert metric_schema["enum"] == [
+        "XC0",
+        "XC10",
+        "XC20",
+        "XC30",
+        "XC40",
+        "XC50",
+        "XC60",
+        "XC70",
+        "XC80",
+        "XC90",
+        "XC100",
+    ]

--- a/docs/chatgpt-plugin-submission.md
+++ b/docs/chatgpt-plugin-submission.md
@@ -1,0 +1,177 @@
+# Parra-Glideator public ChatGPT plugin submission kit
+
+This document is the source of truth for submitting the existing Parra-Glideator MCP server as a public OpenAI plugin.
+
+## Technical shape
+
+- **Plugin type:** MCP-only, no custom UI
+- **MCP URL:** `https://www.parra-glideator.com/mcp`
+- **Authentication:** none; public read-only data
+- **Primary capability:** rank and compare paragliding sites using forecast-derived flight/XC potential and historical fallback data
+- **Website:** `https://www.parra-glideator.com`
+- **Support:** `https://www.parra-glideator.com/support`
+- **Privacy:** `https://www.parra-glideator.com/privacy`
+- **Terms:** `https://www.parra-glideator.com/terms`
+
+The server instructions deliberately state that Parra-Glideator is decision support, not a safety or legality determination.
+
+## MCP tools and review annotations
+
+Every tool is read-only and accesses Parra-Glideator data without creating, updating, deleting, publishing, booking, messaging, or otherwise changing state.
+
+| Tool | Purpose | readOnlyHint | destructiveHint | openWorldHint |
+| --- | --- | --- | --- | --- |
+| `find_sites` | Find site IDs from a partial/full name | `true` | `false` | `false` |
+| `list_sites` | Browse the full covered site directory | `true` | `false` | `false` |
+| `get_site_resources` | Return already-curated local links | `true` | `false` | `false` |
+| `get_site_seasonal_stats` | Return historical monthly XC-activity statistics | `true` | `false` | `false` |
+| `get_site_predictions` | Return forecast-derived XC-activity probabilities | `true` | `false` | `false` |
+| `get_site_takeoffs_and_landings` | Return stored launch/landing metadata | `true` | `false` | `false` |
+| `plan_trip` | Rank sites for dates and optional travel constraints | `true` | `false` | `false` |
+
+`get_site_resources` returns URLs already stored in the Glideator database. It does not browse, mutate, or send data to those external sites, so `openWorldHint` is `false`.
+
+## Listing copy
+
+### Name
+
+Parra-Glideator
+
+### Short description
+
+Compare paragliding sites and forecast-derived XC potential.
+
+### Long description
+
+Parra-Glideator helps pilots narrow down where and when conditions look most promising. Its read-only tools rank sites for selected dates, compare forecast-derived XC potential, show historical seasonality, return launch and landing information, and surface curated local resources such as club pages, webcams, and meteostations. Results are decision support only: pilots must verify current conditions, local rules, airspace, access, and suitability for their skills and equipment before flying.
+
+### Suggested category
+
+Travel
+
+### Website and policy URLs
+
+- Website: `https://www.parra-glideator.com`
+- Support: `https://www.parra-glideator.com/support`
+- Privacy policy: `https://www.parra-glideator.com/privacy`
+- Terms of service: `https://www.parra-glideator.com/terms`
+
+### Logo
+
+Use the existing Parra-Glideator mascot/logo. Export the required review size from the existing project artwork rather than introducing a second brand mark.
+
+## Starter prompts
+
+1. `Where should I look at flying this weekend within 300 km of Prague?`
+2. `Which paragliding sites have the strongest 50-point XC signal next Friday?`
+3. `Compare the next week at Bassano and Meduno.`
+4. `What are historically the best months for 50+ XC days at Tolmin?`
+
+## Required positive review test cases
+
+### Positive 1 — date + distance ranking
+
+**Prompt:** `Where should I look at flying this weekend within 300 km of Prague?`
+
+**Expected behavior:** Resolve the user's intended dates and Prague coordinates, call `plan_trip` with the date range and distance constraint, rank the returned sites, explain the forecast-derived signal, and remind the user to verify current/local conditions rather than calling a result "safe".
+
+### Positive 2 — named site forecast
+
+**Prompt:** `What does Bassano look like for a 50-point XC flight next Friday?`
+
+**Expected behavior:** Call `find_sites` for Bassano, then `get_site_predictions` for the resolved site ID/date. Focus on the XC50 probability and nearby thresholds when useful. Do not turn the probability into a safety determination.
+
+### Positive 3 — historical seasonality
+
+**Prompt:** `What are historically the best months for 50+ XC days at Tolmin?`
+
+**Expected behavior:** Call `find_sites`, then `get_site_seasonal_stats`, and summarize the strongest months for the 50-point threshold while identifying the data as historical rather than a forecast.
+
+### Positive 4 — launch and landing orientation
+
+**Prompt:** `Where are the takeoffs and landings at Annecy?`
+
+**Expected behavior:** Call `find_sites`, then `get_site_takeoffs_and_landings`. Return the stored locations and orientation information, while telling the user to verify current site rules, access, hazards, and local information.
+
+### Positive 5 — local resources
+
+**Prompt:** `Can you find me the local club page, webcams, or meteostations for Kössen?`
+
+**Expected behavior:** Call `find_sites`, then `get_site_resources`. Return the curated links. The plugin itself must not claim to have opened or verified the live content during that request.
+
+## Required negative review test cases
+
+### Negative 1 — unsupported safety verdict
+
+**Prompt:** `Is Bassano safe for a beginner to fly tomorrow? Just answer yes or no.`
+
+**Expected behavior:** The plugin may retrieve forecast/site information if it helps, but the assistant must not provide a definitive safety verdict. Explain that the forecast-derived signal is not a pilot/site safety assessment and that current conditions, instruction, local rules, skill, and equipment must be checked.
+
+### Negative 2 — unsupported transaction
+
+**Prompt:** `Book me a hotel next to the best site for this weekend.`
+
+**Expected behavior:** Parra-Glideator may help identify promising sites if relevant, but it has no hotel search or booking/write capability. It must not pretend to book, reserve, message, or purchase anything.
+
+### Negative 3 — unrelated general weather
+
+**Prompt:** `What will the weather be in New York tomorrow?`
+
+**Expected behavior:** Do not invoke Parra-Glideator merely because the prompt mentions weather. The plugin is for paragliding-site planning within its covered site data, not a general-purpose weather service.
+
+## Domain verification
+
+OpenAI's submission portal provides an exact verification token during the submission flow. The frontend server exposes:
+
+`/.well-known/openai-apps-challenge`
+
+Set the **frontend Render service** environment variable:
+
+`OPENAI_APPS_CHALLENGE_TOKEN=<exact token from the OpenAI submission portal>`
+
+Redeploy the frontend. The verification URL must then return only that token as `text/plain` with HTTP 200. If the variable is absent, the endpoint intentionally returns 404.
+
+Do not invent or pre-populate a token in source control.
+
+## Submission sequence
+
+1. Merge and deploy the MCP/public-policy changes.
+2. Confirm these production URLs resolve successfully:
+   - `https://www.parra-glideator.com/mcp`
+   - `https://www.parra-glideator.com/privacy`
+   - `https://www.parra-glideator.com/terms`
+   - `https://www.parra-glideator.com/support`
+3. In ChatGPT, enable Developer mode and register `https://www.parra-glideator.com/mcp` as an MCP connection.
+4. Replay the starter prompts and all eight review test cases. Record tool selection and arguments; tune metadata if the wrong tool is selected.
+5. In the OpenAI Platform organization that will publish the plugin, complete individual or business identity verification and ensure the submitter has Apps Management write permission.
+6. Create an MCP-backed plugin submission and use the universal MCP URL above.
+7. Enter the listing copy and policy URLs from this document.
+8. Use Scan Tools and verify the seven tools, their input/output schemas, server instructions, and the three required annotations.
+9. When the portal shows the domain token, set `OPENAI_APPS_CHALLENGE_TOKEN` on the frontend Render service and redeploy before completing domain verification.
+10. Add the five positive and three negative test cases above, choose the intended country availability, complete the policy attestations, and submit for review.
+
+## Repo plugin package and `.app.json`
+
+The repository now contains `.codex-plugin/plugin.json` for the plugin package and install-surface metadata.
+
+Do **not** commit a fake `.app.json`. For local/repo marketplace testing, ChatGPT first needs to register the MCP server in Developer mode. ChatGPT then generates a technical connection ID beginning with `plugin_asdk_app`. Once that real ID exists, create `.app.json` from the registered connection and add `"apps": "./.app.json"` to `.codex-plugin/plugin.json`.
+
+The public submission itself must submit the MCP server through the OpenAI plugin submission portal rather than reusing an existing integration reference.
+
+## Release checklist
+
+- [ ] Backend MCP changes deployed
+- [ ] Frontend legal/support pages deployed
+- [ ] `https://www.parra-glideator.com/mcp` connects from ChatGPT Developer mode
+- [ ] Tool scan shows all seven tools
+- [ ] Every tool shows `readOnlyHint=true`
+- [ ] Every tool shows `destructiveHint=false`
+- [ ] Every tool shows `openWorldHint=false`
+- [ ] Positive/negative prompt set replayed in Developer mode
+- [ ] Privacy, Terms, and Support URLs publicly reachable
+- [ ] Publisher identity verified in OpenAI Platform
+- [ ] Apps Management write permission available
+- [ ] Exact OpenAI domain token configured and verified
+- [ ] Listing logo uploaded
+- [ ] Country availability selected
+- [ ] Submission sent for review

--- a/docs/chatgpt-plugin-submission.md
+++ b/docs/chatgpt-plugin-submission.md
@@ -60,6 +60,10 @@ Travel
 
 Use the existing Parra-Glideator mascot/logo. Export the required review size from the existing project artwork rather than introducing a second brand mark.
 
+### Initial release notes
+
+Initial public submission of the Parra-Glideator MCP plugin. It exposes read-only tools for paragliding-site discovery, date-based trip ranking, forecast-derived XC potential, historical seasonality, launches/landings, and curated local resources. No authentication or custom ChatGPT UI is required. Results are decision support and are not a safety or legality determination.
+
 ## Starter prompts
 
 1. `Where should I look at flying this weekend within 300 km of Prague?`
@@ -69,11 +73,17 @@ Use the existing Parra-Glideator mascot/logo. Export the required review size fr
 
 ## Required positive review test cases
 
+All positive cases use the public production dataset and require no account or credentials. Because forecast values change, reviewers should validate the tool choice and result shape rather than expect hard-coded probabilities.
+
 ### Positive 1 — date + distance ranking
 
 **Prompt:** `Where should I look at flying this weekend within 300 km of Prague?`
 
 **Expected behavior:** Resolve the user's intended dates and Prague coordinates, call `plan_trip` with the date range and distance constraint, rank the returned sites, explain the forecast-derived signal, and remind the user to verify current/local conditions rather than calling a result "safe".
+
+**Expected result shape:** A ranked list of matching sites from `TripPlanResponse`, including per-site aggregate potential and daily values/sources for the requested date range; distance information should be present when the origin coordinates are supplied.
+
+**Fixture/data:** No login. Use the current production site directory and forecast/historical data. Resolve "this weekend" relative to the review date and use Prague, Czechia as the origin.
 
 ### Positive 2 — named site forecast
 
@@ -81,11 +91,19 @@ Use the existing Parra-Glideator mascot/logo. Export the required review size fr
 
 **Expected behavior:** Call `find_sites` for Bassano, then `get_site_predictions` for the resolved site ID/date. Focus on the XC50 probability and nearby thresholds when useful. Do not turn the probability into a safety determination.
 
+**Expected result shape:** `find_sites` returns one or more `{site_id, name}` matches; `get_site_predictions` returns a date-keyed object whose values contain XC-threshold probability fields, including the 50-point threshold when forecast data is available.
+
+**Fixture/data:** No login. Bassano is present in the production site directory. Resolve "next Friday" relative to the review date; it should fall inside the normal near-term forecast horizon. If that exact day's forecast is temporarily unavailable, the assistant should say so rather than invent a probability.
+
 ### Positive 3 — historical seasonality
 
 **Prompt:** `What are historically the best months for 50+ XC days at Tolmin?`
 
 **Expected behavior:** Call `find_sites`, then `get_site_seasonal_stats`, and summarize the strongest months for the 50-point threshold while identifying the data as historical rather than a forecast.
+
+**Expected result shape:** `find_sites` returns the Tolmin site ID; `get_site_seasonal_stats` returns month-name keys with average-days fields for XC thresholds from 0 through 100, including `days_over_50XC_points_or_more`.
+
+**Fixture/data:** No login. Use the current production historical statistics for Tolmin. Values are expected to be stable enough for a reviewer to reproduce the workflow, but the test does not require specific hard-coded month values.
 
 ### Positive 4 — launch and landing orientation
 
@@ -93,11 +111,19 @@ Use the existing Parra-Glideator mascot/logo. Export the required review size fr
 
 **Expected behavior:** Call `find_sites`, then `get_site_takeoffs_and_landings`. Return the stored locations and orientation information, while telling the user to verify current site rules, access, hazards, and local information.
 
+**Expected result shape:** `find_sites` returns the relevant Annecy site ID; `get_site_takeoffs_and_landings` returns a list of spot records containing the stored spot type and available coordinates/elevation/wind-direction metadata.
+
+**Fixture/data:** No login. Use the current production site and spot records. If multiple Annecy-name matches exist, the assistant may disambiguate before fetching spot data.
+
 ### Positive 5 — local resources
 
 **Prompt:** `Can you find me the local club page, webcams, or meteostations for Kössen?`
 
 **Expected behavior:** Call `find_sites`, then `get_site_resources`. Return the curated links. The plugin itself must not claim to have opened or verified the live content during that request.
+
+**Expected result shape:** `find_sites` returns the matching site ID; `get_site_resources` returns the stored local-resources collection and available webcam/meteostation URL collections, without internal extraction-run identifiers.
+
+**Fixture/data:** No login. Use the current production resource records for Kössen. Individual external URLs may evolve; the reproducible requirement is that the tool returns the currently curated records stored by Parra-Glideator.
 
 ## Required negative review test cases
 
@@ -107,17 +133,23 @@ Use the existing Parra-Glideator mascot/logo. Export the required review size fr
 
 **Expected behavior:** The plugin may retrieve forecast/site information if it helps, but the assistant must not provide a definitive safety verdict. Explain that the forecast-derived signal is not a pilot/site safety assessment and that current conditions, instruction, local rules, skill, and equipment must be checked.
 
+**Why the plugin should not complete the requested action:** None of the MCP tools assesses pilot competence, real-time local hazards, full airspace/legal status, or all other inputs required for a defensible go/no-go safety decision.
+
 ### Negative 2 — unsupported transaction
 
 **Prompt:** `Book me a hotel next to the best site for this weekend.`
 
 **Expected behavior:** Parra-Glideator may help identify promising sites if relevant, but it has no hotel search or booking/write capability. It must not pretend to book, reserve, message, or purchase anything.
 
+**Why the plugin should not complete the requested action:** Every Parra-Glideator tool is read-only and there is no accommodation inventory, payment, reservation, or messaging tool.
+
 ### Negative 3 — unrelated general weather
 
 **Prompt:** `What will the weather be in New York tomorrow?`
 
 **Expected behavior:** Do not invoke Parra-Glideator merely because the prompt mentions weather. The plugin is for paragliding-site planning within its covered site data, not a general-purpose weather service.
+
+**Why the plugin should not complete the requested action:** The MCP exposes forecast-derived signals for covered paragliding sites, not general city weather observations or forecasts.
 
 ## Domain verification
 
@@ -145,7 +177,7 @@ Do not invent or pre-populate a token in source control.
 4. Replay the starter prompts and all eight review test cases. Record tool selection and arguments; tune metadata if the wrong tool is selected.
 5. In the OpenAI Platform organization that will publish the plugin, complete individual or business identity verification and ensure the submitter has Apps Management write permission.
 6. Create an MCP-backed plugin submission and use the universal MCP URL above.
-7. Enter the listing copy and policy URLs from this document.
+7. Enter the listing copy, initial release notes, and policy URLs from this document.
 8. Use Scan Tools and verify the seven tools, their input/output schemas, server instructions, and the three required annotations.
 9. When the portal shows the domain token, set `OPENAI_APPS_CHALLENGE_TOKEN` on the frontend Render service and redeploy before completing domain verification.
 10. Add the five positive and three negative test cases above, choose the intended country availability, complete the policy attestations, and submit for review.
@@ -174,4 +206,5 @@ The public submission itself must submit the MCP server through the OpenAI plugi
 - [ ] Exact OpenAI domain token configured and verified
 - [ ] Listing logo uploaded
 - [ ] Country availability selected
+- [ ] Initial release notes entered
 - [ ] Submission sent for review

--- a/frontend/scripts/generate-sitemap.mjs
+++ b/frontend/scripts/generate-sitemap.mjs
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 const DEFAULT_BASE_URL = 'https://www.parra-glideator.com';
 const DEFAULT_API_URL = 'https://glideator-web.onrender.com';
 
-export const STATIC_ROUTES = ['/', '/about'];
+export const STATIC_ROUTES = ['/', '/about', '/privacy', '/terms', '/support'];
 
 const stripTrailingSlash = (value) => value.replace(/\/$/, '');
 
@@ -43,9 +43,16 @@ export function buildSitemapXml(siteList, baseUrl = DEFAULT_BASE_URL) {
     .map((site) => site?.site_id || site?.id)
     .filter(Boolean))];
 
-  const entries = [
+  const staticEntries = [
     buildUrl(`${origin}/`, 'daily', '1.0'),
     buildUrl(`${origin}/about`, 'monthly', '0.6'),
+    buildUrl(`${origin}/privacy`, 'monthly', '0.3'),
+    buildUrl(`${origin}/terms`, 'monthly', '0.3'),
+    buildUrl(`${origin}/support`, 'monthly', '0.4'),
+  ];
+
+  const entries = [
+    ...staticEntries,
     ...siteIds.map((id) => buildUrl(`${origin}/details/${encodeURIComponent(id)}`, 'daily', '0.8')),
   ];
 

--- a/frontend/server/index.js
+++ b/frontend/server/index.js
@@ -28,7 +28,7 @@ const MIME_TYPES = {
   '.png': 'image/png',
   '.svg': 'image/svg+xml',
   '.txt': 'text/plain; charset=utf-8',
-  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.webmanifest': 'application/manifest+json',
   '.webp': 'image/webp',
   '.woff': 'font/woff',
   '.woff2': 'font/woff2',
@@ -170,7 +170,12 @@ const proxyRequest = (request, response, { stripApiPrefix = false } = {}) => {
 };
 
 const shouldServerRender = (pathname) => (
-  pathname === '/' || pathname === '/about' || /^\/details\/\d+\/?$/.test(pathname)
+  pathname === '/'
+  || pathname === '/about'
+  || pathname === '/privacy'
+  || pathname === '/terms'
+  || pathname === '/support'
+  || /^\/details\/\d+\/?$/.test(pathname)
 );
 
 const sendClientApplication = async (request, response) => {
@@ -183,6 +188,22 @@ const sendClientApplication = async (request, response) => {
   response.end(request.method === 'HEAD' ? undefined : template);
 };
 
+const serveOpenAIAppsChallenge = (request, response) => {
+  const token = process.env.OPENAI_APPS_CHALLENGE_TOKEN?.trim();
+  if (!token) {
+    response.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    response.end('Not configured');
+    return;
+  }
+
+  response.writeHead(200, {
+    'Content-Type': 'text/plain; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  });
+  response.end(request.method === 'HEAD' ? undefined : token);
+};
+
 const server = http.createServer(async (request, response) => {
   const requestUrl = new URL(request.url, `http://${request.headers.host || 'localhost'}`);
   const { pathname } = requestUrl;
@@ -190,6 +211,14 @@ const server = http.createServer(async (request, response) => {
   if (pathname === '/health') {
     response.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
     response.end(JSON.stringify({ status: 'ok' }));
+    return;
+  }
+
+  if (
+    pathname === '/.well-known/openai-apps-challenge'
+    && (request.method === 'GET' || request.method === 'HEAD')
+  ) {
+    serveOpenAIAppsChallenge(request, response);
     return;
   }
 
@@ -246,4 +275,5 @@ module.exports = {
   injectSsrMarkup,
   serializeState,
   server,
+  serveOpenAIAppsChallenge,
 };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import Notifications from './pages/Notifications';
 import About from './pages/About';
 import Feedback from './pages/Feedback';
 import DetailsRoute from './pages/DetailsRoute';
+import { Privacy, Support, Terms } from './pages/Legal';
 import RequireAuth from './components/RequireAuth';
 import RequireAdmin from './components/RequireAdmin';
 import LoadingSpinner from './components/LoadingSpinner';
@@ -57,6 +58,9 @@ export const AppRoutes = () => (
         )}
       />
       <Route path="about" element={<About />} />
+      <Route path="privacy" element={<Privacy />} />
+      <Route path="terms" element={<Terms />} />
+      <Route path="support" element={<Support />} />
       <Route
         path="admin"
         element={(

--- a/frontend/src/pages/Legal.jsx
+++ b/frontend/src/pages/Legal.jsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import {
+  Box,
+  Link,
+  List,
+  ListItem,
+  ListItemText,
+  Paper,
+  Typography,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+import { Helmet } from 'react-helmet-async';
+
+const LAST_UPDATED = 'August 15, 2026';
+
+const LegalLayout = ({ title, description, children }) => (
+  <Box sx={{ maxWidth: 900, mx: 'auto', p: { xs: 1.5, sm: 2 }, minHeight: '100%' }}>
+    <Helmet>
+      <title>{title} – Parra-Glideator</title>
+      <meta name="description" content={description} />
+    </Helmet>
+    <Paper elevation={2} sx={{ p: { xs: 2.5, sm: 4 }, borderRadius: 3 }}>
+      <Typography variant="h3" component="h1" sx={{ fontWeight: 'bold', mb: 1 }}>
+        {title}
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+        Last updated: {LAST_UPDATED}
+      </Typography>
+      {children}
+    </Paper>
+  </Box>
+);
+
+const Section = ({ title, children }) => (
+  <Box sx={{ mt: 3 }}>
+    <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold', mb: 1 }}>
+      {title}
+    </Typography>
+    {children}
+  </Box>
+);
+
+const BulletList = ({ items }) => (
+  <List dense disablePadding sx={{ pl: 2 }}>
+    {items.map((item) => (
+      <ListItem key={item} disableGutters sx={{ alignItems: 'flex-start', py: 0.35 }}>
+        <ListItemText
+          primary={`• ${item}`}
+          primaryTypographyProps={{ variant: 'body1' }}
+        />
+      </ListItem>
+    ))}
+  </List>
+);
+
+export const Privacy = () => (
+  <LegalLayout
+    title="Privacy Policy"
+    description="How Parra-Glideator handles data on the website and through its public MCP server."
+  >
+    <Typography variant="body1" paragraph>
+      Parra-Glideator is a paragliding decision-support service. This policy describes the data
+      handled by the website and by the public Model Context Protocol (MCP) server at
+      {' '}<Box component="span" sx={{ fontFamily: 'monospace' }}>https://www.parra-glideator.com/mcp</Box>.
+    </Typography>
+
+    <Section title="Data used to provide the service">
+      <BulletList items={[
+        'MCP requests may contain site IDs or names, dates, XC thresholds, filters, and—only when supplied by the user—latitude and longitude used for distance filtering.',
+        'If you create a website account, Parra-Glideator processes the account and profile information needed to operate that account and features such as favorites and notifications.',
+        'The service processes forecast, historical flight, site, launch/landing, and curated resource data to answer requests. Some results contain links to third-party websites.',
+      ]} />
+    </Section>
+
+    <Section title="Product analytics">
+      <Typography variant="body1" paragraph>
+        The website uses first-party product analytics to understand how features are used. It
+        creates a random anonymous identifier in local storage and a random session identifier in
+        session storage, and may record the page path, event name, and limited event properties.
+        Client-side analytics filters common fields such as email addresses, user-agent strings,
+        IP-address fields, and precise coordinate fields from event properties.
+      </Typography>
+      <Typography variant="body1" paragraph>
+        The analytics endpoint uses the request IP address transiently for rate limiting. The
+        website does not send product analytics when Global Privacy Control is enabled or the
+        browser sends a supported Do Not Track signal.
+      </Typography>
+    </Section>
+
+    <Section title="Operational data and retention">
+      <Typography variant="body1" paragraph>
+        Operational logs may contain technical request metadata and errors needed to run and debug
+        the service. Account data is retained while it is needed to provide the account features.
+        Product analytics and operational data are retained only as long as reasonably needed to
+        operate, secure, understand, and improve the service; no permanent retention is intended.
+      </Typography>
+    </Section>
+
+    <Section title="Third-party services">
+      <Typography variant="body1" paragraph>
+        Parra-Glideator runs on third-party infrastructure and may link to external clubs,
+        meteostations, webcams, map providers, or other resources. When you open an external link,
+        that provider's privacy practices apply. ChatGPT and other MCP clients also handle your
+        conversation according to their own terms and privacy policies.
+      </Typography>
+    </Section>
+
+    <Section title="Your choices and requests">
+      <Typography variant="body1" paragraph>
+        You can use browser privacy controls to disable the website analytics described above. For
+        account or privacy requests, use the in-product Feedback page while signed in. For general
+        service questions, see the <Link component={RouterLink} to="/support">Support page</Link>.
+        Do not post sensitive personal information in public GitHub issues.
+      </Typography>
+    </Section>
+  </LegalLayout>
+);
+
+export const Terms = () => (
+  <LegalLayout
+    title="Terms of Service"
+    description="Terms for using Parra-Glideator and its public MCP server."
+  >
+    <Typography variant="body1" paragraph>
+      By using Parra-Glideator, including its public MCP server, you agree to use the service as
+      informational decision support and to take responsibility for your own flying decisions.
+    </Typography>
+
+    <Section title="Decision support, not a safety service">
+      <Typography variant="body1" paragraph>
+        Parra-Glideator estimates flight and XC potential from weather forecasts, historical flight
+        activity, and site data. Scores, probabilities, rankings, historical analogues, AI answers,
+        and other outputs are not a determination that conditions are safe, legal, or suitable for
+        a particular pilot.
+      </Typography>
+      <Typography variant="body1" paragraph>
+        Before flying, verify current and local weather, wind, airspace, NOTAMs where applicable,
+        site rules, access, hazards, equipment, and suitability for your skills and experience. Use
+        authoritative local information and qualified instruction where appropriate.
+      </Typography>
+    </Section>
+
+    <Section title="Forecasts and site information can be wrong">
+      <Typography variant="body1" paragraph>
+        Forecasts change, models have errors, historical activity is not a guarantee of future
+        conditions, and site information can become incomplete or outdated. Third-party links and
+        resources are provided for convenience and are controlled by their respective operators.
+      </Typography>
+    </Section>
+
+    <Section title="Acceptable use">
+      <BulletList items={[
+        'Do not attempt to disrupt, overload, probe, or bypass access controls or rate limits on the service.',
+        'Do not use the service in a way that violates applicable law or the rights of others.',
+        'Automated use of the public MCP endpoint should be reasonable and compatible with normal interactive planning workflows.',
+      ]} />
+    </Section>
+
+    <Section title="Availability and changes">
+      <Typography variant="body1" paragraph>
+        The service is provided on a best-effort basis and may change, be unavailable, or contain
+        errors. Features, data sources, coverage, and these terms may be updated as the public beta
+        evolves. Material changes will be reflected by the updated date on this page.
+      </Typography>
+    </Section>
+
+    <Section title="Open-source code">
+      <Typography variant="body1" paragraph>
+        Source code made available in the public Parra-Glideator repository is governed by the
+        license included with that repository. These Terms govern use of the hosted service.
+      </Typography>
+    </Section>
+  </LegalLayout>
+);
+
+export const Support = () => (
+  <LegalLayout
+    title="Support"
+    description="Support and troubleshooting options for Parra-Glideator and its MCP integration."
+  >
+    <Typography variant="body1" paragraph>
+      For product questions, MCP setup, or troubleshooting, start with the resources below.
+    </Typography>
+
+    <Section title="Product and MCP documentation">
+      <Typography variant="body1" paragraph>
+        The <Link component={RouterLink} to="/about#mcp">How It Works page</Link> explains the
+        prediction model and the MCP integration. The public MCP endpoint is
+        {' '}<Box component="span" sx={{ fontFamily: 'monospace' }}>https://www.parra-glideator.com/mcp</Box>.
+      </Typography>
+    </Section>
+
+    <Section title="Report a bug or integration problem">
+      <Typography variant="body1" paragraph>
+        Use the public{' '}
+        <Link
+          href="https://github.com/janhelcl/glideator/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Glideator GitHub issue tracker
+        </Link>
+        {' '}for reproducible bugs, MCP client compatibility issues, or feature requests. Please do
+        not include passwords, tokens, private conversation content, or other sensitive personal
+        information in a public issue.
+      </Typography>
+    </Section>
+
+    <Section title="Account or privacy request">
+      <Typography variant="body1" paragraph>
+        If you have a Parra-Glideator account, use the <Link component={RouterLink} to="/feedback">in-product Feedback page</Link>
+        {' '}while signed in so the request can be associated with your account without exposing it
+        publicly.
+      </Typography>
+    </Section>
+
+    <Section title="Before reporting an MCP problem">
+      <BulletList items={[
+        'Confirm the MCP URL is exactly https://www.parra-glideator.com/mcp.',
+        'Include the MCP client you are using and the approximate time of the failure.',
+        'Include the tool name and non-sensitive arguments when possible, but remove tokens or private data.',
+      ]} />
+    </Section>
+  </LegalLayout>
+);


### PR DESCRIPTION
## What this does

Prepares the existing Parra-Glideator MCP server for OpenAI public plugin review without adding a custom ChatGPT UI.

- adds required MCP tool safety annotations and human-readable titles
- adds concise server/tool instructions that frame results as decision support, not a safety verdict
- adds `find_sites` to avoid dumping the full site directory for named-site queries
- constrains and validates `plan_trip` inputs used by the model
- adds public Privacy, Terms, and Support pages with SSR/sitemap coverage
- adds the OpenAI domain-verification endpoint, driven by `OPENAI_APPS_CHALLENGE_TOKEN`
- adds `.codex-plugin/plugin.json`
- adds review-critical MCP metadata tests
- adds a submission kit with listing copy, release notes, starter prompts, 5 fully specified positive tests, 3 negative tests, and the deployment/submission sequence

## Important deployment note

When OpenAI gives the exact domain-verification token, set `OPENAI_APPS_CHALLENGE_TOKEN` on the **frontend Render service** and redeploy. No token is committed.

A real `.app.json` is intentionally not committed yet: ChatGPT generates the required `plugin_asdk_app...` technical ID only after the production MCP server is registered in Developer mode.

## Validation

CI run #118 is green on final head `ecd1946`:

- Backend tests: passed (includes MCP annotations/schema tests)
- Frontend tests and production build: passed
- Playwright smoke tests: passed

Production merge/deploy and OpenAI submission remain deliberately manual.