### PR TITLE
Add first-class site aliases

### DIFF
--- a/backend/alembic/versions/0013_site_aliases.py
+++ b/backend/alembic/versions/0013_site_aliases.py
@@ -1,0 +1,100 @@
+"""Add first-class site aliases.
+
+Revision ID: 0013_site_aliases
+Revises: 0012_bot_events
+Create Date: 2026-08-27
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0013_site_aliases"
+down_revision = "0012_bot_events"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "site_aliases",
+        sa.Column("alias_id", sa.Integer(), nullable=False),
+        sa.Column("site_id", sa.Integer(), nullable=False),
+        sa.Column("alias", sa.String(), nullable=False),
+        sa.Column("alias_normalized", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["site_id"],
+            ["sites.site_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("alias_id"),
+        sa.UniqueConstraint(
+            "site_id",
+            "alias_normalized",
+            name="uq_site_alias_site_normalized",
+        ),
+    )
+    op.create_index(
+        op.f("ix_site_aliases_alias_id"),
+        "site_aliases",
+        ["alias_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_site_aliases_site_id"),
+        "site_aliases",
+        ["site_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_site_aliases_alias_normalized"),
+        "site_aliases",
+        ["alias_normalized"],
+        unique=False,
+    )
+
+    # Seed only aliases that add semantics beyond accent/case normalization.
+    # INSERT ... SELECT keeps fresh/empty databases valid if sites are seeded later.
+    op.execute(
+        """
+        INSERT INTO site_aliases (site_id, alias, alias_normalized)
+        SELECT site_id, 'Monte Grappa', 'monte grappa'
+        FROM sites
+        WHERE name = 'Bassano'
+        ON CONFLICT ON CONSTRAINT uq_site_alias_site_normalized DO NOTHING
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO site_aliases (site_id, alias, alias_normalized)
+        SELECT site_id, 'Bassano del Grappa', 'bassano del grappa'
+        FROM sites
+        WHERE name = 'Bassano'
+        ON CONFLICT ON CONSTRAINT uq_site_alias_site_normalized DO NOTHING
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO site_aliases (site_id, alias, alias_normalized)
+        SELECT site_id, 'Monte Valinis', 'monte valinis'
+        FROM sites
+        WHERE name = 'Meduno'
+        ON CONFLICT ON CONSTRAINT uq_site_alias_site_normalized DO NOTHING
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO site_aliases (site_id, alias, alias_normalized)
+        SELECT site_id, 'Valinis', 'valinis'
+        FROM sites
+        WHERE name = 'Meduno'
+        ON CONFLICT ON CONSTRAINT uq_site_alias_site_normalized DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_site_aliases_alias_normalized"), table_name="site_aliases")
+    op.drop_index(op.f("ix_site_aliases_site_id"), table_name="site_aliases")
+    op.drop_index(op.f("ix_site_aliases_alias_id"), table_name="site_aliases")
+    op.drop_table("site_aliases")

--- a/backend/app/data/site_aliases.csv
+++ b/backend/app/data/site_aliases.csv
@@ -1,0 +1,5 @@
+site_id,alias
+133,Monte Grappa
+133,Bassano del Grappa
+135,Monte Valinis
+135,Valinis

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from .security import is_production
 
 from .services.sites_loader import load_sites_from_csv
+from .services.site_aliases_loader import load_site_aliases_from_csv
 from .services.flight_stats_loader import load_flight_stats_from_csv
 from .services.spots_loader import load_spots_from_csv
 from .services.sites_info_loader import load_sites_info_from_jsonl
@@ -73,6 +74,9 @@ def startup_logic():
             try:
                 logger.info("Loading sites data...")
                 load_sites_from_csv(db, 'sites.csv')
+
+                logger.info("Loading site aliases data...")
+                load_site_aliases_from_csv(db)
                 
                 logger.info("Loading flight stats data...")
                 load_flight_stats_from_csv(db)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -328,3 +328,21 @@ class FeedbackSubmission(Base):
     message = Column(Text, nullable=False)
     user_id = Column(Integer, ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True, index=True)
     created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+class SiteAlias(Base):
+    __tablename__ = "site_aliases"
+    __table_args__ = (
+        UniqueConstraint("site_id", "alias_normalized", name="uq_site_alias_site_normalized"),
+    )
+
+    alias_id = Column(Integer, primary_key=True, index=True)
+    site_id = Column(
+        Integer,
+        ForeignKey("sites.site_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    alias = Column(String, nullable=False)
+    alias_normalized = Column(String, nullable=False, index=True)
+
+    site = relationship("Site", backref="aliases")

--- a/backend/app/services/site_aliases_loader.py
+++ b/backend/app/services/site_aliases_loader.py
@@ -1,0 +1,42 @@
+import csv
+import logging
+import os
+
+from sqlalchemy.orm import Session
+
+from .. import models
+from .site_search import normalize_site_search_text
+
+
+logger = logging.getLogger(__name__)
+
+
+def load_site_aliases_from_csv(
+    db: Session,
+    csv_filename: str = "site_aliases.csv",
+) -> None:
+    """Replace curated site aliases from the bundled seed file."""
+    db.query(models.SiteAlias).delete()
+    db.commit()
+
+    csv_path = os.path.join(os.path.dirname(__file__), "..", "data", csv_filename)
+    loaded = 0
+
+    with open(csv_path, mode="r", encoding="utf-8") as file:
+        reader = csv.DictReader(file)
+        for row in reader:
+            alias = row["alias"].strip()
+            if not alias:
+                continue
+
+            db.add(
+                models.SiteAlias(
+                    site_id=int(row["site_id"]),
+                    alias=alias,
+                    alias_normalized=normalize_site_search_text(alias),
+                )
+            )
+            loaded += 1
+
+    db.commit()
+    logger.info("Loaded %d site aliases", loaded)

--- a/backend/app/services/site_search.py
+++ b/backend/app/services/site_search.py
@@ -4,13 +4,15 @@ Keep this module independent of transport-specific schemas so search semantics s
 consistent without coupling the public MCP contract to web-only changes.
 """
 
+from collections import defaultdict
 from difflib import SequenceMatcher
-from typing import Iterable, List
+from typing import Iterable, List, Mapping
 import unicodedata
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import crud, schemas
+from app import crud, models, schemas
 
 
 _MIN_FUZZY_QUERY_LENGTH = 4
@@ -45,16 +47,20 @@ def _fuzzy_ratio(cleaned_query: str, cleaned_name: str) -> float:
     return max(SequenceMatcher(None, cleaned_query, candidate).ratio() for candidate in candidates)
 
 
-def _match_rank(name: str, cleaned_query: str):
-    """Return a sortable rank tuple, or None when the candidate should not match."""
+def _match_rank(name: str, cleaned_query: str, source_priority: int = 0):
+    """Return a sortable rank tuple, or None when the candidate should not match.
+
+    source_priority keeps canonical names ahead of aliases within the same match
+    class while still allowing an exact alias to beat a canonical prefix match.
+    """
     cleaned_name = normalize_site_search_text(name)
 
     if cleaned_name == cleaned_query:
-        return (0, 0.0, len(cleaned_name), cleaned_name)
+        return (0, source_priority, 0.0, len(cleaned_name), cleaned_name)
     if cleaned_name.startswith(cleaned_query):
-        return (1, 0.0, len(cleaned_name), cleaned_name)
+        return (1, source_priority, 0.0, len(cleaned_name), cleaned_name)
     if cleaned_query in cleaned_name:
-        return (2, 0.0, len(cleaned_name), cleaned_name)
+        return (2, source_priority, 0.0, len(cleaned_name), cleaned_name)
 
     if len(cleaned_query) < _MIN_FUZZY_QUERY_LENGTH:
         return None
@@ -64,27 +70,50 @@ def _match_rank(name: str, cleaned_query: str):
         return None
 
     # Higher similarity should sort first, hence the negative value.
-    return (3, -ratio, len(cleaned_name), cleaned_name)
+    return (3, source_priority, -ratio, len(cleaned_name), cleaned_name)
 
 
 def rank_site_matches(
     sites: Iterable[object],
     query: str,
     limit: int = 10,
+    aliases_by_site: Mapping[int, Iterable[str]] | None = None,
 ) -> List[schemas.SiteListItem]:
-    """Rank site rows by exact, prefix, substring, then conservative fuzzy match."""
+    """Rank sites using canonical names and aliases without duplicating results.
+
+    Ranking order is exact, prefix, substring, then conservative fuzzy match.
+    Within each class a canonical-name match wins over an alias match.
+    """
     cleaned_query = normalize_site_search_text(query)
     if not cleaned_query:
         raise ValueError("query must not be empty")
     if limit < 1 or limit > 50:
         raise ValueError("limit must be between 1 and 50")
 
+    aliases_by_site = aliases_by_site or {}
     ranked = []
+
     for row in sites:
-        rank = _match_rank(row.name, cleaned_query)
-        if rank is None:
+        candidate_ranks = []
+
+        canonical_rank = _match_rank(row.name, cleaned_query, source_priority=0)
+        if canonical_rank is not None:
+            candidate_ranks.append(canonical_rank)
+
+        for alias in aliases_by_site.get(row.site_id, ()):
+            alias_rank = _match_rank(alias, cleaned_query, source_priority=1)
+            if alias_rank is not None:
+                candidate_ranks.append(alias_rank)
+
+        if not candidate_ranks:
             continue
-        ranked.append((rank, row))
+
+        best_rank = min(candidate_ranks)
+        deterministic_rank = best_rank + (
+            normalize_site_search_text(row.name),
+            row.site_id,
+        )
+        ranked.append((deterministic_rank, row))
 
     ranked.sort(key=lambda item: item[0])
     return [
@@ -100,4 +129,17 @@ async def search_sites(
 ) -> List[schemas.SiteListItem]:
     """Search the current site directory with shared deterministic semantics."""
     sites = await crud.get_site_list(db)
-    return rank_site_matches(sites, query=query, limit=limit)
+
+    alias_result = await db.execute(
+        select(models.SiteAlias.site_id, models.SiteAlias.alias)
+    )
+    aliases_by_site = defaultdict(list)
+    for site_id, alias in alias_result.all():
+        aliases_by_site[site_id].append(alias)
+
+    return rank_site_matches(
+        sites,
+        query=query,
+        limit=limit,
+        aliases_by_site=aliases_by_site,
+    )

--- a/backend/tests/test_site_search.py
+++ b/backend/tests/test_site_search.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.services import site_search
 from app.services.site_search import normalize_site_search_text, rank_site_matches
 
 
@@ -142,3 +143,30 @@ def test_fuzzy_matching_works_through_aliases():
     )
 
     assert [(result.site_id, result.name) for result in results] == [(1, "Meduno")]
+
+
+
+@pytest.mark.asyncio
+async def test_search_sites_loads_aliases_from_database(monkeypatch):
+    async def fake_get_site_list(db):
+        return [_site(133, "Bassano"), _site(135, "Meduno")]
+
+    class AliasResult:
+        def all(self):
+            return [
+                (133, "Monte Grappa"),
+                (135, "Monte Valinis"),
+            ]
+
+    class FakeDb:
+        async def execute(self, statement):
+            return AliasResult()
+
+    monkeypatch.setattr(site_search.crud, "get_site_list", fake_get_site_list)
+
+    results = await site_search.search_sites(
+        FakeDb(),
+        query="Monte Grappa",
+    )
+
+    assert [(result.site_id, result.name) for result in results] == [(133, "Bassano")]

--- a/backend/tests/test_site_search.py
+++ b/backend/tests/test_site_search.py
@@ -76,3 +76,69 @@ def test_empty_query_is_rejected(query):
 def test_invalid_limit_is_rejected(limit):
     with pytest.raises(ValueError, match="limit must be between 1 and 50"):
         rank_site_matches([], "rana", limit=limit)
+
+
+
+def test_exact_alias_beats_canonical_prefix_match():
+    sites = [
+        _site(1, "Bassano"),
+        _site(2, "Monte Grappa Ridge"),
+    ]
+    aliases = {1: ["Monte Grappa"]}
+
+    results = rank_site_matches(
+        sites,
+        "Monte Grappa",
+        aliases_by_site=aliases,
+    )
+
+    assert [result.site_id for result in results] == [1, 2]
+    assert results[0].name == "Bassano"
+
+
+def test_exact_canonical_name_beats_exact_alias_match():
+    sites = [
+        _site(1, "Bassano"),
+        _site(2, "Monte Grappa"),
+    ]
+    aliases = {1: ["Monte Grappa"]}
+
+    results = rank_site_matches(
+        sites,
+        "Monte Grappa",
+        aliases_by_site=aliases,
+    )
+
+    assert [result.site_id for result in results] == [2, 1]
+
+
+def test_alias_search_returns_each_site_only_once():
+    sites = [_site(1, "Bassano")]
+    aliases = {1: ["Monte Grappa", "Grappa"]}
+
+    results = rank_site_matches(
+        sites,
+        "Grappa",
+        aliases_by_site=aliases,
+    )
+
+    assert [(result.site_id, result.name) for result in results] == [(1, "Bassano")]
+
+
+def test_fuzzy_matching_works_through_aliases():
+    sites = [
+        _site(1, "Meduno"),
+        _site(2, "Bassano"),
+    ]
+    aliases = {
+        1: ["Valinis"],
+        2: ["Monte Grappa"],
+    }
+
+    results = rank_site_matches(
+        sites,
+        "Valins",
+        aliases_by_site=aliases,
+    )
+
+    assert [(result.site_id, result.name) for result in results] == [(1, "Meduno")]


### PR DESCRIPTION
## Summary
- add a `site_aliases` table with normalized aliases and uniqueness per site
- search canonical names and aliases through the same deterministic ranking engine
- keep public REST/MCP output canonical (`site_id`, `name`) with no MCP schema change
- seed Bassano/Monte Grappa and Meduno/Valinis aliases
- reload aliases during `FORCE_INITIAL_DATA_LOAD`
- add regression tests for ranking, deduplication, fuzzy alias matching, and DB integration

## Ranking
Within each match class canonical names outrank aliases:
1. exact canonical
2. exact alias
3. prefix canonical
4. prefix alias
5. substring canonical
6. substring alias
7. fuzzy canonical
8. fuzzy alias

An exact alias can therefore beat a weaker canonical prefix/substring match.

## Deployment
Migration seeds existing populated databases using `INSERT ... SELECT`. Fresh/full reloads use `app/data/site_aliases.csv`, so aliases survive site replacement.