### PR TITLE
Expand curated site alias catalogue

### DIFF
--- a/backend/alembic/versions/0014_expand_site_aliases.py
+++ b/backend/alembic/versions/0014_expand_site_aliases.py
@@ -1,0 +1,171 @@
+"""Expand the curated site alias catalogue.
+
+Revision ID: 0014_expand_site_aliases
+Revises: 0013_site_aliases
+Create Date: 2026-08-27
+
+"""
+import unicodedata
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0014_expand_site_aliases"
+down_revision = "0013_site_aliases"
+branch_labels = None
+depends_on = None
+
+
+ALIASES = (
+    ("Cukrák", "Mokropsy"),
+    ("Kössen", "Unterberghorn"),
+    ("Schlick 2000", "Kreuzjoch"),
+    ("Osser", "Ostrý"),
+    ("Osser", "Velký Ostrý"),
+    ("Osser", "Großer Osser"),
+    ("Osterfelder", "Osterfelderkopf"),
+    ("Fiesch", "Fiescheralp"),
+    ("Fiesch", "Heimat"),
+    ("Fiesch", "Kühboden"),
+    ("Amisbühl", "Beatenberg"),
+    ("Amisbühl", "Beatenberg Amisbühl"),
+    ("Grindelwald", "First"),
+    ("Grindelwald", "Grindelwald First"),
+    ("Rotenfluh", "Rotenflue"),
+    ("Oberi Wängi", "Obere Wängi"),
+    ("Crap Sogn Gion", "Laax"),
+    ("Crap Sogn Gion", "Laax Crap Sogn Gion"),
+    ("Tschenten", "Tschentenalp"),
+    ("Niederbauen", "Emmetten Niederbauen"),
+    ("Jakobshorn", "Davos Jakobshorn"),
+    ("Cornizzolo", "Suello"),
+    ("Cornizzolo", "Cornizzolo Suello"),
+    ("Gemona", "Monte Cuarnan"),
+    ("Gemona", "Cuarnan"),
+    ("Col Rodella", "Campitello"),
+    ("Col Rodella", "Campitello di Fassa"),
+    ("Laveno", "Sasso del Ferro"),
+    ("Feltre", "Monte Avena"),
+    ("Piossasco", "Monte San Giorgio"),
+    ("Gas Monte Belpo", "Monte Belpo"),
+    ("Gas Monte Belpo", "Il Gas"),
+    ("Kronplatz", "Plan de Corones"),
+    ("Monte Ripoli", "Tivoli"),
+    ("Monte Baldo", "Malcesine"),
+    ("Monte Baldo", "Malcesine Monte Baldo"),
+    ("Cà del Monte", "Cecima"),
+    ("Kobala", "Tolmin"),
+    ("Kobala", "Tolmin Kobala"),
+    ("Lijak", "Nova Gorica"),
+    ("Lijak", "Nova Gorica Lijak"),
+    ("Stol", "Kobarid"),
+    ("Stol", "Kobarid Stol"),
+    ("Col de La Forclaz", "Annecy Forclaz"),
+    ("Col de La Forclaz", "Annecy Col de la Forclaz"),
+    ("Saint Hilaire", "Saint-Hilaire-du-Touvet"),
+    ("St. André", "Saint-André-les-Alpes"),
+    ("St. André", "Le Chalvet"),
+    ("St. André", "Chalvet"),
+    ("Planfait", "Annecy Planfait"),
+    ("Planfait", "Talloires Planfait"),
+    ("Treh", "Le Treh"),
+    ("Treh", "Markstein"),
+    ("Treh", "Treh Markstein"),
+    ("Planpraz", "Chamonix Planpraz"),
+    ("Plaine Joux", "Passy"),
+    ("Plaine Joux", "Passy Plaine-Joux"),
+    ("Mont Lachat", "Le Grand-Bornand"),
+    ("Millau", "Puncho d'Agast"),
+    ("Millau", "Pouncho d'Agast"),
+    ("Chabre", "Laragne"),
+    ("Chabre", "Laragne-Chabre"),
+    ("St. Jean", "Saint Jean Montclar"),
+    ("St. Jean", "Saint-Jean-Montclar"),
+    ("St. Jean", "Montclar"),
+    ("St. Jean", "Montclar-le-lac"),
+    ("St. Vincent Les Forts", "Saint-Vincent-les-Forts"),
+    ("Saint-Omer", "Clécy"),
+    ("Saint-Omer", "Clécy Saint-Omer"),
+    ("Gréolières", "Cheiron"),
+    ("Semnoz", "Annecy Semnoz"),
+    ("Collet d'Allevard", "Allevard"),
+    ("Mauroux", "Pic des Mauroux"),
+    ("Mauroux", "Targasonne"),
+    ("Mauroux", "Targasonne Mauroux"),
+    ("Poniente", "Algodonales Poniente"),
+    ("Poniente", "Sierra de Líjar"),
+    ("Peña Negra", "Piedrahita"),
+    ("Peña Negra", "Puerto de Peña Negra"),
+    ("Santa Marina de Orozco", "Orozko"),
+    ("Santa Marina de Orozco", "Santa Marina de Orozko"),
+    ("Santa Marina de Orozco", "Arrola"),
+    ("Alcúdia", "Puig de Sant Martí"),
+    ("Óbuda", "Hármashatár-hegy"),
+    ("Óbuda", "HHH"),
+    ("Csolnok", "Mókus-hegy"),
+    ("Vértesszőlős", "Öregkovács-hegy"),
+    ("Eged", "Nagy-Eged-hegy"),
+    ("Eged", "Nagy-Eged"),
+    ("Csákberény", "Orond"),
+    ("Csákberény", "Csóka-hegy"),
+    ("Sárhegy", "Sár-hegy"),
+    ("Tardos", "Gorba-tető"),
+    ("Tardos", "Tardosbánya"),
+)
+
+
+def _normalize(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value.strip().casefold())
+    without_accents = "".join(
+        char for char in normalized if not unicodedata.combining(char)
+    )
+    return " ".join(without_accents.split())
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    statement = sa.text(
+        """
+        INSERT INTO site_aliases (site_id, alias, alias_normalized)
+        SELECT site_id, :alias, :alias_normalized
+        FROM sites
+        WHERE name = :site_name
+        ON CONFLICT ON CONSTRAINT uq_site_alias_site_normalized DO NOTHING
+        """
+    )
+
+    for site_name, alias in ALIASES:
+        connection.execute(
+            statement,
+            {
+                "site_name": site_name,
+                "alias": alias,
+                "alias_normalized": _normalize(alias),
+            },
+        )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    statement = sa.text(
+        """
+        DELETE FROM site_aliases
+        WHERE alias_id IN (
+            SELECT site_aliases.alias_id
+            FROM site_aliases
+            JOIN sites ON sites.site_id = site_aliases.site_id
+            WHERE sites.name = :site_name
+              AND site_aliases.alias_normalized = :alias_normalized
+        )
+        """
+    )
+
+    for site_name, alias in ALIASES:
+        connection.execute(
+            statement,
+            {
+                "site_name": site_name,
+                "alias_normalized": _normalize(alias),
+            },
+        )

--- a/backend/app/data/site_aliases.csv
+++ b/backend/app/data/site_aliases.csv
@@ -1,4 +1,98 @@
 site_id,alias
+22,Mokropsy
+38,Unterberghorn
+44,Kreuzjoch
+72,Ostrý
+72,Velký Ostrý
+72,Großer Osser
+74,Osterfelderkopf
+82,Fiescheralp
+82,Heimat
+82,Kühboden
+85,Beatenberg
+85,Beatenberg Amisbühl
+86,First
+86,Grindelwald First
+101,Rotenflue
+103,Obere Wängi
+104,Laax
+104,Laax Crap Sogn Gion
+111,Tschentenalp
+114,Emmetten Niederbauen
+131,Davos Jakobshorn
+134,Suello
+134,Cornizzolo Suello
+137,Monte Cuarnan
+137,Cuarnan
+140,Campitello
+140,Campitello di Fassa
+141,Sasso del Ferro
+142,Monte Avena
+150,Monte San Giorgio
+151,Monte Belpo
+151,Il Gas
+155,Plan de Corones
+158,Tivoli
+163,Malcesine
+163,Malcesine Monte Baldo
+172,Cecima
+182,Tolmin
+182,Tolmin Kobala
+183,Nova Gorica
+183,Nova Gorica Lijak
+184,Kobarid
+184,Kobarid Stol
+185,Annecy Forclaz
+185,Annecy Col de la Forclaz
+186,Saint-Hilaire-du-Touvet
+187,Saint-André-les-Alpes
+187,Le Chalvet
+187,Chalvet
+188,Annecy Planfait
+188,Talloires Planfait
+190,Le Treh
+190,Markstein
+190,Treh Markstein
+191,Chamonix Planpraz
+194,Passy
+194,Passy Plaine-Joux
+195,Le Grand-Bornand
+197,Puncho d'Agast
+197,Pouncho d'Agast
+198,Laragne
+198,Laragne-Chabre
+199,Saint Jean Montclar
+199,Saint-Jean-Montclar
+199,Montclar
+199,Montclar-le-lac
+201,Saint-Vincent-les-Forts
+206,Clécy
+206,Clécy Saint-Omer
+207,Cheiron
+211,Annecy Semnoz
+213,Allevard
+216,Pic des Mauroux
+216,Targasonne
+216,Targasonne Mauroux
+221,Algodonales Poniente
+221,Sierra de Líjar
+223,Piedrahita
+223,Puerto de Peña Negra
+233,Orozko
+233,Santa Marina de Orozko
+233,Arrola
+235,Puig de Sant Martí
+242,Hármashatár-hegy
+242,HHH
+243,Mókus-hegy
+245,Öregkovács-hegy
+246,Nagy-Eged-hegy
+246,Nagy-Eged
+247,Orond
+247,Csóka-hegy
+249,Sár-hegy
+250,Gorba-tető
+250,Tardosbánya
 133,Monte Grappa
 133,Bassano del Grappa
 135,Monte Valinis

--- a/backend/tests/test_site_alias_catalogue.py
+++ b/backend/tests/test_site_alias_catalogue.py
@@ -1,0 +1,84 @@
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+from app.services.site_search import normalize_site_search_text
+
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "app" / "data"
+
+
+def _read_csv(name: str):
+    with (DATA_DIR / name).open(encoding="utf-8", newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def test_alias_catalogue_references_existing_sites_and_is_not_redundant():
+    sites = {
+        int(row["site_id"]): row["name"]
+        for row in _read_csv("sites.csv")
+    }
+    aliases = _read_csv("site_aliases.csv")
+
+    assert len(aliases) >= 90
+
+    for row in aliases:
+        site_id = int(row["site_id"])
+        alias = row["alias"].strip()
+
+        assert site_id in sites
+        assert alias
+        assert normalize_site_search_text(alias) != normalize_site_search_text(
+            sites[site_id]
+        )
+
+
+def test_alias_catalogue_has_no_duplicate_or_ambiguous_exact_aliases():
+    aliases = _read_csv("site_aliases.csv")
+    by_site = defaultdict(set)
+    exact_owner = {}
+
+    for row in aliases:
+        site_id = int(row["site_id"])
+        normalized = normalize_site_search_text(row["alias"])
+
+        assert normalized not in by_site[site_id]
+        by_site[site_id].add(normalized)
+
+        existing_owner = exact_owner.setdefault(normalized, site_id)
+        assert existing_owner == site_id
+
+
+def test_researched_aliases_are_present():
+    aliases = {
+        (int(row["site_id"]), row["alias"])
+        for row in _read_csv("site_aliases.csv")
+    }
+
+    expected = {
+        (22, "Mokropsy"),
+        (38, "Unterberghorn"),
+        (44, "Kreuzjoch"),
+        (72, "Ostrý"),
+        (82, "Fiescheralp"),
+        (86, "First"),
+        (104, "Laax"),
+        (133, "Monte Grappa"),
+        (135, "Monte Valinis"),
+        (137, "Monte Cuarnan"),
+        (142, "Monte Avena"),
+        (155, "Plan de Corones"),
+        (186, "Saint-Hilaire-du-Touvet"),
+        (187, "Le Chalvet"),
+        (197, "Pouncho d'Agast"),
+        (206, "Clécy"),
+        (221, "Algodonales Poniente"),
+        (223, "Piedrahita"),
+        (233, "Orozko"),
+        (242, "Hármashatár-hegy"),
+        (245, "Öregkovács-hegy"),
+        (246, "Nagy-Eged-hegy"),
+        (250, "Gorba-tető"),
+    }
+
+    assert expected <= aliases


### PR DESCRIPTION
## Summary
- expand the curated alias catalogue from 4 to 98 aliases
- cover established launch/mountain names, cross-language names, and common destination+launch names
- migrate the 94 new aliases into existing databases
- keep fresh/full reloads sourced from `app/data/site_aliases.csv`
- add catalogue data-quality tests for missing sites, redundant aliases, duplicates, and ambiguous exact aliases

## Research policy
Aliases are intentionally conservative:
- same flying site / established takeoff name
- established cross-language name
- well-known destination+launch pairing where useful
- no accent-only aliases (search normalization already handles those)
- no generic nearby-region tags

Examples include:
- Kössen → Unterberghorn
- Fiesch → Fiescheralp / Heimat / Kühboden
- Grindelwald → First
- Crap Sogn Gion → Laax
- Feltre → Monte Avena
- Gemona → Monte Cuarnan
- Saint André → Le Chalvet
- Millau → Puncho/Pouncho d'Agast
- Poniente → Algodonales Poniente / Sierra de Líjar
- Óbuda → Hármashatár-hegy / HHH
- Tardos → Gorba-tető

## Compatibility
No REST or MCP schema changes. Search still returns only canonical `{site_id, name}` results.