### PR TITLE
Fix admin analytics funnel metrics

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException
 from .database import AsyncSessionLocal, SessionLocal
 from .routers import (
     admin,
+    admin_analytics,
     admin_bot_analytics,
     analytics,
     auth,
@@ -174,6 +175,8 @@ app.include_router(s2s.router)
 app.include_router(d2d.router)
 app.include_router(feedback.router)
 app.include_router(analytics.router)
+# Keep corrected analytics route ahead of the legacy admin router so it owns GET /admin/analytics.
+app.include_router(admin_analytics.router)
 app.include_router(admin.router)
 app.include_router(admin_bot_analytics.router)
 

--- a/backend/app/routers/admin_analytics.py
+++ b/backend/app/routers/admin_analytics.py
@@ -1,0 +1,316 @@
+from datetime import datetime, timedelta, timezone
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from .admin import (
+    AnalyticsDailyPoint,
+    AnalyticsEventCount,
+    AnalyticsFeedbackSurface,
+    AnalyticsPathCount,
+    AnalyticsSiteInteraction,
+    get_db,
+    require_admin,
+    _rate,
+)
+from .analytics import ProductEvent
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+class AnalyticsFunnel(BaseModel):
+    planner_sessions: int = 0
+    submitted_sessions: int = 0
+    results_sessions: int = 0
+    opened_site_sessions: int = 0
+    results_rate: float = 0
+    site_open_rate: float = 0
+
+
+class AdminAnalyticsResponse(BaseModel):
+    window_days: int
+    total_events: int
+    unique_visitors: int
+    unique_sessions: int
+    map_sessions: int
+    site_detail_sessions: int
+    map_to_site_sessions: int
+    map_site_open_events: int
+    sites_opened_per_map_session: float
+    map_to_site_rate: float
+    daily: List[AnalyticsDailyPoint]
+    event_counts: List[AnalyticsEventCount]
+    top_paths: List[AnalyticsPathCount]
+    trip_planner: AnalyticsFunnel
+    recommendation_feedback: List[AnalyticsFeedbackSurface]
+    top_sites: List[AnalyticsSiteInteraction]
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(numerator / denominator, 2)
+
+
+@router.get("/analytics", response_model=AdminAnalyticsResponse)
+async def get_analytics(
+    days: int = Query(default=30, ge=1, le=365),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    summary = (
+        await db.execute(
+            select(
+                func.count(ProductEvent.event_id),
+                func.count(func.distinct(ProductEvent.anonymous_id)),
+                func.count(func.distinct(ProductEvent.session_id)),
+            ).where(ProductEvent.created_at >= cutoff)
+        )
+    ).one()
+
+    daily_result = await db.execute(
+        text(
+            """
+            SELECT
+                date_trunc('day', created_at)::date AS day,
+                COUNT(DISTINCT anonymous_id) AS visitors,
+                COUNT(DISTINCT session_id) AS sessions,
+                COUNT(*) AS events
+            FROM product_events
+            WHERE created_at >= :cutoff
+            GROUP BY 1
+            ORDER BY 1
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    daily = [
+        AnalyticsDailyPoint(
+            day=row["day"].isoformat(),
+            visitors=int(row["visitors"] or 0),
+            sessions=int(row["sessions"] or 0),
+            events=int(row["events"] or 0),
+        )
+        for row in daily_result.mappings().all()
+    ]
+
+    event_result = await db.execute(
+        text(
+            """
+            SELECT
+                event_name,
+                COUNT(*) AS events,
+                COUNT(DISTINCT anonymous_id) AS visitors
+            FROM product_events
+            WHERE created_at >= :cutoff
+            GROUP BY event_name
+            ORDER BY events DESC, event_name
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    event_counts = [AnalyticsEventCount(**dict(row)) for row in event_result.mappings().all()]
+
+    path_result = await db.execute(
+        text(
+            """
+            SELECT
+                COALESCE(NULLIF(path, ''), '(unknown)') AS path,
+                COUNT(*) AS events,
+                COUNT(DISTINCT anonymous_id) AS visitors
+            FROM product_events
+            WHERE created_at >= :cutoff
+            GROUP BY 1
+            ORDER BY events DESC, path
+            LIMIT 20
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    top_paths = [AnalyticsPathCount(**dict(row)) for row in path_result.mappings().all()]
+
+    engagement_row = (
+        await db.execute(
+            text(
+                """
+                WITH scoped AS (
+                    SELECT event_id, session_id, event_name, path, created_at
+                    FROM product_events
+                    WHERE created_at >= :cutoff
+                ),
+                map_entries AS (
+                    SELECT session_id, MIN(created_at) AS first_map_at
+                    FROM scoped
+                    WHERE event_name = 'page_view' AND path = '/'
+                    GROUP BY session_id
+                ),
+                map_activity AS (
+                    SELECT
+                        m.session_id,
+                        COUNT(e.event_id) FILTER (
+                            WHERE e.event_name = 'site_detail_viewed'
+                              AND e.created_at >= m.first_map_at
+                        ) AS site_open_events
+                    FROM map_entries m
+                    LEFT JOIN scoped e ON e.session_id = m.session_id
+                    GROUP BY m.session_id
+                ),
+                planner_entries AS (
+                    SELECT session_id, MIN(created_at) AS first_planner_at
+                    FROM scoped
+                    WHERE event_name = 'page_view' AND path = '/trip-planner'
+                    GROUP BY session_id
+                ),
+                planner_activity AS (
+                    SELECT
+                        p.session_id,
+                        COUNT(e.event_id) FILTER (
+                            WHERE e.event_name = 'trip_plan_submitted'
+                              AND e.created_at >= p.first_planner_at
+                        ) AS submits,
+                        COUNT(e.event_id) FILTER (
+                            WHERE e.event_name = 'trip_plan_results_viewed'
+                              AND e.created_at >= p.first_planner_at
+                        ) AS results,
+                        COUNT(e.event_id) FILTER (
+                            WHERE e.event_name = 'trip_plan_site_opened'
+                              AND e.created_at >= p.first_planner_at
+                        ) AS site_opens
+                    FROM planner_entries p
+                    LEFT JOIN scoped e ON e.session_id = p.session_id
+                    GROUP BY p.session_id
+                )
+                SELECT
+                    (SELECT COUNT(*) FROM map_entries) AS map_sessions,
+                    (
+                        SELECT COUNT(DISTINCT session_id)
+                        FROM scoped
+                        WHERE event_name = 'site_detail_viewed'
+                    ) AS site_detail_sessions,
+                    (
+                        SELECT COUNT(*)
+                        FROM map_activity
+                        WHERE site_open_events > 0
+                    ) AS map_to_site_sessions,
+                    (
+                        SELECT COALESCE(SUM(site_open_events), 0)
+                        FROM map_activity
+                    ) AS map_site_open_events,
+                    (SELECT COUNT(*) FROM planner_entries) AS planner_sessions,
+                    (
+                        SELECT COUNT(*)
+                        FROM planner_activity
+                        WHERE submits > 0
+                    ) AS submitted_sessions,
+                    (
+                        SELECT COUNT(*)
+                        FROM planner_activity
+                        WHERE results > 0
+                    ) AS results_sessions,
+                    (
+                        SELECT COUNT(*)
+                        FROM planner_activity
+                        WHERE results > 0 AND site_opens > 0
+                    ) AS opened_site_sessions
+                """
+            ),
+            {"cutoff": cutoff},
+        )
+    ).mappings().one()
+
+    map_sessions = int(engagement_row["map_sessions"] or 0)
+    site_detail_sessions = int(engagement_row["site_detail_sessions"] or 0)
+    map_to_site_sessions = int(engagement_row["map_to_site_sessions"] or 0)
+    map_site_open_events = int(engagement_row["map_site_open_events"] or 0)
+    planner_sessions = int(engagement_row["planner_sessions"] or 0)
+    submitted_sessions = int(engagement_row["submitted_sessions"] or 0)
+    results_sessions = int(engagement_row["results_sessions"] or 0)
+    opened_site_sessions = int(engagement_row["opened_site_sessions"] or 0)
+
+    feedback_result = await db.execute(
+        text(
+            """
+            SELECT
+                COALESCE(NULLIF(properties ->> 'surface', ''), '(unknown)') AS surface,
+                COUNT(*) FILTER (WHERE properties ->> 'rating' = 'helpful') AS helpful,
+                COUNT(*) FILTER (WHERE properties ->> 'rating' = 'not_helpful') AS not_helpful,
+                COUNT(*) AS total
+            FROM product_events
+            WHERE created_at >= :cutoff
+              AND event_name = 'recommendation_feedback_submitted'
+            GROUP BY 1
+            ORDER BY total DESC, surface
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    recommendation_feedback = []
+    for row in feedback_result.mappings().all():
+        helpful = int(row["helpful"] or 0)
+        total = int(row["total"] or 0)
+        recommendation_feedback.append(
+            AnalyticsFeedbackSurface(
+                surface=row["surface"],
+                helpful=helpful,
+                not_helpful=int(row["not_helpful"] or 0),
+                total=total,
+                helpful_rate=_rate(helpful, total) if total else None,
+            )
+        )
+
+    top_sites_result = await db.execute(
+        text(
+            """
+            SELECT
+                NULLIF(e.properties ->> 'site_id', '')::integer AS site_id,
+                MAX(s.name) AS site_name,
+                COUNT(*) AS interactions,
+                COUNT(DISTINCT e.anonymous_id) AS visitors
+            FROM product_events e
+            LEFT JOIN sites s
+              ON s.site_id = NULLIF(e.properties ->> 'site_id', '')::integer
+            WHERE e.created_at >= :cutoff
+              AND e.event_name IN ('site_detail_viewed', 'trip_plan_site_opened')
+              AND NULLIF(e.properties ->> 'site_id', '') IS NOT NULL
+            GROUP BY 1
+            ORDER BY interactions DESC, site_id
+            LIMIT 15
+            """
+        ),
+        {"cutoff": cutoff},
+    )
+    top_sites = [
+        AnalyticsSiteInteraction(**dict(row)) for row in top_sites_result.mappings().all()
+    ]
+
+    return AdminAnalyticsResponse(
+        window_days=days,
+        total_events=int(summary[0] or 0),
+        unique_visitors=int(summary[1] or 0),
+        unique_sessions=int(summary[2] or 0),
+        map_sessions=map_sessions,
+        site_detail_sessions=site_detail_sessions,
+        map_to_site_sessions=map_to_site_sessions,
+        map_site_open_events=map_site_open_events,
+        sites_opened_per_map_session=_ratio(map_site_open_events, map_sessions),
+        map_to_site_rate=_rate(map_to_site_sessions, map_sessions),
+        daily=daily,
+        event_counts=event_counts,
+        top_paths=top_paths,
+        trip_planner=AnalyticsFunnel(
+            planner_sessions=planner_sessions,
+            submitted_sessions=submitted_sessions,
+            results_sessions=results_sessions,
+            opened_site_sessions=opened_site_sessions,
+            results_rate=_rate(results_sessions, planner_sessions),
+            site_open_rate=_rate(opened_site_sessions, results_sessions),
+        ),
+        recommendation_feedback=recommendation_feedback,
+        top_sites=top_sites,
+    )

--- a/backend/app/routers/admin_analytics.py
+++ b/backend/app/routers/admin_analytics.py
@@ -1,53 +1,24 @@
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
-from sqlalchemy import func, select, text
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from .. import models
-from .admin import (
-    AnalyticsDailyPoint,
-    AnalyticsEventCount,
-    AnalyticsFeedbackSurface,
-    AnalyticsPathCount,
-    AnalyticsSiteInteraction,
-    get_db,
-    require_admin,
-    _rate,
-)
-from .analytics import ProductEvent
+from . import admin
 
 router = APIRouter(prefix="/admin", tags=["Admin"])
 
 
-class AnalyticsFunnel(BaseModel):
+class AnalyticsFunnel(admin.AnalyticsFunnel):
     planner_sessions: int = 0
-    submitted_sessions: int = 0
-    results_sessions: int = 0
-    opened_site_sessions: int = 0
-    results_rate: float = 0
-    site_open_rate: float = 0
 
 
-class AdminAnalyticsResponse(BaseModel):
-    window_days: int
-    total_events: int
-    unique_visitors: int
-    unique_sessions: int
-    map_sessions: int
-    site_detail_sessions: int
-    map_to_site_sessions: int
-    map_site_open_events: int
-    sites_opened_per_map_session: float
-    map_to_site_rate: float
-    daily: List[AnalyticsDailyPoint]
-    event_counts: List[AnalyticsEventCount]
-    top_paths: List[AnalyticsPathCount]
+class AdminAnalyticsResponse(admin.AdminAnalyticsResponse):
+    map_to_site_sessions: int = 0
+    map_site_open_events: int = 0
+    sites_opened_per_map_session: float = 0
     trip_planner: AnalyticsFunnel
-    recommendation_feedback: List[AnalyticsFeedbackSurface]
-    top_sites: List[AnalyticsSiteInteraction]
 
 
 def _ratio(numerator: int, denominator: int) -> float:
@@ -59,81 +30,13 @@ def _ratio(numerator: int, denominator: int) -> float:
 @router.get("/analytics", response_model=AdminAnalyticsResponse)
 async def get_analytics(
     days: int = Query(default=30, ge=1, le=365),
-    _: models.User = Depends(require_admin),
-    db: AsyncSession = Depends(get_db),
+    _: models.User = Depends(admin.require_admin),
+    db: AsyncSession = Depends(admin.get_db),
 ):
+    # Reuse the legacy endpoint for the broad analytics payload and replace only
+    # the engagement metrics whose denominators need session sequencing.
+    base = await admin.get_analytics(days=days, _=_, db=db)
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
-
-    summary = (
-        await db.execute(
-            select(
-                func.count(ProductEvent.event_id),
-                func.count(func.distinct(ProductEvent.anonymous_id)),
-                func.count(func.distinct(ProductEvent.session_id)),
-            ).where(ProductEvent.created_at >= cutoff)
-        )
-    ).one()
-
-    daily_result = await db.execute(
-        text(
-            """
-            SELECT
-                date_trunc('day', created_at)::date AS day,
-                COUNT(DISTINCT anonymous_id) AS visitors,
-                COUNT(DISTINCT session_id) AS sessions,
-                COUNT(*) AS events
-            FROM product_events
-            WHERE created_at >= :cutoff
-            GROUP BY 1
-            ORDER BY 1
-            """
-        ),
-        {"cutoff": cutoff},
-    )
-    daily = [
-        AnalyticsDailyPoint(
-            day=row["day"].isoformat(),
-            visitors=int(row["visitors"] or 0),
-            sessions=int(row["sessions"] or 0),
-            events=int(row["events"] or 0),
-        )
-        for row in daily_result.mappings().all()
-    ]
-
-    event_result = await db.execute(
-        text(
-            """
-            SELECT
-                event_name,
-                COUNT(*) AS events,
-                COUNT(DISTINCT anonymous_id) AS visitors
-            FROM product_events
-            WHERE created_at >= :cutoff
-            GROUP BY event_name
-            ORDER BY events DESC, event_name
-            """
-        ),
-        {"cutoff": cutoff},
-    )
-    event_counts = [AnalyticsEventCount(**dict(row)) for row in event_result.mappings().all()]
-
-    path_result = await db.execute(
-        text(
-            """
-            SELECT
-                COALESCE(NULLIF(path, ''), '(unknown)') AS path,
-                COUNT(*) AS events,
-                COUNT(DISTINCT anonymous_id) AS visitors
-            FROM product_events
-            WHERE created_at >= :cutoff
-            GROUP BY 1
-            ORDER BY events DESC, path
-            LIMIT 20
-            """
-        ),
-        {"cutoff": cutoff},
-    )
-    top_paths = [AnalyticsPathCount(**dict(row)) for row in path_result.mappings().all()]
 
     engagement_row = (
         await db.execute(
@@ -189,11 +92,6 @@ async def get_analytics(
                 SELECT
                     (SELECT COUNT(*) FROM map_entries) AS map_sessions,
                     (
-                        SELECT COUNT(DISTINCT session_id)
-                        FROM scoped
-                        WHERE event_name = 'site_detail_viewed'
-                    ) AS site_detail_sessions,
-                    (
                         SELECT COUNT(*)
                         FROM map_activity
                         WHERE site_open_events > 0
@@ -225,7 +123,6 @@ async def get_analytics(
     ).mappings().one()
 
     map_sessions = int(engagement_row["map_sessions"] or 0)
-    site_detail_sessions = int(engagement_row["site_detail_sessions"] or 0)
     map_to_site_sessions = int(engagement_row["map_to_site_sessions"] or 0)
     map_site_open_events = int(engagement_row["map_site_open_events"] or 0)
     planner_sessions = int(engagement_row["planner_sessions"] or 0)
@@ -233,84 +130,21 @@ async def get_analytics(
     results_sessions = int(engagement_row["results_sessions"] or 0)
     opened_site_sessions = int(engagement_row["opened_site_sessions"] or 0)
 
-    feedback_result = await db.execute(
-        text(
-            """
-            SELECT
-                COALESCE(NULLIF(properties ->> 'surface', ''), '(unknown)') AS surface,
-                COUNT(*) FILTER (WHERE properties ->> 'rating' = 'helpful') AS helpful,
-                COUNT(*) FILTER (WHERE properties ->> 'rating' = 'not_helpful') AS not_helpful,
-                COUNT(*) AS total
-            FROM product_events
-            WHERE created_at >= :cutoff
-              AND event_name = 'recommendation_feedback_submitted'
-            GROUP BY 1
-            ORDER BY total DESC, surface
-            """
-        ),
-        {"cutoff": cutoff},
-    )
-    recommendation_feedback = []
-    for row in feedback_result.mappings().all():
-        helpful = int(row["helpful"] or 0)
-        total = int(row["total"] or 0)
-        recommendation_feedback.append(
-            AnalyticsFeedbackSurface(
-                surface=row["surface"],
-                helpful=helpful,
-                not_helpful=int(row["not_helpful"] or 0),
-                total=total,
-                helpful_rate=_rate(helpful, total) if total else None,
-            )
-        )
-
-    top_sites_result = await db.execute(
-        text(
-            """
-            SELECT
-                NULLIF(e.properties ->> 'site_id', '')::integer AS site_id,
-                MAX(s.name) AS site_name,
-                COUNT(*) AS interactions,
-                COUNT(DISTINCT e.anonymous_id) AS visitors
-            FROM product_events e
-            LEFT JOIN sites s
-              ON s.site_id = NULLIF(e.properties ->> 'site_id', '')::integer
-            WHERE e.created_at >= :cutoff
-              AND e.event_name IN ('site_detail_viewed', 'trip_plan_site_opened')
-              AND NULLIF(e.properties ->> 'site_id', '') IS NOT NULL
-            GROUP BY 1
-            ORDER BY interactions DESC, site_id
-            LIMIT 15
-            """
-        ),
-        {"cutoff": cutoff},
-    )
-    top_sites = [
-        AnalyticsSiteInteraction(**dict(row)) for row in top_sites_result.mappings().all()
-    ]
-
-    return AdminAnalyticsResponse(
-        window_days=days,
-        total_events=int(summary[0] or 0),
-        unique_visitors=int(summary[1] or 0),
-        unique_sessions=int(summary[2] or 0),
+    payload = base.model_dump()
+    payload.update(
         map_sessions=map_sessions,
-        site_detail_sessions=site_detail_sessions,
         map_to_site_sessions=map_to_site_sessions,
         map_site_open_events=map_site_open_events,
         sites_opened_per_map_session=_ratio(map_site_open_events, map_sessions),
-        map_to_site_rate=_rate(map_to_site_sessions, map_sessions),
-        daily=daily,
-        event_counts=event_counts,
-        top_paths=top_paths,
-        trip_planner=AnalyticsFunnel(
-            planner_sessions=planner_sessions,
-            submitted_sessions=submitted_sessions,
-            results_sessions=results_sessions,
-            opened_site_sessions=opened_site_sessions,
-            results_rate=_rate(results_sessions, planner_sessions),
-            site_open_rate=_rate(opened_site_sessions, results_sessions),
-        ),
-        recommendation_feedback=recommendation_feedback,
-        top_sites=top_sites,
+        map_to_site_rate=admin._rate(map_to_site_sessions, map_sessions),
+        trip_planner={
+            **base.trip_planner.model_dump(),
+            "planner_sessions": planner_sessions,
+            "submitted_sessions": submitted_sessions,
+            "results_sessions": results_sessions,
+            "opened_site_sessions": opened_site_sessions,
+            "results_rate": admin._rate(results_sessions, planner_sessions),
+            "site_open_rate": admin._rate(opened_site_sessions, results_sessions),
+        },
     )
+    return AdminAnalyticsResponse(**payload)

--- a/backend/tests/test_admin_analytics.py
+++ b/backend/tests/test_admin_analytics.py
@@ -1,0 +1,104 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret")
+
+from app.routers import admin, admin_analytics
+
+
+class FakeMappings:
+    def __init__(self, row):
+        self.row = row
+
+    def one(self):
+        return self.row
+
+
+class FakeResult:
+    def __init__(self, row):
+        self.row = row
+
+    def mappings(self):
+        return FakeMappings(self.row)
+
+
+class FakeDb:
+    def __init__(self, row):
+        self.row = row
+        self.statement = None
+
+    async def execute(self, statement, params):
+        self.statement = str(statement)
+        return FakeResult(self.row)
+
+
+def empty_base_response():
+    return admin.AdminAnalyticsResponse(
+        window_days=30,
+        total_events=20,
+        unique_visitors=8,
+        unique_sessions=10,
+        map_sessions=9,
+        site_detail_sessions=7,
+        map_to_site_rate=77.8,
+        daily=[],
+        event_counts=[],
+        top_paths=[],
+        trip_planner=admin.AnalyticsFunnel(
+            submitted_sessions=0,
+            results_sessions=4,
+            opened_site_sessions=2,
+            results_rate=0,
+            site_open_rate=50,
+        ),
+        recommendation_feedback=[],
+        top_sites=[],
+    )
+
+
+def test_ratio_is_safe_and_rounded():
+    assert admin_analytics._ratio(7, 4) == 1.75
+    assert admin_analytics._ratio(1, 3) == 0.33
+    assert admin_analytics._ratio(4, 0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_engagement_metrics_use_sequenced_session_denominators(monkeypatch):
+    base = empty_base_response()
+
+    async def fake_legacy_analytics(*, days, _, db):
+        assert days == 30
+        return base
+
+    monkeypatch.setattr(admin_analytics.admin, "get_analytics", fake_legacy_analytics)
+    db = FakeDb(
+        {
+            "map_sessions": 4,
+            "map_to_site_sessions": 3,
+            "map_site_open_events": 7,
+            "planner_sessions": 5,
+            "submitted_sessions": 2,
+            "results_sessions": 4,
+            "opened_site_sessions": 2,
+        }
+    )
+
+    result = await admin_analytics.get_analytics(days=30, _=SimpleNamespace(), db=db)
+
+    assert result.map_sessions == 4
+    assert result.site_detail_sessions == 7
+    assert result.map_to_site_sessions == 3
+    assert result.map_to_site_rate == 75.0
+    assert result.map_site_open_events == 7
+    assert result.sites_opened_per_map_session == 1.75
+    assert result.trip_planner.planner_sessions == 5
+    assert result.trip_planner.submitted_sessions == 2
+    assert result.trip_planner.results_sessions == 4
+    assert result.trip_planner.results_rate == 80.0
+    assert result.trip_planner.opened_site_sessions == 2
+    assert result.trip_planner.site_open_rate == 50.0
+    assert "e.created_at >= m.first_map_at" in db.statement
+    assert "e.created_at >= p.first_planner_at" in db.statement

--- a/frontend/src/components/admin/AdminAnalyticsPanel.jsx
+++ b/frontend/src/components/admin/AdminAnalyticsPanel.jsx
@@ -1,0 +1,327 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { fetchAdminAnalytics } from '../../adminApi';
+
+const InsightCard = ({ label, value, detail }) => (
+  <Card variant="outlined" sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="overline" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h4" sx={{ mt: 0.5, fontWeight: 700 }}>
+        {value}
+      </Typography>
+      {detail && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {detail}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const SectionTitle = ({ children, detail }) => (
+  <Box sx={{ mb: 1.5 }}>
+    <Typography variant="h6" sx={{ fontWeight: 700 }}>{children}</Typography>
+    {detail && <Typography variant="body2" color="text.secondary">{detail}</Typography>}
+  </Box>
+);
+
+const ActivityBars = ({ daily }) => {
+  const maxVisitors = useMemo(
+    () => Math.max(1, ...(daily || []).map((point) => point.visitors)),
+    [daily],
+  );
+
+  if (!daily?.length) {
+    return <Typography color="text.secondary">No activity in this period.</Typography>;
+  }
+
+  return (
+    <Stack spacing={1}>
+      {daily.map((point) => (
+        <Stack key={point.day} direction="row" spacing={1.5} alignItems="center">
+          <Typography variant="caption" sx={{ width: 78, flexShrink: 0 }}>
+            {point.day.slice(5)}
+          </Typography>
+          <Box sx={{ flexGrow: 1, height: 10, backgroundColor: 'action.hover', borderRadius: 1 }}>
+            <Box
+              sx={{
+                width: `${Math.max(3, 100 * point.visitors / maxVisitors)}%`,
+                height: '100%',
+                backgroundColor: 'primary.main',
+                borderRadius: 1,
+              }}
+            />
+          </Box>
+          <Typography variant="caption" sx={{ width: 110, textAlign: 'right', flexShrink: 0 }}>
+            {point.visitors} visitors · {point.sessions} sessions
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+};
+
+const AdminAnalyticsPanel = () => {
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setData(await fetchAdminAnalytics(days));
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load product analytics.');
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={1.5}
+      >
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700 }}>Product analytics</Typography>
+          <Typography variant="body2" color="text.secondary">
+            First-party anonymous visitors, sessions and meaningful product actions.
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={1}>
+          <TextField
+            select
+            size="small"
+            label="Period"
+            value={days}
+            onChange={(event) => setDays(Number(event.target.value))}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value={7}>7 days</MenuItem>
+            <MenuItem value={30}>30 days</MenuItem>
+            <MenuItem value={90}>90 days</MenuItem>
+            <MenuItem value={365}>1 year</MenuItem>
+          </TextField>
+          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={load} disabled={loading}>
+            Refresh
+          </Button>
+        </Stack>
+      </Stack>
+
+      {loading && <LinearProgress />}
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {data && (
+        <>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Anonymous visitors" value={data.unique_visitors} detail={`${data.window_days}-day window`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard label="Sessions" value={data.unique_sessions} detail={`${data.total_events.toLocaleString()} captured events`} />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard
+                label="Map → site"
+                value={`${data.map_to_site_rate}%`}
+                detail={`${data.map_to_site_sessions} of ${data.map_sessions} map sessions opened a site`}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <InsightCard
+                label="Site opens / map session"
+                value={data.sites_opened_per_map_session}
+                detail={`${data.map_site_open_events} site opens across ${data.map_sessions} map sessions`}
+              />
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} lg={7}>
+              <Paper variant="outlined" sx={{ p: 2.5, height: '100%' }}>
+                <SectionTitle detail="Distinct anonymous visitors and sessions by day">Daily activity</SectionTitle>
+                <ActivityBars daily={data.daily} />
+              </Paper>
+            </Grid>
+            <Grid item xs={12} lg={5}>
+              <Paper variant="outlined" sx={{ p: 2.5, height: '100%' }}>
+                <SectionTitle detail="Distinct sessions: planner visit → results → suggested site">Trip Planner funnel</SectionTitle>
+                <Stack spacing={1.5}>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography>Planner sessions</Typography>
+                    <Typography fontWeight={700}>{data.trip_planner.planner_sessions}</Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography>Viewed results</Typography>
+                    <Typography fontWeight={700}>
+                      {data.trip_planner.results_sessions} ({data.trip_planner.results_rate}%)
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography>Opened a suggested site</Typography>
+                    <Typography fontWeight={700}>
+                      {data.trip_planner.opened_site_sessions} ({data.trip_planner.site_open_rate}%)
+                    </Typography>
+                  </Stack>
+                  <Stack direction="row" justifyContent="space-between">
+                    <Typography color="text.secondary">Explicit criteria submits</Typography>
+                    <Typography color="text.secondary" fontWeight={700}>
+                      {data.trip_planner.submitted_sessions}
+                    </Typography>
+                  </Stack>
+                </Stack>
+              </Paper>
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="What visitors actually do">Top events</SectionTitle>
+                <TableContainer sx={{ maxHeight: 360 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Event</TableCell>
+                        <TableCell align="right">Events</TableCell>
+                        <TableCell align="right">Visitors</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.event_counts.map((row) => (
+                        <TableRow key={row.event_name} hover>
+                          <TableCell>{row.event_name}</TableCell>
+                          <TableCell align="right">{row.events}</TableCell>
+                          <TableCell align="right">{row.visitors}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="Site-detail and planner-result interactions">Most engaged sites</SectionTitle>
+                <TableContainer sx={{ maxHeight: 360 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Site</TableCell>
+                        <TableCell align="right">Interactions</TableCell>
+                        <TableCell align="right">Visitors</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.top_sites.map((row) => (
+                        <TableRow key={row.site_id || row.site_name} hover>
+                          <TableCell>{row.site_name || `Site ${row.site_id}`}</TableCell>
+                          <TableCell align="right">{row.interactions}</TableCell>
+                          <TableCell align="right">{row.visitors}</TableCell>
+                        </TableRow>
+                      ))}
+                      {data.top_sites.length === 0 && (
+                        <TableRow><TableCell colSpan={3}>No site interactions yet.</TableCell></TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+          </Grid>
+
+          <Grid container spacing={3}>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="Contextual helpful / not-helpful responses">Recommendation feedback</SectionTitle>
+                <TableContainer>
+                  <Table size="small">
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Surface</TableCell>
+                        <TableCell align="right">Helpful</TableCell>
+                        <TableCell align="right">Not helpful</TableCell>
+                        <TableCell align="right">Rate</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.recommendation_feedback.map((row) => (
+                        <TableRow key={row.surface} hover>
+                          <TableCell>{row.surface}</TableCell>
+                          <TableCell align="right">{row.helpful}</TableCell>
+                          <TableCell align="right">{row.not_helpful}</TableCell>
+                          <TableCell align="right">{row.helpful_rate == null ? '—' : `${row.helpful_rate}%`}</TableCell>
+                        </TableRow>
+                      ))}
+                      {data.recommendation_feedback.length === 0 && (
+                        <TableRow><TableCell colSpan={4}>No contextual feedback yet.</TableCell></TableRow>
+                      )}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+            <Grid item xs={12} lg={6}>
+              <Paper variant="outlined" sx={{ p: 2.5 }}>
+                <SectionTitle detail="Routes receiving the most captured activity">Top paths</SectionTitle>
+                <TableContainer sx={{ maxHeight: 320 }}>
+                  <Table size="small" stickyHeader>
+                    <TableHead>
+                      <TableRow>
+                        <TableCell>Path</TableCell>
+                        <TableCell align="right">Events</TableCell>
+                        <TableCell align="right">Visitors</TableCell>
+                      </TableRow>
+                    </TableHead>
+                    <TableBody>
+                      {data.top_paths.map((row) => (
+                        <TableRow key={row.path} hover>
+                          <TableCell>{row.path}</TableCell>
+                          <TableCell align="right">{row.events}</TableCell>
+                          <TableCell align="right">{row.visitors}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </TableContainer>
+              </Paper>
+            </Grid>
+          </Grid>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export default AdminAnalyticsPanel;

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -37,7 +37,6 @@ import EditIcon from '@mui/icons-material/Edit';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import RefreshIcon from '@mui/icons-material/Refresh';
-import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import {
   fetchAdminForecastRuns,
   fetchAdminOverview,
@@ -46,9 +45,9 @@ import {
   triggerAdminForecastCheck,
   updateAdminSite,
 } from '../adminApi';
+import AdminAnalyticsPanel from '../components/admin/AdminAnalyticsPanel';
 import AdminBotAnalyticsPanel from '../components/admin/AdminBotAnalyticsPanel';
 import {
-  AdminAnalyticsPanel,
   AdminFeedbackPanel,
   AdminUsersPanel,
 } from '../components/admin/AdminInsightPanels';

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -37,6 +37,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import RefreshIcon from '@mui/icons-material/Refresh';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import {
   fetchAdminForecastRuns,
   fetchAdminOverview,


### PR DESCRIPTION
## What changed
- make **Map → site** a real session conversion: map sessions that subsequently opened at least one site / map sessions
- add **Site opens / map session** as a separate exploration-depth metric
- sequence site opens after the first map view in the session, so direct site traffic no longer inflates conversion
- fix the Trip Planner funnel denominator to start from `/trip-planner` sessions rather than explicit submit clicks (results load automatically today)
- keep explicit criteria submits as a separate diagnostic
- add backend coverage for the corrected engagement calculations

This addresses the impossible `305.7%` map conversion and the `18 of 0` planner display.