### PR TITLE
Add MCP usage analytics

### DIFF
--- a/backend/alembic/versions/0016_mcp_tool_events.py
+++ b/backend/alembic/versions/0016_mcp_tool_events.py
@@ -1,0 +1,45 @@
+"""Add MCP tool usage analytics
+
+Revision ID: 0016_mcp_tool_events
+Revises: 0015_emberger_greifenburg_alias
+Create Date: 2026-08-28
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0016_mcp_tool_events"
+down_revision = "0015_emberger_greifenburg_alias"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mcp_tool_events",
+        sa.Column("event_id", sa.Integer(), nullable=False),
+        sa.Column("tool_name", sa.String(length=80), nullable=False),
+        sa.Column("success", sa.Boolean(), nullable=False),
+        sa.Column("duration_ms", sa.Integer(), nullable=False),
+        sa.Column("error_type", sa.String(length=120), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("event_id"),
+    )
+    op.create_index(op.f("ix_mcp_tool_events_event_id"), "mcp_tool_events", ["event_id"], unique=False)
+    op.create_index(op.f("ix_mcp_tool_events_tool_name"), "mcp_tool_events", ["tool_name"], unique=False)
+    op.create_index(op.f("ix_mcp_tool_events_success"), "mcp_tool_events", ["success"], unique=False)
+    op.create_index(op.f("ix_mcp_tool_events_created_at"), "mcp_tool_events", ["created_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_mcp_tool_events_created_at"), table_name="mcp_tool_events")
+    op.drop_index(op.f("ix_mcp_tool_events_success"), table_name="mcp_tool_events")
+    op.drop_index(op.f("ix_mcp_tool_events_tool_name"), table_name="mcp_tool_events")
+    op.drop_index(op.f("ix_mcp_tool_events_event_id"), table_name="mcp_tool_events")
+    op.drop_table("mcp_tool_events")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from .routers import (
     admin,
     admin_analytics,
     admin_bot_analytics,
+    admin_mcp_analytics,
     analytics,
     auth,
     d2d,
@@ -183,6 +184,7 @@ app.include_router(analytics.router)
 app.include_router(admin_analytics.router)
 app.include_router(admin.router)
 app.include_router(admin_bot_analytics.router)
+app.include_router(admin_mcp_analytics.router)
 
 @app.get("/health")
 async def healthcheck():

--- a/backend/app/mcp.py
+++ b/backend/app/mcp.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field, TypeAdapter
 
 from app import crud, schemas
 from app.database import AsyncSessionLocal
+from app.mcp_analytics import track_mcp_tool
 from app.services import site_search, trip_planner_service
 
 
@@ -59,6 +60,7 @@ mcp = FastMCP(
 
 
 @mcp.tool(title="Find paragliding sites", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("find_sites")
 async def find_sites(query: str, limit: int = 10) -> List[schemas.SiteListItem]:
     """Use this when the user names or searches for a paragliding site and you need its site ID.
 
@@ -74,6 +76,7 @@ async def find_sites(query: str, limit: int = 10) -> List[schemas.SiteListItem]:
 
 
 @mcp.tool(title="List paragliding sites", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("list_sites")
 async def list_sites() -> List[schemas.SiteListItem]:
     """Use this when the user wants to browse all paragliding sites covered by Parra-Glideator.
 
@@ -89,6 +92,7 @@ async def list_sites() -> List[schemas.SiteListItem]:
 
 
 @mcp.tool(title="Get site overview", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("get_site_info")
 async def get_site_info(site_id: int) -> schemas.SiteInfo:
     """Use this when the user asks for a general overview or description of a known site.
 
@@ -108,6 +112,7 @@ async def get_site_info(site_id: int) -> schemas.SiteInfo:
 
 
 @mcp.tool(title="Get site resources", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("get_site_resources")
 async def get_site_resources(site_id: int) -> PublicSiteResources:
     """Use this when the user wants practical local links for a known paragliding site.
 
@@ -126,6 +131,7 @@ async def get_site_resources(site_id: int) -> PublicSiteResources:
 
 
 @mcp.tool(title="Get site seasonal statistics", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("get_site_seasonal_stats")
 async def get_site_seasonal_stats(site_id: int) -> Dict[str, Dict[str, float]]:
     """Use this when the user asks when a paragliding site historically performs best.
 
@@ -174,6 +180,7 @@ async def get_site_seasonal_stats(site_id: int) -> Dict[str, Dict[str, float]]:
 
 
 @mcp.tool(title="Get site flight-potential forecast", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("get_site_predictions")
 async def get_site_predictions(
     site_id: int,
     query_date: Optional[str] = None,
@@ -230,6 +237,7 @@ async def get_site_predictions(
 
 
 @mcp.tool(title="Get site takeoffs and landings", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("get_site_takeoffs_and_landings")
 async def get_site_takeoffs_and_landings(site_id: int) -> List[schemas.Spot]:
     """Use this when the user asks where launches or landings are at a known paragliding site.
 
@@ -248,6 +256,7 @@ async def get_site_takeoffs_and_landings(site_id: int) -> List[schemas.Spot]:
 
 
 @mcp.tool(title="Plan a paragliding trip", annotations=READ_ONLY_ANNOTATIONS)
+@track_mcp_tool("plan_trip")
 async def plan_trip(
     start_date: str,
     end_date: str,

--- a/backend/app/mcp_analytics.py
+++ b/backend/app/mcp_analytics.py
@@ -1,0 +1,84 @@
+import functools
+import logging
+import time
+from typing import Awaitable, Callable, Optional, TypeVar
+
+from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy.sql import func
+
+from .database import AsyncSessionLocal, Base
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class McpToolEvent(Base):
+    __tablename__ = "mcp_tool_events"
+
+    event_id = Column(Integer, primary_key=True, index=True)
+    tool_name = Column(String(80), nullable=False, index=True)
+    success = Column(Boolean, nullable=False, index=True)
+    duration_ms = Column(Integer, nullable=False)
+    error_type = Column(String(120), nullable=True)
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        index=True,
+    )
+
+
+async def _record_mcp_tool_event(
+    *,
+    tool_name: str,
+    success: bool,
+    duration_ms: int,
+    error_type: Optional[str] = None,
+) -> None:
+    """Persist privacy-minimal MCP usage analytics without affecting the tool call."""
+    try:
+        async with AsyncSessionLocal() as db:
+            db.add(
+                McpToolEvent(
+                    tool_name=tool_name,
+                    success=success,
+                    duration_ms=max(0, duration_ms),
+                    error_type=error_type,
+                )
+            )
+            await db.commit()
+    except Exception:
+        logger.exception("Failed to persist MCP analytics event tool_name=%s", tool_name)
+
+
+def track_mcp_tool(tool_name: str) -> Callable[[Callable[..., Awaitable[T]]], Callable[..., Awaitable[T]]]:
+    """Track an async MCP tool call while preserving the tool's public signature."""
+
+    def decorator(func: Callable[..., Awaitable[T]]) -> Callable[..., Awaitable[T]]:
+        @functools.wraps(func)
+        async def wrapper(*args, **kwargs) -> T:
+            started_at = time.perf_counter()
+            try:
+                result = await func(*args, **kwargs)
+            except Exception as exc:
+                duration_ms = round((time.perf_counter() - started_at) * 1000)
+                await _record_mcp_tool_event(
+                    tool_name=tool_name,
+                    success=False,
+                    duration_ms=duration_ms,
+                    error_type=type(exc).__name__,
+                )
+                raise
+
+            duration_ms = round((time.perf_counter() - started_at) * 1000)
+            await _record_mcp_tool_event(
+                tool_name=tool_name,
+                success=True,
+                duration_ms=duration_ms,
+            )
+            return result
+
+        return wrapper
+
+    return decorator

--- a/backend/app/routers/admin_mcp_analytics.py
+++ b/backend/app/routers/admin_mcp_analytics.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta, timezone
+from typing import List
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .. import models
+from ..mcp_analytics import McpToolEvent
+from .admin import get_db, require_admin
+
+router = APIRouter(prefix="/admin", tags=["Admin"])
+
+
+class McpToolUsageRow(BaseModel):
+    tool_name: str
+    calls: int
+    successful_calls: int
+    failed_calls: int
+    success_rate: float
+    avg_duration_ms: float
+
+
+class AdminMcpAnalyticsResponse(BaseModel):
+    window_days: int
+    total_calls: int
+    successful_calls: int
+    failed_calls: int
+    success_rate: float
+    avg_duration_ms: float
+    tools_used: int
+    tools: List[McpToolUsageRow]
+
+
+def _rate(numerator: int, denominator: int) -> float:
+    if denominator <= 0:
+        return 0.0
+    return round(100 * numerator / denominator, 1)
+
+
+@router.get("/mcp-analytics", response_model=AdminMcpAnalyticsResponse)
+async def get_mcp_analytics(
+    days: int = Query(default=30, ge=1, le=365),
+    _: models.User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+
+    summary = (
+        await db.execute(
+            select(
+                func.count(McpToolEvent.event_id),
+                func.count(McpToolEvent.event_id).filter(McpToolEvent.success.is_(True)),
+                func.avg(McpToolEvent.duration_ms),
+                func.count(func.distinct(McpToolEvent.tool_name)),
+            ).where(McpToolEvent.created_at >= cutoff)
+        )
+    ).one()
+
+    total_calls = int(summary[0] or 0)
+    successful_calls = int(summary[1] or 0)
+    failed_calls = total_calls - successful_calls
+
+    rows = (
+        await db.execute(
+            select(
+                McpToolEvent.tool_name,
+                func.count(McpToolEvent.event_id).label("calls"),
+                func.count(McpToolEvent.event_id)
+                .filter(McpToolEvent.success.is_(True))
+                .label("successful_calls"),
+                func.avg(McpToolEvent.duration_ms).label("avg_duration_ms"),
+            )
+            .where(McpToolEvent.created_at >= cutoff)
+            .group_by(McpToolEvent.tool_name)
+            .order_by(func.count(McpToolEvent.event_id).desc(), McpToolEvent.tool_name.asc())
+        )
+    ).all()
+
+    tools = []
+    for tool_name, calls, successful, avg_duration_ms in rows:
+        calls = int(calls or 0)
+        successful = int(successful or 0)
+        tools.append(
+            McpToolUsageRow(
+                tool_name=tool_name,
+                calls=calls,
+                successful_calls=successful,
+                failed_calls=calls - successful,
+                success_rate=_rate(successful, calls),
+                avg_duration_ms=round(float(avg_duration_ms or 0), 1),
+            )
+        )
+
+    return AdminMcpAnalyticsResponse(
+        window_days=days,
+        total_calls=total_calls,
+        successful_calls=successful_calls,
+        failed_calls=failed_calls,
+        success_rate=_rate(successful_calls, total_calls),
+        avg_duration_ms=round(float(summary[2] or 0), 1),
+        tools_used=int(summary[3] or 0),
+        tools=tools,
+    )

--- a/backend/tests/test_admin_mcp_analytics.py
+++ b/backend/tests/test_admin_mcp_analytics.py
@@ -1,0 +1,59 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.routers import admin_mcp_analytics
+
+
+class FakeResult:
+    def __init__(self, *, one=None, all_rows=None):
+        self._one = one
+        self._all = all_rows
+
+    def one(self):
+        return self._one
+
+    def all(self):
+        return self._all
+
+
+class FakeDb:
+    def __init__(self):
+        self.calls = 0
+
+    async def execute(self, statement):
+        self.calls += 1
+        if self.calls == 1:
+            return FakeResult(one=(10, 9, 125.4, 3))
+        return FakeResult(
+            all_rows=[
+                ("plan_trip", 6, 6, 150.0),
+                ("find_sites", 3, 2, 80.0),
+                ("get_site_info", 1, 1, 40.0),
+            ]
+        )
+
+
+def test_mcp_rate_is_safe_and_rounded():
+    assert admin_mcp_analytics._rate(9, 10) == 90.0
+    assert admin_mcp_analytics._rate(1, 3) == 33.3
+    assert admin_mcp_analytics._rate(0, 0) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_mcp_analytics_aggregates_tool_usage():
+    result = await admin_mcp_analytics.get_mcp_analytics(
+        days=30,
+        _=SimpleNamespace(),
+        db=FakeDb(),
+    )
+
+    assert result.total_calls == 10
+    assert result.successful_calls == 9
+    assert result.failed_calls == 1
+    assert result.success_rate == 90.0
+    assert result.avg_duration_ms == 125.4
+    assert result.tools_used == 3
+    assert result.tools[0].tool_name == "plan_trip"
+    assert result.tools[1].failed_calls == 1
+    assert result.tools[1].success_rate == 66.7

--- a/backend/tests/test_mcp_analytics.py
+++ b/backend/tests/test_mcp_analytics.py
@@ -26,7 +26,7 @@ async def test_track_mcp_tool_records_success_without_arguments(monkeypatch):
     assert len(recorded) == 1
     assert recorded[0]["tool_name"] == "example_tool"
     assert recorded[0]["success"] is True
-    assert recorded[0]["error_type"] if "error_type" in recorded[0] else None is None
+    assert recorded[0].get("error_type") is None
     assert isinstance(recorded[0]["duration_ms"], int)
     assert "secret_value" not in recorded[0]
 

--- a/backend/tests/test_mcp_analytics.py
+++ b/backend/tests/test_mcp_analytics.py
@@ -1,0 +1,57 @@
+import os
+
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://postgres:postgres@postgres:5432/glideator")
+
+from app import mcp_analytics
+
+
+@pytest.mark.asyncio
+async def test_track_mcp_tool_records_success_without_arguments(monkeypatch):
+    recorded = []
+
+    async def fake_record(**event):
+        recorded.append(event)
+
+    monkeypatch.setattr(mcp_analytics, "_record_mcp_tool_event", fake_record)
+
+    @mcp_analytics.track_mcp_tool("example_tool")
+    async def example_tool(secret_value: str):
+        return f"ok:{secret_value}"
+
+    result = await example_tool("do-not-store")
+
+    assert result == "ok:do-not-store"
+    assert len(recorded) == 1
+    assert recorded[0]["tool_name"] == "example_tool"
+    assert recorded[0]["success"] is True
+    assert recorded[0]["error_type"] if "error_type" in recorded[0] else None is None
+    assert isinstance(recorded[0]["duration_ms"], int)
+    assert "secret_value" not in recorded[0]
+
+
+@pytest.mark.asyncio
+async def test_track_mcp_tool_records_failure_and_reraises(monkeypatch):
+    recorded = []
+
+    async def fake_record(**event):
+        recorded.append(event)
+
+    monkeypatch.setattr(mcp_analytics, "_record_mcp_tool_event", fake_record)
+
+    @mcp_analytics.track_mcp_tool("broken_tool")
+    async def broken_tool():
+        raise ValueError("sensitive details")
+
+    with pytest.raises(ValueError, match="sensitive details"):
+        await broken_tool()
+
+    assert recorded == [
+        {
+            "tool_name": "broken_tool",
+            "success": False,
+            "duration_ms": recorded[0]["duration_ms"],
+            "error_type": "ValueError",
+        }
+    ]

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -4,6 +4,8 @@ Glideator records a small first-party event stream in the `product_events` table
 
 Known crawler traffic is classified at ingestion from the request User-Agent and stored separately in `bot_events`. This keeps the normal product analytics stream human-focused while preserving a lightweight view of crawler activity and the canonical bot identity.
 
+MCP tool usage is also stored separately in `mcp_tool_events`. Each tool invocation records only the tool name, success/failure, execution duration, error class on failure, and timestamp. Prompts, tool arguments, IP addresses, MCP client metadata, and response payloads are not stored.
+
 ## Privacy properties
 
 - No IP address, raw user agent, email address, account ID, or precise coordinates are stored.
@@ -11,8 +13,9 @@ Known crawler traffic is classified at ingestion from the request User-Agent and
 - The frontend sends only `window.location.pathname`, never the URL query string.
 - Property keys that look like coordinates, IP addresses, emails, or user-agent data are removed client-side.
 - Anonymous browser and session IDs are random identifiers stored in `localStorage` and `sessionStorage`.
-- Global Privacy Control and Do Not Track are respected.
+- Global Privacy Control and Do Not Track are respected for frontend analytics.
 - Set `REACT_APP_ANALYTICS_ENABLED=false` to disable frontend collection entirely.
+- MCP analytics contain no browser identifiers and do not attempt to infer unique users or sessions.
 
 The ingestion endpoint is `POST /analytics/events`. Payloads and event names are validated, property size is capped, and Redis-backed rate limits protect the endpoint. Known bots are diverted into `bot_events`; all other accepted events go to `product_events`.
 
@@ -40,6 +43,25 @@ The ingestion endpoint is `POST /analytics/events`. Payloads and event names are
 Known bots are matched against explicit User-Agent signatures and stored with a canonical name. The list covers major search crawlers, AI crawlers/fetchers, social preview bots, and common SEO crawlers. Unknown automation is intentionally left in the normal stream rather than guessed from broad strings such as `bot` or `crawler`.
 
 The administrator cockpit exposes a dedicated **Bots** tab with bot events, sessions, anonymous visitor IDs, and a per-bot breakdown for the selected time window.
+
+## MCP usage analytics
+
+All eight public MCP tools are instrumented at the tool boundary. Analytics writes are fail-open: if the analytics database write fails, the underlying MCP call still succeeds or fails exactly as it otherwise would.
+
+The administrator cockpit exposes a dedicated **MCP** tab showing total tool calls, success rate, average execution duration, distinct tools used, and a per-tool breakdown. This stream intentionally does not report "users" or "sessions" because the server does not have a stable privacy-preserving MCP identity to support those metrics.
+
+Example query:
+
+```sql
+select
+    tool_name,
+    count(*) as calls,
+    count(*) filter (where success) as successful_calls,
+    round(avg(duration_ms), 1) as avg_duration_ms
+from mcp_tool_events
+group by 1
+order by calls desc, tool_name;
+```
 
 ## Starter queries
 

--- a/frontend/src/adminApi.js
+++ b/frontend/src/adminApi.js
@@ -25,6 +25,11 @@ export const fetchAdminBotAnalytics = async (days = 30) => {
   return response.data;
 };
 
+export const fetchAdminMcpAnalytics = async (days = 30) => {
+  const response = await apiClient.get('/admin/mcp-analytics', { params: { days } });
+  return response.data;
+};
+
 export const fetchAdminForecastRuns = async (limit = 20) => {
   const response = await apiClient.get('/admin/forecast-runs', { params: { limit } });
   return response.data;

--- a/frontend/src/components/admin/AdminMcpAnalyticsPanel.jsx
+++ b/frontend/src/components/admin/AdminMcpAnalyticsPanel.jsx
@@ -1,0 +1,172 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Grid,
+  LinearProgress,
+  MenuItem,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import { fetchAdminMcpAnalytics } from '../../adminApi';
+
+const MetricCard = ({ label, value, detail }) => (
+  <Card variant="outlined" sx={{ height: '100%' }}>
+    <CardContent>
+      <Typography variant="overline" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography variant="h4" sx={{ mt: 0.5, fontWeight: 700 }}>
+        {value}
+      </Typography>
+      {detail && (
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+          {detail}
+        </Typography>
+      )}
+    </CardContent>
+  </Card>
+);
+
+const AdminMcpAnalyticsPanel = () => {
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      setData(await fetchAdminMcpAnalytics(days));
+    } catch (err) {
+      setError(err.response?.data?.detail || 'Failed to load MCP analytics.');
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <Stack spacing={3}>
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        justifyContent="space-between"
+        alignItems={{ xs: 'stretch', sm: 'center' }}
+        spacing={1.5}
+      >
+        <Box>
+          <Typography variant="h5" sx={{ fontWeight: 700 }}>MCP usage</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Privacy-minimal tool-call analytics. Arguments, prompts, IP addresses and raw client metadata are not stored.
+          </Typography>
+        </Box>
+        <Stack direction="row" spacing={1}>
+          <TextField
+            select
+            size="small"
+            label="Period"
+            value={days}
+            onChange={(event) => setDays(Number(event.target.value))}
+            sx={{ minWidth: 120 }}
+          >
+            <MenuItem value={7}>7 days</MenuItem>
+            <MenuItem value={30}>30 days</MenuItem>
+            <MenuItem value={90}>90 days</MenuItem>
+            <MenuItem value={365}>1 year</MenuItem>
+          </TextField>
+          <Button variant="outlined" startIcon={<RefreshIcon />} onClick={load} disabled={loading}>
+            Refresh
+          </Button>
+        </Stack>
+      </Stack>
+
+      {loading && <LinearProgress />}
+      {error && <Alert severity="error">{error}</Alert>}
+
+      {data && (
+        <>
+          <Grid container spacing={2}>
+            <Grid item xs={12} sm={6} lg={3}>
+              <MetricCard
+                label="Tool calls"
+                value={data.total_calls.toLocaleString()}
+                detail={`${data.window_days}-day window`}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <MetricCard
+                label="Success rate"
+                value={`${data.success_rate}%`}
+                detail={`${data.failed_calls.toLocaleString()} failed calls`}
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <MetricCard
+                label="Average duration"
+                value={`${data.avg_duration_ms.toLocaleString()} ms`}
+                detail="End-to-end tool execution"
+              />
+            </Grid>
+            <Grid item xs={12} sm={6} lg={3}>
+              <MetricCard
+                label="Tools used"
+                value={data.tools_used}
+                detail="Distinct MCP tools called"
+              />
+            </Grid>
+          </Grid>
+
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Tool</TableCell>
+                  <TableCell align="right">Calls</TableCell>
+                  <TableCell align="right">Success</TableCell>
+                  <TableCell align="right">Failed</TableCell>
+                  <TableCell align="right">Success rate</TableCell>
+                  <TableCell align="right">Avg duration</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {data.tools.map((row) => (
+                  <TableRow key={row.tool_name} hover>
+                    <TableCell>{row.tool_name}</TableCell>
+                    <TableCell align="right">{row.calls.toLocaleString()}</TableCell>
+                    <TableCell align="right">{row.successful_calls.toLocaleString()}</TableCell>
+                    <TableCell align="right">{row.failed_calls.toLocaleString()}</TableCell>
+                    <TableCell align="right">{row.success_rate}%</TableCell>
+                    <TableCell align="right">{row.avg_duration_ms.toLocaleString()} ms</TableCell>
+                  </TableRow>
+                ))}
+                {data.tools.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} align="center">No MCP tool calls captured in this period.</TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </>
+      )}
+    </Stack>
+  );
+};
+
+export default AdminMcpAnalyticsPanel;

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -48,6 +48,7 @@ import {
 } from '../adminApi';
 import AdminAnalyticsPanel from '../components/admin/AdminAnalyticsPanel';
 import AdminBotAnalyticsPanel from '../components/admin/AdminBotAnalyticsPanel';
+import AdminMcpAnalyticsPanel from '../components/admin/AdminMcpAnalyticsPanel';
 import {
   AdminFeedbackPanel,
   AdminUsersPanel,
@@ -263,6 +264,7 @@ const Admin = () => {
           <Tab label="Sites" />
           <Tab label="Resources" />
           <Tab label="Bots" />
+          <Tab label="MCP" />
         </Tabs>
 
         <Box sx={{ p: { xs: 2, md: 3 } }}>
@@ -501,6 +503,7 @@ const Admin = () => {
           )}
 
           {tab === 7 && <AdminBotAnalyticsPanel />}
+          {tab === 8 && <AdminMcpAnalyticsPanel />}
         </Box>
       </Paper>
 


### PR DESCRIPTION
## Summary

- add privacy-minimal `mcp_tool_events` storage for all public MCP tools
- record tool name, success/failure, duration, error class, and timestamp only
- keep analytics fail-open so storage failures never break MCP responses
- add authenticated `/admin/mcp-analytics` aggregation endpoint
- add an MCP tab to the admin cockpit with usage, success rate, latency, and per-tool breakdown
- document the MCP analytics privacy model
- add backend tests for instrumentation and aggregation

## Privacy

MCP analytics do **not** store prompts, arguments, response payloads, IP addresses, raw client metadata, or fabricated user/session identifiers.
