### PR TITLE
Surface approved ChatGPT plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Meet **Parra-Glideator**, our charming, paragliding gladiator parrot who traded 
 
 The project is currently in **public beta** and available at [parra-glideator.com](https://www.parra-glideator.com/). Try it out, plan your next flight adventure, and help us refine this pilot-friendly tool!
 
+🤖 **Now available in ChatGPT:** Parra-Glideator has been approved as a public ChatGPT plugin. Ask ChatGPT where and when to fly, compare sites and dates, inspect forecast-derived XC potential, check historical seasonality, or pull up launches, landings, and curated local resources using Glideator's live tools.
+
 
 ---
 
@@ -85,7 +87,7 @@ Each core component can be run on its own. Follow the dedicated README in the co
 * **Scrapers** (`scrapers/`) – Flight & site data collection with Scrapy.
 * **Ground Crew** (`agents/ground_crew/`) – Browser-use pipelines that discover and validate local site/club links, extract webcam & meteostation URLs, and export JSON for the Glideator API (`export-resources` → `backend/app/data/site_resources.json`). Supersedes the old Site Researcher agent.
 * **Chat** (`agents/chat/`) – Conversational assistant for the product.
-* **MCP Integration** – Model Context Protocol server enabling AI assistants to access paragliding data through structured tools for site information, weather forecasts, trip planning, and more.
+* **ChatGPT & MCP Integration** – The approved public Parra-Glideator ChatGPT plugin gives ChatGPT structured access to site discovery, forecasts, XC potential, trip planning, historical seasonality, launches/landings, and curated local resources. The same read-only tools remain available through the MCP server for other compatible assistants.
 
 ---
 

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -254,8 +254,8 @@ const About = () => {
             <Grid item xs={12} sm={6}>
               <FeatureCard
                 icon={<SmartToyIcon />}
-                title="Ask your AI"
-                description={'Use Glideator through any MCP-compatible assistant when you want to ask things like “Where should I fly this weekend?” in plain language.'}
+                title="Ask ChatGPT"
+                description={'Use the public Parra-Glideator ChatGPT plugin to ask things like “Where should I fly this weekend?” in plain language. The same tools also work with other MCP-compatible assistants.'}
                 to="/about#mcp"
               />
             </Grid>
@@ -269,11 +269,11 @@ const About = () => {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
             <SmartToyIcon color="primary" />
             <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold' }}>
-              Talk to your AI about flying
+              Talk to ChatGPT about flying
             </Typography>
           </Box>
           <Typography variant="body1" color="text.secondary" paragraph>
-            Parra-Glideator exposes an MCP server, so compatible AI assistants can query forecasts and site data directly. That means you can ask normal planning questions instead of forcing a chatbot to improvise about valley winds.
+            Parra-Glideator is now available as a public ChatGPT plugin. ChatGPT can query Glideator forecasts, XC potential, trip rankings, site information, historical seasonality, launches and landings, and curated local resources directly. If you use another MCP-compatible assistant, the same read-only tools are available through the MCP server below.
           </Typography>
 
           <Box sx={{
@@ -297,6 +297,9 @@ const About = () => {
           </Box>
 
           <Paper variant="outlined" sx={{ p: 2, borderRadius: 2, backgroundColor: 'grey.50' }}>
+            <Typography variant="body2" sx={{ fontWeight: 'bold', mb: 1 }}>
+              ChatGPT: use the public Parra-Glideator plugin.
+            </Typography>
             <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
               MCP server URL:{' '}
               <Box component="span" sx={{ fontWeight: 'bold', color: 'primary.main' }}>
@@ -304,7 +307,7 @@ const About = () => {
               </Box>
             </Typography>
             <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
-              Add this URL to Claude Desktop, ChatGPT, or any MCP-compatible client.
+              For Claude Desktop and other MCP-compatible clients, add the MCP URL above.
             </Typography>
           </Paper>
         </Box>


### PR DESCRIPTION
Adds the newly approved public Parra-Glideator ChatGPT plugin to the README and the website's How It Works page. Keeps the raw MCP URL documented for other compatible clients. No MCP schema or backend behavior changes.