### PR TITLE
Fix MCP remote tool execution

### DIFF
--- a/backend/app/mcp.py
+++ b/backend/app/mcp.py
@@ -25,6 +25,11 @@ mcp = FastMCP(
         "conditions are safe or legal to fly. Users must verify current weather, local rules, "
         "airspace, site access, and suitability for their skills and equipment before flying."
     ),
+    # Remote MCP clients should not depend on an in-memory session surviving
+    # proxies, reconnects, or deploys. JSON responses also avoid an SSE stream
+    # for ordinary read-only tool calls.
+    stateless_http=True,
+    json_response=True,
 )
 
 

--- a/backend/tests/test_mcp_metadata.py
+++ b/backend/tests/test_mcp_metadata.py
@@ -18,6 +18,11 @@ EXPECTED_TOOLS = {
 }
 
 
+def test_mcp_uses_stateless_json_http_transport():
+    assert mcp.settings.stateless_http is True
+    assert mcp.settings.json_response is True
+
+
 @pytest.mark.asyncio
 async def test_all_mcp_tools_declare_public_review_annotations():
     tools = await mcp.list_tools()


### PR DESCRIPTION
## Root cause

Production Render logs show MCP discovery succeeds, but Claude tool invocations reach `POST /mcp` as HTTP 400 before FastMCP processes `CallToolRequest`. The deployed MCP SDK (1.13.1) uses stateful Streamable HTTP by default and returns `400 Bad Request: No valid session ID provided` when a request carries a session ID that is not in the process-local session registry.

## Fix

- configure FastMCP with `stateless_http=True`
- configure `json_response=True` for ordinary read-only tool calls
- add a regression test that locks both production transport settings

No Glideator tool business logic or schemas are changed.

This follows the official MCP Python SDK production recommendation for Streamable HTTP and removes dependence on an in-memory MCP session surviving proxies/reconnects/deploys.