### PR TITLE
Add Greifenburg alias for Emberger Alm

### DIFF
--- a/backend/alembic/versions/0015_emberger_greifenburg_alias.py
+++ b/backend/alembic/versions/0015_emberger_greifenburg_alias.py
@@ -1,0 +1,38 @@
+"""Add Greifenburg alias for Emberger Alm.
+
+Revision ID: 0015_emberger_greifenburg_alias
+Revises: 0014_expand_site_aliases
+Create Date: 2026-08-27
+
+"""
+from alembic import op
+
+
+revision = "0015_emberger_greifenburg_alias"
+down_revision = "0014_expand_site_aliases"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO site_aliases (site_id, alias, alias_normalized)
+        SELECT site_id, 'Greifenburg', 'greifenburg'
+        FROM sites
+        WHERE name = 'Emberger Alm'
+        ON CONFLICT ON CONSTRAINT uq_site_alias_site_normalized DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM site_aliases
+        WHERE site_id IN (
+            SELECT site_id FROM sites WHERE name = 'Emberger Alm'
+        )
+          AND alias_normalized = 'greifenburg'
+        """
+    )

--- a/backend/app/data/site_aliases.csv
+++ b/backend/app/data/site_aliases.csv
@@ -1,4 +1,5 @@
 site_id,alias
+34,Greifenburg
 22,Mokropsy
 38,Unterberghorn
 44,Kreuzjoch

--- a/backend/tests/test_site_alias_catalogue.py
+++ b/backend/tests/test_site_alias_catalogue.py
@@ -57,6 +57,7 @@ def test_researched_aliases_are_present():
 
     expected = {
         (22, "Mokropsy"),
+        (34, "Greifenburg"),
         (38, "Unterberghorn"),
         (44, "Kreuzjoch"),
         (72, "Ostrý"),


### PR DESCRIPTION
## Summary
- add `Greifenburg` as a curated alias for canonical site `Emberger Alm`
- include the alias in full reload seed data
- add a forward Alembic migration for existing production databases
- guard the mapping in the alias catalogue tests

No REST or MCP schema changes.