### PR TITLE
Separate known bot traffic in product analytics

### DIFF
--- a/backend/alembic/versions/0012_bot_events.py
+++ b/backend/alembic/versions/0012_bot_events.py
@@ -1,0 +1,51 @@
+"""Add bot analytics events
+
+Revision ID: 0012_bot_events
+Revises: 0011_product_events
+Create Date: 2026-08-19
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0012_bot_events"
+down_revision = "0011_product_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "bot_events",
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("bot_name", sa.String(length=80), nullable=False),
+        sa.Column("event_name", sa.String(length=80), nullable=False),
+        sa.Column("anonymous_id", sa.String(length=64), nullable=False),
+        sa.Column("session_id", sa.String(length=64), nullable=False),
+        sa.Column("path", sa.String(length=500), nullable=True),
+        sa.Column("properties", sa.JSON(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("event_id"),
+    )
+    op.create_index(op.f("ix_bot_events_event_id"), "bot_events", ["event_id"], unique=False)
+    op.create_index(op.f("ix_bot_events_bot_name"), "bot_events", ["bot_name"], unique=False)
+    op.create_index(op.f("ix_bot_events_event_name"), "bot_events", ["event_name"], unique=False)
+    op.create_index(op.f("ix_bot_events_anonymous_id"), "bot_events", ["anonymous_id"], unique=False)
+    op.create_index(op.f("ix_bot_events_session_id"), "bot_events", ["session_id"], unique=False)
+    op.create_index(op.f("ix_bot_events_created_at"), "bot_events", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_bot_events_created_at"), table_name="bot_events")
+    op.drop_index(op.f("ix_bot_events_session_id"), table_name="bot_events")
+    op.drop_index(op.f("ix_bot_events_anonymous_id"), table_name="bot_events")
+    op.drop_index(op.f("ix_bot_events_event_name"), table_name="bot_events")
+    op.drop_index(op.f("ix_bot_events_bot_name"), table_name="bot_events")
+    op.drop_index(op.f("ix_bot_events_event_id"), table_name="bot_events")
+    op.drop_table("bot_events")

--- a/backend/app/bot_detection.py
+++ b/backend/app/bot_detection.py
@@ -1,0 +1,58 @@
+from typing import Optional, Sequence, Tuple
+
+
+# Canonical bot name -> identifying User-Agent fragments. Keep the most specific
+# signatures before broader vendor signatures so the stored bot name remains useful.
+BOT_SIGNATURES: Sequence[Tuple[str, Tuple[str, ...]]] = (
+    ("OAI-SearchBot", ("oai-searchbot",)),
+    ("ChatGPT-User", ("chatgpt-user",)),
+    ("GPTBot", ("gptbot",)),
+    ("Claude-SearchBot", ("claude-searchbot",)),
+    ("Claude-User", ("claude-user",)),
+    ("ClaudeBot", ("claudebot",)),
+    ("Perplexity-User", ("perplexity-user",)),
+    ("PerplexityBot", ("perplexitybot",)),
+    ("Google-InspectionTool", ("google-inspectiontool",)),
+    ("GoogleOther", ("googleother",)),
+    ("Google-Agent", ("google-agent",)),
+    ("Googlebot", ("googlebot",)),
+    ("BingPreview", ("bingpreview",)),
+    ("Bingbot", ("bingbot",)),
+    ("DuckDuckBot", ("duckduckbot",)),
+    ("Applebot", ("applebot",)),
+    ("YandexBot", ("yandexbot",)),
+    ("Baiduspider", ("baiduspider",)),
+    ("PetalBot", ("petalbot",)),
+    ("Bytespider", ("bytespider",)),
+    ("Amazonbot", ("amazonbot",)),
+    ("YouBot", ("youbot",)),
+    ("CCBot", ("ccbot",)),
+    ("FacebookBot", ("facebookexternalhit", "facebookcatalog", "meta-externalagent", "meta-externalfetcher")),
+    ("Twitterbot", ("twitterbot",)),
+    ("LinkedInBot", ("linkedinbot",)),
+    ("Slackbot", ("slackbot",)),
+    ("Discordbot", ("discordbot",)),
+    ("TelegramBot", ("telegrambot",)),
+    ("AhrefsBot", ("ahrefsbot",)),
+    ("SemrushBot", ("semrushbot",)),
+    ("MJ12bot", ("mj12bot",)),
+    ("DotBot", ("dotbot",)),
+    ("DataForSeoBot", ("dataforseobot",)),
+    ("BLEXBot", ("blexbot",)),
+)
+
+
+def detect_known_bot(user_agent: Optional[str]) -> Optional[str]:
+    """Return a canonical bot name for a known User-Agent, otherwise None.
+
+    The raw User-Agent is intentionally used only in-memory for classification and
+    is never persisted by the analytics pipeline.
+    """
+    if not user_agent:
+        return None
+
+    normalized = user_agent.lower()
+    for bot_name, signatures in BOT_SIGNATURES:
+        if any(signature in normalized for signature in signatures):
+            return bot_name
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException
 from .database import AsyncSessionLocal, SessionLocal
 from .routers import (
     admin,
+    admin_bot_analytics,
     analytics,
     auth,
     d2d,
@@ -174,6 +175,7 @@ app.include_router(d2d.router)
 app.include_router(feedback.router)
 app.include_router(analytics.router)
 app.include_router(admin.router)
+app.include_router(admin_bot_analytics.router)
 
 @app.get("/health")
 async def healthcheck():

--- a/backend/app/routers/admin_bot_analytics.py
+++ b/backend/app/routers/admin_bot_analytics.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from .admin import get_db, require_admin
+from .analytics import BotEvent
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+class BotTrafficRow(BaseModel):
+    bot_name: str
+    events: int
+    visitors: int
+    sessions: int
+
+
+class AdminBotAnalyticsResponse(BaseModel):
+    window_days: int
+    total_events: int
+    unique_visitors: int
+    unique_sessions: int
+    bot_types: int
+    bots: List[BotTrafficRow]
+
+
+@router.get("/bot-analytics", response_model=AdminBotAnalyticsResponse)
+async def get_bot_analytics(
+    days: int = Query(default=30, ge=1, le=365),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    summary = (
+        await db.execute(
+            select(
+                func.count(BotEvent.event_id),
+                func.count(func.distinct(BotEvent.anonymous_id)),
+                func.count(func.distinct(BotEvent.session_id)),
+                func.count(func.distinct(BotEvent.bot_name)),
+            ).where(BotEvent.created_at >= cutoff)
+        )
+    ).one()
+
+    rows = (
+        await db.execute(
+            select(
+                BotEvent.bot_name,
+                func.count(BotEvent.event_id).label("events"),
+                func.count(func.distinct(BotEvent.anonymous_id)).label("visitors"),
+                func.count(func.distinct(BotEvent.session_id)).label("sessions"),
+            )
+            .where(BotEvent.created_at >= cutoff)
+            .group_by(BotEvent.bot_name)
+            .order_by(func.count(BotEvent.event_id).desc(), BotEvent.bot_name.asc())
+        )
+    ).all()
+
+    return AdminBotAnalyticsResponse(
+        window_days=days,
+        total_events=int(summary[0] or 0),
+        unique_visitors=int(summary[1] or 0),
+        unique_sessions=int(summary[2] or 0),
+        bot_types=int(summary[3] or 0),
+        bots=[
+            BotTrafficRow(
+                bot_name=bot_name,
+                events=int(events or 0),
+                visitors=int(visitors or 0),
+                sessions=int(sessions or 0),
+            )
+            for bot_name, events, visitors, sessions in rows
+        ],
+    )

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -9,6 +9,7 @@ from sqlalchemy import Column, DateTime, Integer, JSON, String
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.sql import func
 
+from ..bot_detection import detect_known_bot
 from ..cache import get_redis_client
 from ..database import AsyncSessionLocal, Base
 
@@ -27,6 +28,24 @@ class ProductEvent(Base):
     __tablename__ = "product_events"
 
     event_id = Column(Integer, primary_key=True, index=True)
+    event_name = Column(String(80), nullable=False, index=True)
+    anonymous_id = Column(String(64), nullable=False, index=True)
+    session_id = Column(String(64), nullable=False, index=True)
+    path = Column(String(500), nullable=True)
+    properties = Column(JSON, nullable=False)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        index=True,
+    )
+
+
+class BotEvent(Base):
+    __tablename__ = "bot_events"
+
+    event_id = Column(Integer, primary_key=True, index=True)
+    bot_name = Column(String(80), nullable=False, index=True)
     event_name = Column(String(80), nullable=False, index=True)
     anonymous_id = Column(String(64), nullable=False, index=True)
     session_id = Column(String(64), nullable=False, index=True)
@@ -140,20 +159,23 @@ async def create_product_event(
         anonymous_id=payload.anonymous_id,
     )
 
-    event = ProductEvent(
-        event_name=payload.event_name,
-        anonymous_id=payload.anonymous_id,
-        session_id=payload.session_id,
-        path=payload.path,
-        properties=payload.properties,
-    )
+    bot_name = detect_known_bot(request.headers.get("user-agent"))
+    common_fields = {
+        "event_name": payload.event_name,
+        "anonymous_id": payload.anonymous_id,
+        "session_id": payload.session_id,
+        "path": payload.path,
+        "properties": payload.properties,
+    }
+    event = BotEvent(bot_name=bot_name, **common_fields) if bot_name else ProductEvent(**common_fields)
     db.add(event)
     await db.commit()
 
     logger.debug(
-        "Product event accepted event_name=%s anonymous_id=%s session_id=%s",
+        "Analytics event accepted event_name=%s anonymous_id=%s session_id=%s bot_name=%s",
         payload.event_name,
         payload.anonymous_id,
         payload.session_id,
+        bot_name,
     )
     return ProductEventAccepted()

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -7,6 +7,7 @@ os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5
 os.environ.setdefault("CORS_ALLOW_ORIGINS", "http://localhost:3000")
 os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
 
+from app.bot_detection import detect_known_bot
 from app.main import app
 from app.routers import analytics
 
@@ -21,6 +22,23 @@ class FakeSession:
 
     async def commit(self):
         self.committed = True
+
+
+@pytest.mark.parametrize(
+    ("user_agent", "expected"),
+    [
+        ("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)", "Googlebot"),
+        ("Mozilla/5.0 AppleWebKit/537.36 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)", "Bingbot"),
+        ("Mozilla/5.0 (compatible; GPTBot/1.2; +https://openai.com/gptbot)", "GPTBot"),
+        ("Mozilla/5.0 (compatible; OAI-SearchBot/1.0; +https://openai.com/searchbot)", "OAI-SearchBot"),
+        ("Mozilla/5.0 (compatible; ClaudeBot/1.0; +https://anthropic.com)", "ClaudeBot"),
+        ("Mozilla/5.0 AppleWebKit/537.36 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)", "PerplexityBot"),
+        ("facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)", "FacebookBot"),
+        ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/140.0 Safari/537.36", None),
+    ],
+)
+def test_detect_known_bot(user_agent, expected):
+    assert detect_known_bot(user_agent) == expected
 
 
 @pytest.mark.asyncio
@@ -55,6 +73,7 @@ async def test_product_event_is_accepted_without_personal_data(monkeypatch):
     assert response.status_code == 202
     assert response.json() == {"accepted": True}
     assert session.committed is True
+    assert isinstance(session.added, analytics.ProductEvent)
     assert session.added.event_name == "trip_plan_submitted"
     assert session.added.anonymous_id == "anonymous-12345"
     assert session.added.session_id == "session-12345"
@@ -65,6 +84,41 @@ async def test_product_event_is_accepted_without_personal_data(monkeypatch):
         "tags_count": 2,
     }
     assert not hasattr(session.added, "ip_address")
+    assert not hasattr(session.added, "user_agent")
+
+
+@pytest.mark.asyncio
+async def test_known_bot_event_is_stored_separately_with_bot_name(monkeypatch):
+    session = FakeSession()
+
+    async def override_get_db():
+        yield session
+
+    monkeypatch.setattr(analytics, "_apply_analytics_rate_limit", lambda **kwargs: None)
+    app.dependency_overrides[analytics.get_db] = override_get_db
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post(
+                "/analytics/events",
+                headers={"User-Agent": "Mozilla/5.0 (compatible; GPTBot/1.2; +https://openai.com/gptbot)"},
+                json={
+                    "event_name": "page_view",
+                    "anonymous_id": "anonymous-bot-12345",
+                    "session_id": "session-bot-12345",
+                    "path": "/details/1",
+                    "properties": {"route": "/details/:siteId"},
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(analytics.get_db, None)
+
+    assert response.status_code == 202
+    assert session.committed is True
+    assert isinstance(session.added, analytics.BotEvent)
+    assert session.added.bot_name == "GPTBot"
+    assert session.added.event_name == "page_view"
+    assert session.added.path == "/details/1"
     assert not hasattr(session.added, "user_agent")
 
 

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -2,16 +2,19 @@
 
 Glideator records a small first-party event stream in the `product_events` table. The goal is to understand whether people reach useful forecasts and recommendations without introducing a third-party analytics SDK.
 
+Known crawler traffic is classified at ingestion from the request User-Agent and stored separately in `bot_events`. This keeps the normal product analytics stream human-focused while preserving a lightweight view of crawler activity and the canonical bot identity.
+
 ## Privacy properties
 
-- No IP address, user agent, email address, account ID, or precise coordinates are stored.
+- No IP address, raw user agent, email address, account ID, or precise coordinates are stored.
+- The request User-Agent is inspected transiently only to classify known bots; only the canonical bot name (for example `Googlebot` or `GPTBot`) is persisted in `bot_events`.
 - The frontend sends only `window.location.pathname`, never the URL query string.
 - Property keys that look like coordinates, IP addresses, emails, or user-agent data are removed client-side.
 - Anonymous browser and session IDs are random identifiers stored in `localStorage` and `sessionStorage`.
 - Global Privacy Control and Do Not Track are respected.
 - Set `REACT_APP_ANALYTICS_ENABLED=false` to disable frontend collection entirely.
 
-The ingestion endpoint is `POST /analytics/events`. Payloads and event names are validated, property size is capped, and Redis-backed rate limits protect the endpoint.
+The ingestion endpoint is `POST /analytics/events`. Payloads and event names are validated, property size is capped, and Redis-backed rate limits protect the endpoint. Known bots are diverted into `bot_events`; all other accepted events go to `product_events`.
 
 ## Event catalog
 
@@ -32,6 +35,12 @@ The ingestion endpoint is `POST /analytics/events`. Payloads and event names are
 | `trip_plan_more_requested` | More recommendations were requested | visible and total counts |
 | `recommendation_feedback_submitted` | Contextual helpful/not-helpful feedback | `surface`, `rating`, and recommendation context |
 
+## Bot detection
+
+Known bots are matched against explicit User-Agent signatures and stored with a canonical name. The list covers major search crawlers, AI crawlers/fetchers, social preview bots, and common SEO crawlers. Unknown automation is intentionally left in the normal stream rather than guessed from broad strings such as `bot` or `crawler`.
+
+The administrator cockpit exposes a dedicated **Bots** tab with bot events, sessions, anonymous visitor IDs, and a per-bot breakdown for the selected time window.
+
 ## Starter queries
 
 Daily active anonymous visitors:
@@ -43,6 +52,19 @@ select
 from product_events
 group by 1
 order by 1 desc;
+```
+
+Bot traffic by crawler:
+
+```sql
+select
+    bot_name,
+    count(*) as events,
+    count(distinct session_id) as sessions,
+    count(distinct anonymous_id) as visitors
+from bot_events
+group by 1
+order by events desc, bot_name;
 ```
 
 Trip Planner funnel by day:

--- a/frontend/src/adminApi.js
+++ b/frontend/src/adminApi.js
@@ -20,6 +20,11 @@ export const fetchAdminAnalytics = async (days = 30) => {
   return response.data;
 };
 
+export const fetchAdminBotAnalytics = async (days = 30) => {
+  const response = await apiClient.get('/admin/bot-analytics', { params: { days } });
+  return response.data;
+};
+
 export const fetchAdminForecastRuns = async (limit = 20) => {
   const response = await apiClient.get('/admin/forecast-runs', { params: { limit } });
   return response.data;

--- a/frontend/src/components/admin/AdminBotAnalyticsPanel.jsx
+++ b/frontend/src/components/admin/AdminBotAnalyticsPanel.jsx
@@ -1,0 +1,149 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { fetchAdminBotAnalytics } from '../../adminApi';
+
+const MetricCard = ({ label, value, detail }) => (
+  <Card variant="outlined" sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="overline" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h4" sx={{ mt: 0.5, fontWeight: 700 }}>
+        {value}
+      </Typography>
+      {detail && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {detail}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const AdminBotAnalyticsPanel = () => {
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setData(await fetchAdminBotAnalytics(days));
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load bot analytics.');
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={1.5}
+      >
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700 }}>Bot traffic</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Known crawlers detected from the request User-Agent. Only the canonical bot name is stored; the raw User-Agent is not retained.
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={1}>
+          <TextField
+            select
+            size="small"
+            label="Period"
+            value={days}
+            onChange={(event) => setDays(Number(event.target.value))}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value={7}>7 days</MenuItem>
+            <MenuItem value={30}>30 days</MenuItem>
+            <MenuItem value={90}>90 days</MenuItem>
+            <MenuItem value={365}>1 year</MenuItem>
+          </TextField>
+          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={load} disabled={loading}>
+            Refresh
+          </Button>
+        </Stack>
+      </Stack>
+
+      {loading && <LinearProgress />}
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {data && (
+        <>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} lg={3}>
+              <MetricCard label="Bot events" value={data.total_events.toLocaleString()} detail={`${data.window_days}-day window`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <MetricCard label="Bot sessions" value={data.unique_sessions.toLocaleString()} detail={`${data.unique_visitors.toLocaleString()} anonymous visitor IDs`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <MetricCard label="Bot types" value={data.bot_types} detail="Distinct known crawler identities" />
+            </Grid>
+          </Grid>
+
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Bot</TableCell>
+                  <TableCell align="right">Events</TableCell>
+                  <TableCell align="right">Sessions</TableCell>
+                  <TableCell align="right">Visitor IDs</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.bots.map((row) => (
+                  <TableRow key={row.bot_name} hover>
+                    <TableCell>{row.bot_name}</TableCell>
+                    <TableCell align="right">{row.events.toLocaleString()}</TableCell>
+                    <TableCell align="right">{row.sessions.toLocaleString()}</TableCell>
+                    <TableCell align="right">{row.visitors.toLocaleString()}</TableCell>
+                  </TableRow>
+                ))}
+                {data.bots.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={4} align="center">No known bot traffic captured in this period.</TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export default AdminBotAnalyticsPanel;

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -46,6 +46,7 @@ import {
   triggerAdminForecastCheck,
   updateAdminSite,
 } from '../adminApi';
+import AdminBotAnalyticsPanel from '../components/admin/AdminBotAnalyticsPanel';
 import {
   AdminAnalyticsPanel,
   AdminFeedbackPanel,
@@ -261,6 +262,7 @@ const Admin = () => {
           <Tab label="Forecast runs" />
           <Tab label="Sites" />
           <Tab label="Resources" />
+          <Tab label="Bots" />
         </Tabs>
 
         <Box sx={{ p: { xs: 2, md: 3 } }}>
@@ -497,6 +499,8 @@ const Admin = () => {
               )}
             </Stack>
           )}
+
+          {tab === 7 && <AdminBotAnalyticsPanel />}
         </Box>
       </Paper>
 


### PR DESCRIPTION
## Summary
- classify known crawler User-Agents at analytics ingestion
- keep normal `product_events` human-focused by diverting detected crawlers to a dedicated `bot_events` table
- persist only a canonical bot name, never the raw User-Agent
- add an admin `Bots` tab with totals and per-bot events/sessions/visitor IDs
- cover major search, AI, social-preview, and SEO crawler signatures
- add migration, routing tests, classifier tests, and analytics documentation

## Notes
- no historical backfill by design
- detection is User-Agent based, so this identifies declared known bots rather than cryptographically verifying crawler origin
- simple crawlers that never execute the frontend analytics call will not appear in this event stream

## Tests
- classifier unit cases for Googlebot, Bingbot, GPTBot, OAI-SearchBot, ClaudeBot, PerplexityBot, FacebookBot, and a normal browser
- endpoint test verifies known bot events are written as `BotEvent` and raw User-Agent is not retained
- existing normal analytics event test verifies human traffic remains `ProductEvent`