### PR TITLE
Fix MCP site info serialization

### DIFF
--- a/backend/app/mcp.py
+++ b/backend/app/mcp.py
@@ -35,6 +35,11 @@ def _normalize_site_name(value: str) -> str:
     return "".join(char for char in normalized if not unicodedata.combining(char))
 
 
+def _serialize_site_info(value: object) -> schemas.SiteInfo:
+    """Convert the ORM site-info record to the public Pydantic response shape."""
+    return schemas.SiteInfo.model_validate(value)
+
+
 mcp = FastMCP(
     "Parra-Glideator",
     instructions=(
@@ -121,7 +126,7 @@ async def get_site_info(site_id: int) -> schemas.SiteInfo:
 
     if not site_info:
         raise ValueError(f"No stored site overview found for site {site_id}")
-    return site_info
+    return _serialize_site_info(site_info)
 
 
 @mcp.tool(title="Get site resources", annotations=READ_ONLY_ANNOTATIONS)

--- a/backend/tests/test_mcp_metadata.py
+++ b/backend/tests/test_mcp_metadata.py
@@ -1,11 +1,12 @@
 import os
+from types import SimpleNamespace
 
 import pytest
 
 os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
 
 from app import schemas
-from app.mcp import _normalize_site_name, mcp
+from app.mcp import _normalize_site_name, _serialize_site_info, mcp
 
 
 EXPECTED_TOOLS = {
@@ -28,6 +29,25 @@ def test_mcp_uses_stateless_json_http_transport():
 def test_site_search_normalization_is_accent_insensitive():
     assert _normalize_site_name("Rana") == _normalize_site_name("Raná")
     assert _normalize_site_name("  KÖSSEN ") == _normalize_site_name("Kossen")
+
+
+def test_site_info_orm_is_converted_to_public_schema():
+    orm_record = SimpleNamespace(
+        site_id=1,
+        site_name="Raná",
+        country="Czechia",
+        html="<p>Site guide</p>",
+    )
+
+    result = _serialize_site_info(orm_record)
+
+    assert isinstance(result, schemas.SiteInfo)
+    assert result.model_dump() == {
+        "site_id": 1,
+        "site_name": "Raná",
+        "country": "Czechia",
+        "html": "<p>Site guide</p>",
+    }
 
 
 def test_trip_plan_site_ids_are_integers():


### PR DESCRIPTION
## Why

Cross-client testing found that `get_site_info` successfully loads the ORM record but FastMCP stringifies the raw SQLAlchemy object, returning values like `<app.models.SiteInfo object at ...>` instead of structured site data.

## Fix

- explicitly validate/convert the ORM record to `schemas.SiteInfo` before returning it from the MCP tool
- add a regression test for ORM → public Pydantic serialization

This is intentionally focused; no tool names, permissions, or other response contracts change.