### PR TITLE
Add S2S ML experimentation harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
           cache-dependency-path: ml/pyproject.toml
 
       - name: Install ML test dependencies
-        run: python -m pip install --upgrade pip && pip install -e '.[test]'
+        run: python -m pip install --upgrade pip && pip install -e '.[test,contrastive]'
 
       - name: Run ML tests
         run: python -m pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,31 @@ jobs:
       - name: Run backend tests
         run: python -m pytest -q --cov=app --cov-fail-under=53 --cov-report=term-missing:skip-covered --cov-report=xml
 
+  ml:
+    name: ML experiment tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ml
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: ml/pyproject.toml
+
+      - name: Install ML test dependencies
+        run: python -m pip install --upgrade pip && pip install -e '.[test]'
+
+      - name: Run ML tests
+        run: python -m pytest -q
+
   frontend:
     name: Frontend tests and build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The project is currently in **public beta** and available at [parra-glideator.co
 
 🤖 **Now available in ChatGPT:** Parra-Glideator has been approved as a public ChatGPT plugin. Ask ChatGPT where and when to fly, compare sites and dates, inspect forecast-derived XC potential, check historical seasonality, or pull up launches, landings, and curated local resources using Glideator's live tools.
 
-
 ---
 
 ## Table of Contents
@@ -28,74 +27,78 @@ The project is currently in **public beta** and available at [parra-glideator.co
 
 ## Repository Structure
 
-```
+~~~
 docker-compose.dev.yml   Local dev stack (API, Postgres, Redis, Celery, frontend)
 agents/      Ground Crew (site discovery & resources), Chat assistant
-analytics/   Notebooks, datasets, training pipeline
+analytics/   Notebooks, datasets, production training pipeline
 art/         Brand assets (Parra-Glideator!)
 backend/     FastAPI API, MCP server, Celery workers, Dockerfiles (web & worker)
 db/          dbt project building the analytics warehouse
 frontend/    React + Leaflet single-page app
 gfs/         Library for downloading & flattening NOAA GFS data
+ml/          Reproducible ML experimentation and model documentation
 net/         PyTorch models + preprocessing (Glideator-Net)
 scrapers/    Scrapy spiders for XContest & Paragliding Map
-```
+~~~
 
 ---
 
 ## Quick Start
 
-> **Deployment note:** production runs on **Render** and Render is the source of truth for production configuration. The Docker Compose file `docker-compose.dev.yml` at the repository root is for local development only.
+> **Deployment note:** production runs on **Render** and Render is the source of truth for production configuration. The Docker Compose file docker-compose.dev.yml at the repository root is for local development only.
 
 ### All-in-one (Docker Compose)
 
-```bash
+~~~bash
 # clone & launch everything (API + DB + Worker + Web)
 $ git clone https://github.com/janhelcl/glideator.git
 $ cd glideator
 $ docker-compose -f docker-compose.dev.yml up --build
-```
+~~~
 
-* API docs: <http://localhost:8000/docs>  
+* API docs: <http://localhost:8000/docs>
 * Frontend: <http://localhost:3000>
-* MCP Server <http://localhost:8000/mcp>
+* MCP Server: <http://localhost:8000/mcp>
 
 ### Individual Services
 
-Each core component can be run on its own. Follow the dedicated README in the corresponding folder for setup & usage details:
+Each core component can be run on its own. Follow the dedicated README in the corresponding folder for setup and usage details:
 
-* [`backend/README.md`](backend/README.md) — FastAPI API, Celery worker, Docker Compose details, Render deployment notes
-* [`frontend/README.md`](frontend/README.md) — React single-page application
-* [`db/README.md`](db/README.md) — dbt analytics warehouse
-* [`scrapers/README.md`](scrapers/README.md) — Scrapy project for flight & site data
-* [`gfs/README.md`](gfs/README.md) — GFS data downloader & utilities
-* [`net/README.md`](net/README.md) — PyTorch model library
-* [`analytics/training/README.md`](analytics/training/README.md) — End-to-end training pipeline
-* [`agents/ground_crew/README.md`](agents/ground_crew/README.md) — Ground Crew: browser agents, validation, exports for site resources
-* [`agents/chat/README.md`](agents/chat/README.md) — Parra-Glideator chat assistant
+* [backend/README.md](backend/README.md) — FastAPI API, Celery worker, Docker Compose details, Render deployment notes
+* [frontend/README.md](frontend/README.md) — React single-page application
+* [db/README.md](db/README.md) — dbt analytics warehouse
+* [scrapers/README.md](scrapers/README.md) — Scrapy project for flight and site data
+* [gfs/README.md](gfs/README.md) — GFS data downloader and utilities
+* [ml/README.md](ml/README.md) — ML experiment harness, benchmarks, model docs, and decision records
+* [net/README.md](net/README.md) — PyTorch model library
+* [analytics/training/README.md](analytics/training/README.md) — Production training pipeline
+* [agents/ground_crew/README.md](agents/ground_crew/README.md) — Ground Crew: browser agents, validation, exports for site resources
+* [agents/chat/README.md](agents/chat/README.md) — Parra-Glideator chat assistant
 
 ---
 
 ## Key Components
 
-* **Backend** (`backend/`) – FastAPI, MCP server, PostgreSQL, Celery, Redis, deployed on Render in production.
-* **Frontend** (`frontend/`) – React 18, Material-UI, React-Leaflet, D3.
-* **Warehouse** (`db/`) – Postgres + dbt (staging & mart models).
-* **ML Library** (`net/`) – Neural Networks implemented in PyTorch.
-* **Training** (`analytics/training/`) – WebDataset loaders, notebooks.
-* **Weather** (`gfs/`) – Fetches & processes NOAA GFS GRIB2 files.
-* **Scrapers** (`scrapers/`) – Flight & site data collection with Scrapy.
-* **Ground Crew** (`agents/ground_crew/`) – Browser-use pipelines that discover and validate local site/club links, extract webcam & meteostation URLs, and export JSON for the Glideator API (`export-resources` → `backend/app/data/site_resources.json`). Supersedes the old Site Researcher agent.
-* **Chat** (`agents/chat/`) – Conversational assistant for the product.
-* **ChatGPT & MCP Integration** – The approved public Parra-Glideator ChatGPT plugin gives ChatGPT structured access to site discovery, forecasts, XC potential, trip planning, historical seasonality, launches/landings, and curated local resources. The same read-only tools remain available through the MCP server for other compatible assistants.
+* **Backend** (backend/) – FastAPI, MCP server, PostgreSQL, Celery, Redis, deployed on Render in production.
+* **Frontend** (frontend/) – React 18, Material-UI, React-Leaflet, D3.
+* **Warehouse** (db/) – Postgres + dbt staging and mart models.
+* **ML Experiments** (ml/) – Reproducible model comparison, evaluation, tracking, and research documentation.
+* **ML Library** (net/) – Production neural networks implemented in PyTorch.
+* **Training** (analytics/training/) – WebDataset loaders and production training notebooks.
+* **Weather** (gfs/) – Fetches and processes NOAA GFS GRIB2 files.
+* **Scrapers** (scrapers/) – Flight and site data collection with Scrapy.
+* **Ground Crew** (agents/ground_crew/) – Browser-use pipelines that discover and validate local site and club links, extract webcam and meteostation URLs, and export data for the Glideator API.
+* **Chat** (agents/chat/) – Conversational assistant for the product.
+* **ChatGPT & MCP Integration** – The approved public Parra-Glideator ChatGPT plugin gives ChatGPT structured access to site discovery, forecasts, XC potential, trip planning, historical seasonality, launches and landings, and curated local resources. The same read-only tools remain available through the MCP server for other compatible assistants.
 
 ---
 
 ## Model Training Pipeline
 
-1. Scrapers write raw flights & sites → Postgres.
-2. `dbt` transforms them into clean mart tables.
-3. Training notebooks export WebDataset shards.
-4. PyTorch models are trained & the best checkpoint is shipped to the API.
+1. Scrapers write raw flights and sites to Postgres.
+2. dbt transforms them into clean mart tables.
+3. The production pipeline prepares training data and trains deployable models.
+4. The ml/ workspace provides reproducible benchmarks for comparing candidate models before promotion.
+5. Promoted artifacts are integrated explicitly into the serving stack.
 
-For the full deep-dive (maths included!) see [`analytics/training/README.md`](analytics/training/README.md).
+For production training details, see [analytics/training/README.md](analytics/training/README.md). For model experimentation and benchmark documentation, see [ml/README.md](ml/README.md).

--- a/ml/.gitignore
+++ b/ml/.gitignore
@@ -1,0 +1,5 @@
+.venv/
+__pycache__/
+.pytest_cache/
+mlruns/
+outputs/

--- a/ml/README.md
+++ b/ml/README.md
@@ -72,8 +72,8 @@ fingerprint, and an `eval_set_fingerprint` derived from the exact walk-forward
 examples, so accidentally incomparable runs are visible in MLflow.
 
 The harness supports truncated SVD, the contrastive architecture used by the
-current production model, a DeepSets history encoder, and an asymmetric additive
-contrastive model. SVD and contrastive artifacts remain directly
+current production model, a DeepSets history encoder, an asymmetric additive
+model, and a transformed-additive model. SVD and contrastive artifacts remain directly
 production-compatible: item embeddings are normalized and exported using the
 keys `site_to_idx`, `idx_to_site`, and `matrix`.
 
@@ -84,8 +84,13 @@ weights. The experiment evaluator uses that scorer so inference matches training
 The asymmetric model keeps additive history composition but learns separate
 source and target site embeddings. Its target embeddings remain in `matrix`,
 while the source embedding table is stored in the optional `scorer` payload.
-Do not promote DeepSets or asymmetric artifacts to the current backend until
-serving also understands their scorer payloads.
+The transformed-additive model applies the same DeepSets-style `phi -> rho`
+nonlinear mapping independently to each history site, then sums those transformed
+vectors before normalization. With a one-site history this has the same functional
+form as DeepSets; for longer histories it preserves additive composition instead
+of applying `rho` after pooling. Do not promote DeepSets, asymmetric, or
+transformed-additive artifacts to the current backend until serving understands
+their scorer payloads.
 
 ## Setup
 
@@ -133,6 +138,18 @@ Run the asymmetric additive v1 benchmark:
 glideator-ml run s2s --config configs/s2s/asymmetric.yaml
 ```
 
+Run the transformed-additive v1 benchmark:
+
+```bash
+glideator-ml run s2s --config configs/s2s/transformed-additive.yaml
+```
+
+This ablation keeps the DeepSets `phi` and `rho` dimensions and all contrastive
+training hyperparameters, but changes composition from
+`rho(mean(phi(site)))` to `sum(rho(phi(site)))`. It is intended to isolate
+whether the nonlinear per-site mapping is useful while post-pooling compression is
+harmful.
+
 The asymmetric config matches the production-equivalent contrastive hyperparameters
 and benchmark. The sole architectural change is untied source and target embedding
 tables; history is still summed and normalized before candidate scoring.
@@ -159,8 +176,8 @@ For v2 seed comparisons, keep `temporal_cutoff` unchanged and vary only
 The command writes an S2S artifact plus an evaluation report under `outputs/`,
 and logs the config, dataset fingerprint, benchmark identity, evaluation-set
 fingerprint, metrics, Git SHA, and artifacts to MLflow. SVD and contrastive
-artifacts are directly production-compatible; DeepSets and asymmetric artifacts
-require scorer-aware serving.
+artifacts are directly production-compatible; DeepSets, asymmetric, and
+transformed-additive artifacts require scorer-aware serving.
 
 If training and evaluation finish but MLflow is temporarily unavailable, restore
 the configured tracking service and backfill the saved run without retraining:

--- a/ml/README.md
+++ b/ml/README.md
@@ -57,13 +57,13 @@ before the target, including legitimate pre-cutoff history.
 ```yaml
 data:
   split_strategy: temporal
-  temporal_cutoff: "2025-01-01"
+  temporal_cutoff: "2024-01-01"
 
 evaluation:
   benchmark_id: s2s-v2
 ```
 
-The checked-in v2 benchmark uses 2025-01-01 as its fixed cutoff. Treat the cutoff
+The checked-in v2 benchmark uses 2024-01-01 as its fixed cutoff. Treat the cutoff
 as part of the benchmark definition: changing it should also use a new
 `benchmark_id`.
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -148,6 +148,16 @@ fingerprint, metrics, Git SHA, and artifacts to MLflow. SVD and contrastive
 artifacts are directly production-compatible; DeepSets artifacts additionally
 require scorer-aware serving.
 
+If training and evaluation finish but MLflow is temporarily unavailable, restore
+the configured tracking service and backfill the saved run without retraining:
+
+```bash
+glideator-ml backfill s2s --config configs/s2s/deepsets.yaml
+```
+
+Backfill is idempotent after the resulting `mlflow_run_id` has been saved to the
+local evaluation report.
+
 To inspect local runs:
 
 ```bash

--- a/ml/README.md
+++ b/ml/README.md
@@ -27,6 +27,25 @@ Every evaluation pilot then contributes walk-forward examples:
 This prevents a held-out pilot's future visits from leaking into learned site
 embeddings.
 
+The benchmark split and stochastic model training have separate seeds:
+
+```yaml
+data:
+  split_seed: 42
+
+model:
+  seed: 42
+
+evaluation:
+  benchmark_id: s2s-v1
+```
+
+Keep `data.split_seed` fixed when comparing model seeds or architectures. Change
+only `model.seed` for repeated stochastic runs. The runner logs the
+`benchmark_id`, dataset fingerprint, and an `eval_set_fingerprint` derived from
+the exact walk-forward examples, so accidentally incomparable runs are visible in
+MLflow.
+
 The harness supports truncated SVD and the contrastive architecture used by the
 current production model. Item embeddings are normalized and exported using the
 production-compatible keys `site_to_idx`, `idx_to_site`, and `matrix`. Extra
@@ -55,7 +74,7 @@ can be used with:
 export MLFLOW_TRACKING_URI='http://localhost:5000'
 ```
 
-Run the baseline:
+Run the SVD baseline:
 
 ```bash
 glideator-ml run s2s --config configs/s2s/svd.yaml
@@ -67,9 +86,14 @@ Retrain the production-equivalent contrastive benchmark:
 glideator-ml run s2s --config configs/s2s/contrastive-prod-equivalent.yaml
 ```
 
+For a fixed-split 5-seed contrastive comparison, leave
+`data.split_seed: 42` unchanged and run the same config with
+`model.seed: 42`, `43`, `44`, `45`, and `46`. All five reports should have
+identical `events`, `eval_pilots`, and `eval_set_fingerprint`.
+
 The command writes a production-compatible pickle plus an evaluation report under
-`outputs/`, and logs the config, dataset fingerprint, metrics, Git SHA, and
-artifacts to MLflow.
+`outputs/`, and logs the config, dataset fingerprint, benchmark identity,
+evaluation-set fingerprint, metrics, Git SHA, and artifacts to MLflow.
 
 To inspect local runs:
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,0 +1,98 @@
+# Glideator ML
+
+A small, model-family-agnostic experimentation harness for Glideator.
+
+The goal is not to make every model look the same. It is to make every experiment
+reproducible, comparable, and promotable while each task owns its own data,
+metrics, models, and artifact contract.
+
+## Model families
+
+- `s2s`: site discovery recommender. First complete implementation.
+- `xc`: flight-potential model. Planned next.
+- `d2d`: analogous-day retrieval. Planned next.
+
+## S2S methodology
+
+S2S experiments are evaluated on **first visits** only. Pilots are deterministically
+split into train and evaluation groups. The model is fitted only on train pilots.
+Every evaluation pilot then contributes walk-forward examples:
+
+```text
+[A]       -> B
+[A, B]    -> C
+[A, B, C] -> D
+```
+
+This prevents a held-out pilot's future visits from leaking into learned site
+embeddings.
+
+The first model is truncated SVD over the binary pilot-site matrix. Its item
+embeddings are normalized and exported using the production-compatible keys
+`site_to_idx`, `idx_to_site`, and `matrix`. Extra metadata is additive, so the
+artifact can later replace the existing S2S pickle without changing serving code.
+
+## Setup
+
+```bash
+cd ml
+python -m venv .venv
+source .venv/bin/activate
+pip install -e '.[test,tracking]'
+```
+
+Point the experiment runner at the analytics database:
+
+```bash
+export ML_DATABASE_URL='postgresql://...'
+```
+
+By default MLflow logs to `./mlruns`. A remote server can be used with:
+
+```bash
+export MLFLOW_TRACKING_URI='http://localhost:5000'
+```
+
+Run the baseline:
+
+```bash
+glideator-ml run s2s --config configs/s2s/svd.yaml
+```
+
+The command writes a production-compatible pickle plus an evaluation report under
+`outputs/`, and logs the config, dataset fingerprint, metrics, Git SHA, and
+artifacts to MLflow.
+
+To inspect local runs:
+
+```bash
+mlflow ui --backend-store-uri ./mlruns
+```
+
+## Data contract
+
+The database loader reads `mart.fact_flights` and joins `mart.dim_sites` by the
+XContest site name to obtain `site_id`. It reduces raw flights to one first-visit
+event per pilot/site before any split or model fitting.
+
+For isolated experiments and tests, the same runner can consume a CSV containing:
+
+```text
+pilot,site_id,date,start_time
+```
+
+## Evaluation
+
+S2S currently reports:
+
+- HitRate@k
+- MRR@k
+- NDCG@k
+- catalog coverage@k
+- average log popularity@k
+- cold-start target rate
+- known-source rate
+- number of walk-forward events
+
+Task-specific evaluators deliberately live inside each model family rather than
+being forced into one generic metric abstraction.

--- a/ml/README.md
+++ b/ml/README.md
@@ -73,7 +73,8 @@ examples, so accidentally incomparable runs are visible in MLflow.
 
 The harness supports truncated SVD, the contrastive architecture used by the
 current production model, a DeepSets history encoder, an asymmetric additive
-model, and a transformed-additive model. SVD and contrastive artifacts remain directly
+model, a transformed-additive model, and a residual candidate-attention model.
+SVD and contrastive artifacts remain directly
 production-compatible: item embeddings are normalized and exported using the
 keys `site_to_idx`, `idx_to_site`, and `matrix`.
 
@@ -91,6 +92,13 @@ form as DeepSets; for longer histories it preserves additive composition instead
 of applying `rho` after pooling. Do not promote DeepSets, asymmetric, or
 transformed-additive artifacts to the current backend until serving understands
 their scorer payloads.
+
+Candidate attention keeps the normalized summed-history query as a residual base,
+then computes a separate single-head attention correction for each candidate site.
+Q/K/V projections are learned, the attention scale is learned from a small 0.1
+initial value, and the full catalog can be scored directly because S2S has only a
+few hundred sites. Its artifact stores the raw history embedding table plus the
+attention weights in `scorer`, so it also requires scorer-aware serving.
 
 ## Setup
 
@@ -144,6 +152,17 @@ Run the transformed-additive v1 benchmark:
 glideator-ml run s2s --config configs/s2s/transformed-additive.yaml
 ```
 
+Run the residual candidate-attention v1 benchmark:
+
+```bash
+glideator-ml run s2s --config configs/s2s/candidate-attention.yaml
+```
+
+This model keeps the strong additive contrastive history representation and learns
+only a candidate-specific correction. For each candidate, one attention head
+weights the visited sites differently; the resulting context is added to the
+normalized additive base before cosine scoring.
+
 This ablation keeps the DeepSets `phi` and `rho` dimensions and all contrastive
 training hyperparameters, but changes composition from
 `rho(mean(phi(site)))` to `sum(rho(phi(site)))`. It is intended to isolate
@@ -176,8 +195,9 @@ For v2 seed comparisons, keep `temporal_cutoff` unchanged and vary only
 The command writes an S2S artifact plus an evaluation report under `outputs/`,
 and logs the config, dataset fingerprint, benchmark identity, evaluation-set
 fingerprint, metrics, Git SHA, and artifacts to MLflow. SVD and contrastive
-artifacts are directly production-compatible; DeepSets, asymmetric, and
-transformed-additive artifacts require scorer-aware serving.
+artifacts are directly production-compatible; DeepSets, asymmetric,
+transformed-additive, and candidate-attention artifacts require scorer-aware
+serving.
 
 If training and evaluation finish but MLflow is temporarily unavailable, restore
 the configured tracking service and backfill the saved run without retraining:

--- a/ml/README.md
+++ b/ml/README.md
@@ -72,16 +72,20 @@ fingerprint, and an `eval_set_fingerprint` derived from the exact walk-forward
 examples, so accidentally incomparable runs are visible in MLflow.
 
 The harness supports truncated SVD, the contrastive architecture used by the
-current production model, and a DeepSets history encoder. SVD and contrastive
-artifacts remain directly production-compatible: item embeddings are normalized
-and exported using the keys `site_to_idx`, `idx_to_site`, and `matrix`.
+current production model, a DeepSets history encoder, and an asymmetric additive
+contrastive model. SVD and contrastive artifacts remain directly
+production-compatible: item embeddings are normalized and exported using the
+keys `site_to_idx`, `idx_to_site`, and `matrix`.
 
 DeepSets learns a nonlinear permutation-invariant history encoder
 `rho(pool(phi(site)))`. Its artifact preserves the same three legacy keys and
 adds a small optional `scorer` payload containing the learned history-encoder
 weights. The experiment evaluator uses that scorer so inference matches training.
-Do not promote a DeepSets artifact to the current backend until serving also
-understands the optional scorer payload.
+The asymmetric model keeps additive history composition but learns separate
+source and target site embeddings. Its target embeddings remain in `matrix`,
+while the source embedding table is stored in the optional `scorer` payload.
+Do not promote DeepSets or asymmetric artifacts to the current backend until
+serving also understands their scorer payloads.
 
 ## Setup
 
@@ -123,6 +127,16 @@ Run the DeepSets v1 benchmark on the same held-out-pilot split:
 glideator-ml run s2s --config configs/s2s/deepsets.yaml
 ```
 
+Run the asymmetric additive v1 benchmark:
+
+```bash
+glideator-ml run s2s --config configs/s2s/asymmetric.yaml
+```
+
+The asymmetric config matches the production-equivalent contrastive hyperparameters
+and benchmark. The sole architectural change is untied source and target embedding
+tables; history is still summed and normalized before candidate scoring.
+
 The checked-in DeepSets config keeps the contrastive optimizer, negative sampling,
 embedding dimension, and benchmark identity aligned with the production-equivalent
 contrastive config. Its new degrees of freedom are the per-site `phi` MLP, the
@@ -145,7 +159,7 @@ For v2 seed comparisons, keep `temporal_cutoff` unchanged and vary only
 The command writes an S2S artifact plus an evaluation report under `outputs/`,
 and logs the config, dataset fingerprint, benchmark identity, evaluation-set
 fingerprint, metrics, Git SHA, and artifacts to MLflow. SVD and contrastive
-artifacts are directly production-compatible; DeepSets artifacts additionally
+artifacts are directly production-compatible; DeepSets and asymmetric artifacts
 require scorer-aware serving.
 
 If training and evaluation finish but MLflow is temporarily unavailable, restore

--- a/ml/README.md
+++ b/ml/README.md
@@ -1,257 +1,92 @@
 # Glideator ML
 
-A small, model-family-agnostic experimentation harness for Glideator.
+A small, model-family-agnostic experimentation workspace for Glideator.
 
-The goal is not to make every model look the same. It is to make every experiment
-reproducible, comparable, and promotable while each task owns its own data,
-metrics, models, and artifact contract.
+The shared layer standardizes experiment execution, provenance, tracking, and reproducibility. Task semantics deliberately stay with the task: each model family owns its data preparation, benchmarks, evaluator, models, and artifact contract.
 
 ## Model families
 
-- `s2s`: site discovery recommender. First complete implementation.
-- `xc`: flight-potential model. Planned next.
-- `d2d`: analogous-day retrieval. Planned next.
+| Task | Purpose | Status | Docs |
+| --- | --- | --- | --- |
+| S2S | Recommend new flying sites from a pilot's discovered-site history | Active | [docs/s2s/README.md](docs/s2s/README.md) |
+| XC | Predict flight / XC potential | Planned migration | — |
+| D2D | Retrieve analogous historical days | Planned migration | — |
 
-## S2S methodology
+## Layout
 
-S2S experiments are evaluated on **first visits** only. The harness currently
-defines two benchmark semantics.
+~~~
+ml/
+├── configs/                  Reproducible experiment configurations
+├── glideator_ml/             Shared harness plus task implementations
+│   └── <task>/               Task-owned data, models, evaluator, artifact
+├── docs/
+│   ├── <task>/               Task methodology and model catalogue
+│   └── decisions/            Durable cross-model / benchmark decisions
+├── tests/                    Synthetic and contract tests
+└── outputs/                  Local artifacts and reports; ignored by git
+~~~
 
-### s2s-v1: held-out-pilot generalization
+The documentation follows the same ownership rule as the code:
 
-Pilots are deterministically split into train and evaluation groups. The model is
-fitted only on train pilots. Every evaluation pilot contributes walk-forward
-examples:
+- A **task README** defines the prediction problem, benchmark semantics, evaluation, and serving boundary.
+- A **model page** explains one architecture: hypothesis, delta from the reference model, config, and serving implications.
+- A **decision record** captures reasoning that should constrain future work: benchmark identity, artifact contracts, promotion rules, or shared training policy.
+- **MLflow** is the source of truth for individual run metrics. Docs record durable conclusions, not copied leaderboards.
 
-```text
-[A]       -> B
-[A, B]    -> C
-[A, B, C] -> D
-```
-
-This prevents a held-out pilot's future visits from leaking into learned site
-embeddings. The split identity and stochastic model training use separate seeds:
-
-```yaml
-data:
-  split_strategy: pilot
-  split_seed: 42
-
-model:
-  seed: 42
-
-evaluation:
-  benchmark_id: s2s-v1
-```
-
-Keep `data.split_seed` fixed when comparing model seeds or architectures. Change
-only `model.seed` for repeated stochastic runs.
-
-### s2s-v2: temporal production simulation
-
-The temporal benchmark trains embeddings using only first visits known before a
-fixed cutoff. Evaluation targets are first visits on or after that cutoff. For
-each target, the pilot history contains only sites that pilot had discovered
-before the target, including legitimate pre-cutoff history.
-
-```yaml
-data:
-  split_strategy: temporal
-  temporal_cutoff: "2024-01-01"
-
-evaluation:
-  benchmark_id: s2s-v2
-```
-
-The checked-in v2 benchmark uses 2024-01-01 as its fixed cutoff. Treat the cutoff
-as part of the benchmark definition: changing it should also use a new
-`benchmark_id`.
-
-The runner logs the `benchmark_id`, split strategy, cutoff/seed, dataset
-fingerprint, and an `eval_set_fingerprint` derived from the exact walk-forward
-examples, so accidentally incomparable runs are visible in MLflow.
-
-The harness supports truncated SVD, the contrastive architecture used by the
-current production model, a DeepSets history encoder, an asymmetric additive
-model, a transformed-additive model, and a residual candidate-attention model.
-SVD and contrastive artifacts remain directly
-production-compatible: item embeddings are normalized and exported using the
-keys `site_to_idx`, `idx_to_site`, and `matrix`.
-
-DeepSets learns a nonlinear permutation-invariant history encoder
-`rho(pool(phi(site)))`. Its artifact preserves the same three legacy keys and
-adds a small optional `scorer` payload containing the learned history-encoder
-weights. The experiment evaluator uses that scorer so inference matches training.
-The asymmetric model keeps additive history composition but learns separate
-source and target site embeddings. Its target embeddings remain in `matrix`,
-while the source embedding table is stored in the optional `scorer` payload.
-The transformed-additive model applies the same DeepSets-style `phi -> rho`
-nonlinear mapping independently to each history site, then sums those transformed
-vectors before normalization. With a one-site history this has the same functional
-form as DeepSets; for longer histories it preserves additive composition instead
-of applying `rho` after pooling. Do not promote DeepSets, asymmetric, or
-transformed-additive artifacts to the current backend until serving understands
-their scorer payloads.
-
-Candidate attention keeps the normalized summed-history query as a residual base,
-then computes a separate single-head attention correction for each candidate site.
-Q/K/V projections are learned, the attention scale is learned from a small 0.1
-initial value, and the full catalog can be scored directly because S2S has only a
-few hundred sites. Its artifact stores the raw history embedding table plus the
-attention weights in `scorer`, so it also requires scorer-aware serving.
+See [docs/decisions/README.md](docs/decisions/README.md) for the decision-record convention.
 
 ## Setup
 
-```bash
+~~~bash
 cd ml
 python -m venv .venv
 source .venv/bin/activate
 pip install -e '.[contrastive,test,tracking]'
-```
+~~~
 
-Point the experiment runner at the analytics database:
+Point the runner at the analytics database:
 
-```bash
+~~~bash
 export ML_DATABASE_URL='postgresql://...'
-```
+~~~
 
-By default MLflow logs to the SQLite database under `./mlruns`. A remote server
-can be used with:
+MLflow defaults to the local SQLite store under mlruns/. A remote tracking server can be supplied with:
 
-```bash
+~~~bash
 export MLFLOW_TRACKING_URI='http://localhost:5000'
-```
+~~~
 
-Run the SVD v1 baseline:
+## Running experiments
 
-```bash
-glideator-ml run s2s --config configs/s2s/svd.yaml
-```
+The CLI is intentionally thin:
 
-Run the production-equivalent contrastive v1 benchmark:
+~~~text
+glideator-ml run <task> --config <config>
+glideator-ml backfill <task> --config <config>
+~~~
 
-```bash
-glideator-ml run s2s --config configs/s2s/contrastive-prod-equivalent.yaml
-```
+Task docs define the benchmark-specific configs and comparison rules. Start with [S2S](docs/s2s/README.md).
 
-Run the DeepSets v1 benchmark on the same held-out-pilot split:
+Every run should make it possible to answer:
 
-```bash
-glideator-ml run s2s --config configs/s2s/deepsets.yaml
-```
+1. What exact dataset and evaluation set did this use?
+2. What benchmark definition did it claim to implement?
+3. What code and configuration produced the artifact?
+4. Is the artifact compatible with production serving?
+5. Which stochastic seed changed, and which benchmark inputs stayed fixed?
 
-Run the asymmetric additive v1 benchmark:
+The harness logs dataset fingerprints, evaluation-set fingerprints, benchmark identity, Git SHA, model metadata, metrics, and artifacts to MLflow.
 
-```bash
-glideator-ml run s2s --config configs/s2s/asymmetric.yaml
-```
+## Promotion boundary
 
-Run the transformed-additive v1 benchmark:
+This workspace is for experimentation and comparison. Producing an artifact does **not** make it production-ready.
 
-```bash
-glideator-ml run s2s --config configs/s2s/transformed-additive.yaml
-```
+Promotion is explicit and should require:
 
-Run the residual candidate-attention v1 benchmark:
+- a benchmark result judged against the appropriate reference;
+- reproducibility across the required seeds;
+- a documented serving contract;
+- compatibility with, or an intentional change to, production inference;
+- a recorded decision when the change affects future experiments or serving.
 
-```bash
-glideator-ml run s2s --config configs/s2s/candidate-attention.yaml
-```
-
-This model keeps the strong additive contrastive history representation and learns
-only a candidate-specific correction. For each candidate, one attention head
-weights the visited sites differently; the resulting context is added to the
-normalized additive base before cosine scoring.
-
-This ablation keeps the DeepSets `phi` and `rho` dimensions and all contrastive
-training hyperparameters, but changes composition from
-`rho(mean(phi(site)))` to `sum(rho(phi(site)))`. It is intended to isolate
-whether the nonlinear per-site mapping is useful while post-pooling compression is
-harmful.
-
-The asymmetric config matches the production-equivalent contrastive hyperparameters
-and benchmark. The sole architectural change is untied source and target embedding
-tables; history is still summed and normalized before candidate scoring.
-
-The checked-in DeepSets config keeps the contrastive optimizer, negative sampling,
-embedding dimension, and benchmark identity aligned with the production-equivalent
-contrastive config. Its new degrees of freedom are the per-site `phi` MLP, the
-post-pooling `rho` MLP, and mean pooling over the already-discovered site set.
-
-Run the temporal v2 benchmark:
-
-```bash
-glideator-ml run s2s --config configs/s2s/contrastive-temporal-v2.yaml
-```
-
-For a fixed-split 5-seed v1 contrastive comparison, leave
-`data.split_seed: 42` unchanged and run the same config with
-`model.seed: 42`, `43`, `44`, `45`, and `46`. All five reports should
-have identical `events`, `eval_pilots`, and `eval_set_fingerprint`.
-
-For v2 seed comparisons, keep `temporal_cutoff` unchanged and vary only
-`model.seed`.
-
-The command writes an S2S artifact plus an evaluation report under `outputs/`,
-and logs the config, dataset fingerprint, benchmark identity, evaluation-set
-fingerprint, metrics, Git SHA, and artifacts to MLflow. SVD and contrastive
-artifacts are directly production-compatible; DeepSets, asymmetric,
-transformed-additive, and candidate-attention artifacts require scorer-aware
-serving.
-
-If training and evaluation finish but MLflow is temporarily unavailable, restore
-the configured tracking service and backfill the saved run without retraining:
-
-```bash
-glideator-ml backfill s2s --config configs/s2s/deepsets.yaml
-```
-
-Backfill is idempotent after the resulting `mlflow_run_id` has been saved to the
-local evaluation report.
-
-To inspect local runs:
-
-```bash
-mlflow ui --backend-store-uri sqlite:///mlruns/mlflow.db
-```
-
-## Data contract
-
-The database loader reads `fact_flights` and joins `dim_sites` by the XContest
-site name to obtain `site_id`. The schema is configurable with `data.schema`
-(`mart` by default; the production-equivalent configs use
-`glideator_mart`). It reduces raw flights to one first-visit event per
-pilot/site before any split or model fitting.
-
-For isolated experiments and tests, the same runner can consume a CSV containing:
-
-```text
-pilot,site_id,date,start_time
-```
-
-## Evaluation
-
-S2S reports the original ranking metrics unchanged:
-
-- HitRate@k
-- MRR@k
-- NDCG@k
-- catalog coverage@k
-- average log popularity@k
-- cold-start target rate
-- known-source rate
-- number of walk-forward events
-
-It additionally reports:
-
-- `end_to_end_hit_rate_at_k`, where every benchmark event is in the denominator,
-  including cold-start and unservable events
-- history-length slices: one previous site, two-to-three sites, and four-plus
-- target-popularity slices: head, tail, and cold-start targets
-
-The popularity head is the top 20% of training-catalog sites by first-visit
-count; all other known sites are tail. Each slice includes event count, eligible
-event count, conditional HitRate/MRR/NDCG, and end-to-end HitRate.
-
-Task-specific evaluators deliberately live inside each model family rather than
-being forced into one generic metric abstraction.
+Task docs call out whether a model is directly serving-compatible or needs serving changes.

--- a/ml/README.md
+++ b/ml/README.md
@@ -71,11 +71,17 @@ The runner logs the `benchmark_id`, split strategy, cutoff/seed, dataset
 fingerprint, and an `eval_set_fingerprint` derived from the exact walk-forward
 examples, so accidentally incomparable runs are visible in MLflow.
 
-The harness supports truncated SVD and the contrastive architecture used by the
-current production model. Item embeddings are normalized and exported using the
-production-compatible keys `site_to_idx`, `idx_to_site`, and `matrix`. Extra
-metadata is additive, so an artifact can replace the existing S2S pickle without
-changing serving code.
+The harness supports truncated SVD, the contrastive architecture used by the
+current production model, and a DeepSets history encoder. SVD and contrastive
+artifacts remain directly production-compatible: item embeddings are normalized
+and exported using the keys `site_to_idx`, `idx_to_site`, and `matrix`.
+
+DeepSets learns a nonlinear permutation-invariant history encoder
+`rho(pool(phi(site)))`. Its artifact preserves the same three legacy keys and
+adds a small optional `scorer` payload containing the learned history-encoder
+weights. The experiment evaluator uses that scorer so inference matches training.
+Do not promote a DeepSets artifact to the current backend until serving also
+understands the optional scorer payload.
 
 ## Setup
 
@@ -110,6 +116,17 @@ Run the production-equivalent contrastive v1 benchmark:
 ```bash
 glideator-ml run s2s --config configs/s2s/contrastive-prod-equivalent.yaml
 ```
+
+Run the DeepSets v1 benchmark on the same held-out-pilot split:
+
+```bash
+glideator-ml run s2s --config configs/s2s/deepsets.yaml
+```
+
+The checked-in DeepSets config keeps the contrastive optimizer, negative sampling,
+embedding dimension, and benchmark identity aligned with the production-equivalent
+contrastive config. Its new degrees of freedom are the per-site `phi` MLP, the
+post-pooling `rho` MLP, and mean pooling over the already-discovered site set.
 
 Run the temporal v2 benchmark:
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -142,9 +142,11 @@ have identical `events`, `eval_pilots`, and `eval_set_fingerprint`.
 For v2 seed comparisons, keep `temporal_cutoff` unchanged and vary only
 `model.seed`.
 
-The command writes a production-compatible pickle plus an evaluation report under
-`outputs/`, and logs the config, dataset fingerprint, benchmark identity,
-evaluation-set fingerprint, metrics, Git SHA, and artifacts to MLflow.
+The command writes an S2S artifact plus an evaluation report under `outputs/`,
+and logs the config, dataset fingerprint, benchmark identity, evaluation-set
+fingerprint, metrics, Git SHA, and artifacts to MLflow. SVD and contrastive
+artifacts are directly production-compatible; DeepSets artifacts additionally
+require scorer-aware serving.
 
 To inspect local runs:
 

--- a/ml/README.md
+++ b/ml/README.md
@@ -14,9 +14,14 @@ metrics, models, and artifact contract.
 
 ## S2S methodology
 
-S2S experiments are evaluated on **first visits** only. Pilots are deterministically
-split into train and evaluation groups. The model is fitted only on train pilots.
-Every evaluation pilot then contributes walk-forward examples:
+S2S experiments are evaluated on **first visits** only. The harness currently
+defines two benchmark semantics.
+
+### s2s-v1: held-out-pilot generalization
+
+Pilots are deterministically split into train and evaluation groups. The model is
+fitted only on train pilots. Every evaluation pilot contributes walk-forward
+examples:
 
 ```text
 [A]       -> B
@@ -25,12 +30,11 @@ Every evaluation pilot then contributes walk-forward examples:
 ```
 
 This prevents a held-out pilot's future visits from leaking into learned site
-embeddings.
-
-The benchmark split and stochastic model training have separate seeds:
+embeddings. The split identity and stochastic model training use separate seeds:
 
 ```yaml
 data:
+  split_strategy: pilot
   split_seed: 42
 
 model:
@@ -41,10 +45,31 @@ evaluation:
 ```
 
 Keep `data.split_seed` fixed when comparing model seeds or architectures. Change
-only `model.seed` for repeated stochastic runs. The runner logs the
-`benchmark_id`, dataset fingerprint, and an `eval_set_fingerprint` derived from
-the exact walk-forward examples, so accidentally incomparable runs are visible in
-MLflow.
+only `model.seed` for repeated stochastic runs.
+
+### s2s-v2: temporal production simulation
+
+The temporal benchmark trains embeddings using only first visits known before a
+fixed cutoff. Evaluation targets are first visits on or after that cutoff. For
+each target, the pilot history contains only sites that pilot had discovered
+before the target, including legitimate pre-cutoff history.
+
+```yaml
+data:
+  split_strategy: temporal
+  temporal_cutoff: "2025-01-01"
+
+evaluation:
+  benchmark_id: s2s-v2
+```
+
+The checked-in v2 benchmark uses 2025-01-01 as its fixed cutoff. Treat the cutoff
+as part of the benchmark definition: changing it should also use a new
+`benchmark_id`.
+
+The runner logs the `benchmark_id`, split strategy, cutoff/seed, dataset
+fingerprint, and an `eval_set_fingerprint` derived from the exact walk-forward
+examples, so accidentally incomparable runs are visible in MLflow.
 
 The harness supports truncated SVD and the contrastive architecture used by the
 current production model. Item embeddings are normalized and exported using the
@@ -74,22 +99,31 @@ can be used with:
 export MLFLOW_TRACKING_URI='http://localhost:5000'
 ```
 
-Run the SVD baseline:
+Run the SVD v1 baseline:
 
 ```bash
 glideator-ml run s2s --config configs/s2s/svd.yaml
 ```
 
-Retrain the production-equivalent contrastive benchmark:
+Run the production-equivalent contrastive v1 benchmark:
 
 ```bash
 glideator-ml run s2s --config configs/s2s/contrastive-prod-equivalent.yaml
 ```
 
-For a fixed-split 5-seed contrastive comparison, leave
+Run the temporal v2 benchmark:
+
+```bash
+glideator-ml run s2s --config configs/s2s/contrastive-temporal-v2.yaml
+```
+
+For a fixed-split 5-seed v1 contrastive comparison, leave
 `data.split_seed: 42` unchanged and run the same config with
-`model.seed: 42`, `43`, `44`, `45`, and `46`. All five reports should have
-identical `events`, `eval_pilots`, and `eval_set_fingerprint`.
+`model.seed: 42`, `43`, `44`, `45`, and `46`. All five reports should
+have identical `events`, `eval_pilots`, and `eval_set_fingerprint`.
+
+For v2 seed comparisons, keep `temporal_cutoff` unchanged and vary only
+`model.seed`.
 
 The command writes a production-compatible pickle plus an evaluation report under
 `outputs/`, and logs the config, dataset fingerprint, benchmark identity,
@@ -105,9 +139,9 @@ mlflow ui --backend-store-uri sqlite:///mlruns/mlflow.db
 
 The database loader reads `fact_flights` and joins `dim_sites` by the XContest
 site name to obtain `site_id`. The schema is configurable with `data.schema`
-(`mart` by default; the production-equivalent config uses `glideator_mart`).
-It reduces raw flights to one first-visit event per pilot/site before any split
-or model fitting.
+(`mart` by default; the production-equivalent configs use
+`glideator_mart`). It reduces raw flights to one first-visit event per
+pilot/site before any split or model fitting.
 
 For isolated experiments and tests, the same runner can consume a CSV containing:
 
@@ -117,7 +151,7 @@ pilot,site_id,date,start_time
 
 ## Evaluation
 
-S2S currently reports:
+S2S reports the original ranking metrics unchanged:
 
 - HitRate@k
 - MRR@k
@@ -127,6 +161,17 @@ S2S currently reports:
 - cold-start target rate
 - known-source rate
 - number of walk-forward events
+
+It additionally reports:
+
+- `end_to_end_hit_rate_at_k`, where every benchmark event is in the denominator,
+  including cold-start and unservable events
+- history-length slices: one previous site, two-to-three sites, and four-plus
+- target-popularity slices: head, tail, and cold-start targets
+
+The popularity head is the top 20% of training-catalog sites by first-visit
+count; all other known sites are tail. Each slice includes event count, eligible
+event count, conditional HitRate/MRR/NDCG, and end-to-end HitRate.
 
 Task-specific evaluators deliberately live inside each model family rather than
 being forced into one generic metric abstraction.

--- a/ml/README.md
+++ b/ml/README.md
@@ -27,10 +27,11 @@ Every evaluation pilot then contributes walk-forward examples:
 This prevents a held-out pilot's future visits from leaking into learned site
 embeddings.
 
-The first model is truncated SVD over the binary pilot-site matrix. Its item
-embeddings are normalized and exported using the production-compatible keys
-`site_to_idx`, `idx_to_site`, and `matrix`. Extra metadata is additive, so the
-artifact can later replace the existing S2S pickle without changing serving code.
+The harness supports truncated SVD and the contrastive architecture used by the
+current production model. Item embeddings are normalized and exported using the
+production-compatible keys `site_to_idx`, `idx_to_site`, and `matrix`. Extra
+metadata is additive, so an artifact can replace the existing S2S pickle without
+changing serving code.
 
 ## Setup
 
@@ -38,7 +39,7 @@ artifact can later replace the existing S2S pickle without changing serving code
 cd ml
 python -m venv .venv
 source .venv/bin/activate
-pip install -e '.[test,tracking]'
+pip install -e '.[contrastive,test,tracking]'
 ```
 
 Point the experiment runner at the analytics database:
@@ -47,7 +48,8 @@ Point the experiment runner at the analytics database:
 export ML_DATABASE_URL='postgresql://...'
 ```
 
-By default MLflow logs to `./mlruns`. A remote server can be used with:
+By default MLflow logs to the SQLite database under `./mlruns`. A remote server
+can be used with:
 
 ```bash
 export MLFLOW_TRACKING_URI='http://localhost:5000'
@@ -59,6 +61,12 @@ Run the baseline:
 glideator-ml run s2s --config configs/s2s/svd.yaml
 ```
 
+Retrain the production-equivalent contrastive benchmark:
+
+```bash
+glideator-ml run s2s --config configs/s2s/contrastive-prod-equivalent.yaml
+```
+
 The command writes a production-compatible pickle plus an evaluation report under
 `outputs/`, and logs the config, dataset fingerprint, metrics, Git SHA, and
 artifacts to MLflow.
@@ -66,14 +74,16 @@ artifacts to MLflow.
 To inspect local runs:
 
 ```bash
-mlflow ui --backend-store-uri ./mlruns
+mlflow ui --backend-store-uri sqlite:///mlruns/mlflow.db
 ```
 
 ## Data contract
 
-The database loader reads `mart.fact_flights` and joins `mart.dim_sites` by the
-XContest site name to obtain `site_id`. It reduces raw flights to one first-visit
-event per pilot/site before any split or model fitting.
+The database loader reads `fact_flights` and joins `dim_sites` by the XContest
+site name to obtain `site_id`. The schema is configurable with `data.schema`
+(`mart` by default; the production-equivalent config uses `glideator_mart`).
+It reduces raw flights to one first-visit event per pilot/site before any split
+or model fitting.
 
 For isolated experiments and tests, the same runner can consume a CSV containing:
 

--- a/ml/configs/s2s/asymmetric.yaml
+++ b/ml/configs/s2s/asymmetric.yaml
@@ -1,0 +1,39 @@
+task: s2s
+
+data:
+  source: database
+  database_url_env: ML_DATABASE_URL
+  schema: glideator_mart
+  split_strategy: pilot
+  eval_fraction: 0.20
+  min_eval_history: 1
+  split_seed: 42
+
+model:
+  name: asymmetric
+  seed: 42
+  n_factors: 64
+  epochs: 50
+  learning_rate: 0.005
+  weight_decay: 0.0001
+  temperature: 0.1
+  batch_size: 256
+  negative_samples: 50
+  negative_sampling_power: 0.75
+  add_inbatch_negatives: false
+  device: auto
+
+evaluation:
+  benchmark_id: s2s-v1
+  ks: [5, 10]
+
+artifact:
+  output_dir: outputs/s2s/asymmetric
+  filename: s2s_asymmetric.pkl
+
+tracking:
+  enabled: true
+  experiment_name: glideator-s2s
+  run_name: asymmetric
+  tracking_uri_env: MLFLOW_TRACKING_URI
+  default_tracking_uri: sqlite:///mlruns/mlflow.db

--- a/ml/configs/s2s/candidate-attention.yaml
+++ b/ml/configs/s2s/candidate-attention.yaml
@@ -1,0 +1,40 @@
+task: s2s
+
+data:
+  source: database
+  database_url_env: ML_DATABASE_URL
+  schema: glideator_mart
+  split_strategy: pilot
+  eval_fraction: 0.20
+  min_eval_history: 1
+  split_seed: 42
+
+model:
+  name: candidate_attention
+  seed: 42
+  n_factors: 64
+  epochs: 50
+  learning_rate: 0.005
+  weight_decay: 0.0001
+  temperature: 0.1
+  batch_size: 256
+  negative_samples: 50
+  negative_sampling_power: 0.75
+  add_inbatch_negatives: false
+  attention_scale_init: 0.1
+  device: auto
+
+evaluation:
+  benchmark_id: s2s-v1
+  ks: [5, 10]
+
+artifact:
+  output_dir: outputs/s2s/candidate-attention
+  filename: s2s_candidate_attention.pkl
+
+tracking:
+  enabled: true
+  experiment_name: glideator-s2s
+  run_name: candidate-attention
+  tracking_uri_env: MLFLOW_TRACKING_URI
+  default_tracking_uri: sqlite:///mlruns/mlflow.db

--- a/ml/configs/s2s/contrastive-prod-equivalent.yaml
+++ b/ml/configs/s2s/contrastive-prod-equivalent.yaml
@@ -4,23 +4,32 @@ seed: 42
 data:
   source: database
   database_url_env: ML_DATABASE_URL
+  schema: glideator_mart
   eval_fraction: 0.20
   min_eval_history: 1
 
 model:
-  name: svd
+  name: contrastive
   n_factors: 64
-  sigma_power: 1.0
+  epochs: 50
+  learning_rate: 0.005
+  weight_decay: 0.0001
+  temperature: 0.1
+  batch_size: 256
+  negative_samples: 50
+  add_inbatch_negatives: false
+  device: auto
 
 evaluation:
   ks: [5, 10]
 
 artifact:
-  output_dir: outputs/s2s/svd
+  output_dir: outputs/s2s/contrastive-prod-equivalent
   filename: s2s_covisit_embeddings.pkl
 
 tracking:
   enabled: true
   experiment_name: glideator-s2s
+  run_name: contrastive-prod-equivalent
   tracking_uri_env: MLFLOW_TRACKING_URI
   default_tracking_uri: sqlite:///mlruns/mlflow.db

--- a/ml/configs/s2s/contrastive-prod-equivalent.yaml
+++ b/ml/configs/s2s/contrastive-prod-equivalent.yaml
@@ -4,6 +4,7 @@ data:
   source: database
   database_url_env: ML_DATABASE_URL
   schema: glideator_mart
+  split_strategy: pilot
   eval_fraction: 0.20
   min_eval_history: 1
   split_seed: 42

--- a/ml/configs/s2s/contrastive-prod-equivalent.yaml
+++ b/ml/configs/s2s/contrastive-prod-equivalent.yaml
@@ -19,6 +19,7 @@ model:
   temperature: 0.1
   batch_size: 256
   negative_samples: 50
+  negative_sampling_power: 0.75
   add_inbatch_negatives: false
   device: auto
 

--- a/ml/configs/s2s/contrastive-prod-equivalent.yaml
+++ b/ml/configs/s2s/contrastive-prod-equivalent.yaml
@@ -1,5 +1,4 @@
 task: s2s
-seed: 42
 
 data:
   source: database
@@ -7,9 +6,11 @@ data:
   schema: glideator_mart
   eval_fraction: 0.20
   min_eval_history: 1
+  split_seed: 42
 
 model:
   name: contrastive
+  seed: 42
   n_factors: 64
   epochs: 50
   learning_rate: 0.005
@@ -21,6 +22,7 @@ model:
   device: auto
 
 evaluation:
+  benchmark_id: s2s-v1
   ks: [5, 10]
 
 artifact:

--- a/ml/configs/s2s/contrastive-temporal-v2.yaml
+++ b/ml/configs/s2s/contrastive-temporal-v2.yaml
@@ -5,7 +5,7 @@ data:
   database_url_env: ML_DATABASE_URL
   schema: glideator_mart
   split_strategy: temporal
-  temporal_cutoff: "2025-01-01"
+  temporal_cutoff: "2024-01-01"
   min_eval_history: 1
 
 model:

--- a/ml/configs/s2s/contrastive-temporal-v2.yaml
+++ b/ml/configs/s2s/contrastive-temporal-v2.yaml
@@ -18,6 +18,7 @@ model:
   temperature: 0.1
   batch_size: 256
   negative_samples: 50
+  negative_sampling_power: 0.75
   add_inbatch_negatives: false
   device: auto
 

--- a/ml/configs/s2s/contrastive-temporal-v2.yaml
+++ b/ml/configs/s2s/contrastive-temporal-v2.yaml
@@ -1,0 +1,37 @@
+task: s2s
+
+data:
+  source: database
+  database_url_env: ML_DATABASE_URL
+  schema: glideator_mart
+  split_strategy: temporal
+  temporal_cutoff: "2025-01-01"
+  min_eval_history: 1
+
+model:
+  name: contrastive
+  seed: 42
+  n_factors: 64
+  epochs: 50
+  learning_rate: 0.005
+  weight_decay: 0.0001
+  temperature: 0.1
+  batch_size: 256
+  negative_samples: 50
+  add_inbatch_negatives: false
+  device: auto
+
+evaluation:
+  benchmark_id: s2s-v2
+  ks: [5, 10]
+
+artifact:
+  output_dir: outputs/s2s/contrastive-temporal-v2
+  filename: s2s_covisit_embeddings.pkl
+
+tracking:
+  enabled: true
+  experiment_name: glideator-s2s
+  run_name: contrastive-temporal-v2
+  tracking_uri_env: MLFLOW_TRACKING_URI
+  default_tracking_uri: sqlite:///mlruns/mlflow.db

--- a/ml/configs/s2s/deepsets.yaml
+++ b/ml/configs/s2s/deepsets.yaml
@@ -1,0 +1,42 @@
+task: s2s
+
+data:
+  source: database
+  database_url_env: ML_DATABASE_URL
+  schema: glideator_mart
+  split_strategy: pilot
+  eval_fraction: 0.20
+  min_eval_history: 1
+  split_seed: 42
+
+model:
+  name: deepsets
+  seed: 42
+  n_factors: 64
+  phi_hidden_dim: 128
+  rho_hidden_dim: 128
+  pooling: mean
+  epochs: 50
+  learning_rate: 0.005
+  weight_decay: 0.0001
+  temperature: 0.1
+  batch_size: 256
+  negative_samples: 50
+  negative_sampling_power: 0.75
+  add_inbatch_negatives: false
+  device: auto
+
+evaluation:
+  benchmark_id: s2s-v1
+  ks: [5, 10]
+
+artifact:
+  output_dir: outputs/s2s/deepsets
+  filename: s2s_deepsets.pkl
+
+tracking:
+  enabled: true
+  experiment_name: glideator-s2s
+  run_name: deepsets
+  tracking_uri_env: MLFLOW_TRACKING_URI
+  default_tracking_uri: sqlite:///mlruns/mlflow.db

--- a/ml/configs/s2s/svd.yaml
+++ b/ml/configs/s2s/svd.yaml
@@ -1,0 +1,26 @@
+task: s2s
+seed: 42
+
+data:
+  source: database
+  database_url_env: ML_DATABASE_URL
+  eval_fraction: 0.20
+  min_eval_history: 1
+
+model:
+  name: svd
+  n_factors: 64
+  sigma_power: 1.0
+
+evaluation:
+  ks: [5, 10]
+
+artifact:
+  output_dir: outputs/s2s/svd
+  filename: s2s_covisit_embeddings.pkl
+
+tracking:
+  enabled: true
+  experiment_name: glideator-s2s
+  tracking_uri_env: MLFLOW_TRACKING_URI
+  default_tracking_uri: file:./mlruns

--- a/ml/configs/s2s/svd.yaml
+++ b/ml/configs/s2s/svd.yaml
@@ -1,18 +1,20 @@
 task: s2s
-seed: 42
 
 data:
   source: database
   database_url_env: ML_DATABASE_URL
   eval_fraction: 0.20
   min_eval_history: 1
+  split_seed: 42
 
 model:
   name: svd
+  seed: 42
   n_factors: 64
   sigma_power: 1.0
 
 evaluation:
+  benchmark_id: s2s-v1
   ks: [5, 10]
 
 artifact:

--- a/ml/configs/s2s/svd.yaml
+++ b/ml/configs/s2s/svd.yaml
@@ -3,6 +3,7 @@ task: s2s
 data:
   source: database
   database_url_env: ML_DATABASE_URL
+  split_strategy: pilot
   eval_fraction: 0.20
   min_eval_history: 1
   split_seed: 42

--- a/ml/configs/s2s/transformed-additive.yaml
+++ b/ml/configs/s2s/transformed-additive.yaml
@@ -1,0 +1,41 @@
+task: s2s
+
+data:
+  source: database
+  database_url_env: ML_DATABASE_URL
+  schema: glideator_mart
+  split_strategy: pilot
+  eval_fraction: 0.20
+  min_eval_history: 1
+  split_seed: 42
+
+model:
+  name: transformed_additive
+  seed: 42
+  n_factors: 64
+  phi_hidden_dim: 128
+  rho_hidden_dim: 128
+  epochs: 50
+  learning_rate: 0.005
+  weight_decay: 0.0001
+  temperature: 0.1
+  batch_size: 256
+  negative_samples: 50
+  negative_sampling_power: 0.75
+  add_inbatch_negatives: false
+  device: auto
+
+evaluation:
+  benchmark_id: s2s-v1
+  ks: [5, 10]
+
+artifact:
+  output_dir: outputs/s2s/transformed-additive
+  filename: s2s_transformed_additive.pkl
+
+tracking:
+  enabled: true
+  experiment_name: glideator-s2s
+  run_name: transformed-additive
+  tracking_uri_env: MLFLOW_TRACKING_URI
+  default_tracking_uri: sqlite:///mlruns/mlflow.db

--- a/ml/docs/decisions/0001-stable-benchmark-identity.md
+++ b/ml/docs/decisions/0001-stable-benchmark-identity.md
@@ -1,0 +1,39 @@
+# 0001 — Stable benchmark identity
+
+**Status:** Accepted  
+**Date:** 2026-08-30
+
+## Context
+
+Early S2S comparisons used a single seed for both the train/evaluation split and stochastic model training. Changing the model seed could therefore change the benchmark itself, making multi-seed architecture comparisons subtly incomparable.
+
+Temporal benchmarks have the same identity problem if the cutoff moves without changing the benchmark label.
+
+## Decision
+
+Benchmark identity is separate from model randomness.
+
+For held-out-pilot S2S comparisons:
+
+- data.split_seed defines the deterministic pilot split;
+- model.seed controls stochastic model fitting;
+- comparable runs keep split_seed fixed while model.seed varies.
+
+For temporal S2S comparisons:
+
+- temporal_cutoff is part of benchmark identity;
+- changing the cutoff requires a new benchmark_id.
+
+Every run records benchmark_id and eval_set_fingerprint derived from the exact walk-forward evaluation events.
+
+## Why
+
+A benchmark must remain fixed while the model changes. Otherwise observed variance mixes model randomness with evaluation-set changes.
+
+The explicit evaluation fingerprint also makes accidental mismatch visible even when two configs claim the same benchmark_id.
+
+## Consequences
+
+- Multi-seed comparisons require identical evaluation fingerprints.
+- Benchmark changes are intentional, named changes.
+- Legacy top-level seed remains only as a compatibility fallback for older configs.

--- a/ml/docs/decisions/0002-task-owned-semantics.md
+++ b/ml/docs/decisions/0002-task-owned-semantics.md
@@ -1,0 +1,34 @@
+# 0002 — Shared harness, task-owned semantics
+
+**Status:** Accepted  
+**Date:** 2026-08-30
+
+## Context
+
+Glideator has multiple ML problems with fundamentally different data and evaluation semantics: site discovery, XC potential, and analogous-day retrieval.
+
+A highly generic ML abstraction would reduce duplicated plumbing, but forcing data preparation, metrics, models, and artifact contracts behind one common interface would hide important domain differences and make the code harder to reason about.
+
+## Decision
+
+Share only the experiment infrastructure that is genuinely common: CLI/config loading, provenance, tracking, and repository conventions.
+
+Each task owns:
+
+- data preparation and splitting;
+- benchmark definitions;
+- evaluation logic;
+- models;
+- artifact and serving contract.
+
+## Why
+
+The goal of the ml/ workspace is comparable, reproducible experiments — not making every model family look structurally identical.
+
+Keeping task semantics local makes leakage rules, metric meaning, and serving assumptions visible where they matter.
+
+## Consequences
+
+- Task evaluators may intentionally differ.
+- New tasks should not inherit a generic metric abstraction unless a real shared abstraction emerges.
+- Documentation mirrors code ownership: each task has its own methodology and model catalogue.

--- a/ml/docs/decisions/0003-scorer-aware-artifacts.md
+++ b/ml/docs/decisions/0003-scorer-aware-artifacts.md
@@ -1,0 +1,39 @@
+# 0003 — Preserve the legacy S2S artifact and extend with scorer state
+
+**Status:** Accepted  
+**Date:** 2026-08-30
+
+## Context
+
+The production S2S backend currently expects a simple pickle payload built around site_to_idx, idx_to_site, and matrix. That is sufficient for SVD and the additive contrastive model.
+
+Experimental architectures such as DeepSets, asymmetric embeddings, transformed additive, and candidate attention require additional learned state to reproduce training-time scoring.
+
+Breaking the artifact contract for every experiment would make comparisons and future promotion unnecessarily expensive. Pretending every model can be reduced to matrix alone would make evaluation inconsistent with serving behavior.
+
+## Decision
+
+All S2S artifacts preserve the legacy keys:
+
+~~~text
+site_to_idx
+idx_to_site
+matrix
+~~~
+
+Architectures that need extra inference state add an optional scorer payload.
+
+The experiment evaluator must use scorer when present so evaluation matches the model that was actually trained.
+
+An artifact that requires scorer is **not production-compatible** until backend serving implements that scorer type.
+
+## Why
+
+This keeps backward compatibility for simple models while allowing experimentation with richer scoring functions without lying about inference equivalence.
+
+## Consequences
+
+- SVD and additive contrastive artifacts remain directly compatible with current serving.
+- New scorer types require validation and round-trip tests.
+- Promotion of scorer-based models must include an explicit serving change.
+- Artifact compatibility is documented on every model page.

--- a/ml/docs/decisions/README.md
+++ b/ml/docs/decisions/README.md
@@ -1,0 +1,50 @@
+# ML decision records
+
+Decision records preserve reasoning that should still matter after individual experiment runs are forgotten.
+
+They are intentionally lighter than a formal architecture-governance process.
+
+## Record a decision when
+
+A choice changes one or more of:
+
+- benchmark semantics or identity;
+- train/evaluation leakage guarantees;
+- shared experiment policy;
+- artifact or serving contracts;
+- promotion criteria;
+- the interpretation of future model comparisons.
+
+Do **not** create a decision record for every model run or hyperparameter sweep. Those belong in MLflow.
+
+A model-specific hypothesis belongs on the model page. If the experiment produces a durable conclusion — for example "do not pursue post-pooling DeepSets for S2S" or "promote architecture X" — add a decision record that cites the relevant MLflow run IDs.
+
+## Template
+
+~~~text
+# NNNN — Decision title
+
+Status: Proposed | Accepted | Superseded
+Date: YYYY-MM-DD
+
+## Context
+What problem or ambiguity forced the decision?
+
+## Decision
+What is now the rule?
+
+## Why
+Why this choice over the alternatives?
+
+## Consequences
+What becomes easier, harder, required, or forbidden?
+
+## Evidence
+Optional MLflow run IDs, reports, PRs, or code references.
+~~~
+
+## Current records
+
+- [0001 — Stable benchmark identity](0001-stable-benchmark-identity.md)
+- [0002 — Task-owned semantics](0002-task-owned-semantics.md)
+- [0003 — Scorer-aware artifacts](0003-scorer-aware-artifacts.md)

--- a/ml/docs/s2s/README.md
+++ b/ml/docs/s2s/README.md
@@ -1,0 +1,170 @@
+# S2S — Site-to-site discovery
+
+S2S recommends **new sites a pilot has not yet visited** from the set of sites they have already discovered.
+
+This is a discovery recommender, not a next-flight predictor. Training and evaluation therefore operate on each pilot's **first visit** to each site.
+
+## Prediction problem
+
+A pilot's ordered first visits:
+
+~~~text
+A, B, C, D
+~~~
+
+produce walk-forward examples such as:
+
+~~~text
+[A]       -> B
+[A, B]    -> C
+[A, B, C] -> D
+~~~
+
+The target is always a newly discovered site. Previously visited sites are excluded from recommendations.
+
+## Data contract
+
+The database loader reads fact_flights and joins dim_sites by the XContest site name to obtain site_id. The schema is configurable through data.schema; production-equivalent configs use glideator_mart.
+
+Raw flights are reduced to one first-visit event per pilot/site **before** splitting or fitting.
+
+For isolated tests the same runner can consume CSV data with:
+
+~~~text
+pilot,site_id,date,start_time
+~~~
+
+## Benchmarks
+
+### s2s-v1 — held-out-pilot generalization
+
+Pilots are deterministically split into train and evaluation groups. The model is fitted only on train pilots; evaluation pilots contribute walk-forward first-visit examples.
+
+This answers: **does the model generalize to pilots it never trained on?**
+
+Benchmark identity and model randomness are intentionally separate:
+
+~~~yaml
+data:
+  split_strategy: pilot
+  split_seed: 42
+
+model:
+  seed: 42
+
+evaluation:
+  benchmark_id: s2s-v1
+~~~
+
+When comparing architectures or stochastic seeds, keep data.split_seed fixed. Vary model.seed only.
+
+### s2s-v2 — temporal production simulation
+
+The temporal benchmark trains on first visits before a fixed cutoff and evaluates first visits on or after that cutoff. A target's history may include legitimate discoveries made before the cutoff.
+
+~~~yaml
+data:
+  split_strategy: temporal
+  temporal_cutoff: "2024-01-01"
+
+evaluation:
+  benchmark_id: s2s-v2
+~~~
+
+The checked-in v2 benchmark uses 2024-01-01. The cutoff is part of the benchmark definition; changing it requires a new benchmark identity.
+
+The runner logs benchmark_id, split strategy, split seed or cutoff, dataset fingerprint, and an eval_set_fingerprint derived from the exact walk-forward events.
+
+See [ADR 0001](../decisions/0001-stable-benchmark-identity.md).
+
+## Evaluation
+
+The core ranking metrics are:
+
+- HitRate@k
+- MRR@k
+- NDCG@k
+- catalog coverage@k
+- average log popularity@k
+- cold-start target rate
+- known-source rate
+- number of walk-forward events
+
+The evaluator also reports:
+
+- end_to_end_hit_rate_at_k, using every benchmark event as the denominator;
+- history slices: 1 site, 2–3 sites, and 4+ sites;
+- target popularity slices: head, tail, and cold-start.
+
+The popularity head is the top 20% of the training catalogue by first-visit count. Every other known site is tail.
+
+Task-specific evaluation deliberately lives in glideator_ml/s2s/evaluation.py rather than in a generic metric abstraction. See [ADR 0002](../decisions/0002-task-owned-semantics.md).
+
+## Model catalogue
+
+| Model | Role / hypothesis | Serving today | Doc |
+| --- | --- | --- | --- |
+| SVD | Classical latent-factor baseline | Compatible | [SVD](models/svd.md) |
+| Contrastive additive | Production-equivalent neural reference | Compatible | [Contrastive](models/contrastive.md) |
+| DeepSets | Nonlinear set encoder after pooling | Requires scorer-aware serving | [DeepSets](models/deepsets.md) |
+| Asymmetric additive | Untie history and candidate embeddings | Requires scorer-aware serving | [Asymmetric](models/asymmetric.md) |
+| Transformed additive | Nonlinear per-site transform while preserving additive history | Requires scorer-aware serving | [Transformed additive](models/transformed-additive.md) |
+| Candidate attention | Candidate-specific residual correction over additive history | Requires scorer-aware serving | [Candidate attention](models/candidate-attention.md) |
+
+The model pages intentionally do not duplicate current metric tables. Run metrics and artifacts belong in MLflow; model docs explain architecture and experimental intent. Durable promote/reject decisions should be recorded under docs/decisions/.
+
+## Checked-in configs
+
+~~~text
+configs/s2s/svd.yaml
+configs/s2s/contrastive-prod-equivalent.yaml
+configs/s2s/contrastive-temporal-v2.yaml
+configs/s2s/deepsets.yaml
+configs/s2s/asymmetric.yaml
+configs/s2s/transformed-additive.yaml
+configs/s2s/candidate-attention.yaml
+~~~
+
+Run a model from the ml/ directory:
+
+~~~bash
+glideator-ml run s2s --config configs/s2s/contrastive-prod-equivalent.yaml
+~~~
+
+For fixed-split seed comparisons, leave data.split_seed unchanged and vary only model.seed. All comparable runs should have identical event counts and eval_set_fingerprint.
+
+For temporal comparisons, keep temporal_cutoff unchanged and vary only model.seed.
+
+## Artifacts and serving
+
+All S2S artifacts preserve the legacy payload keys:
+
+~~~text
+site_to_idx
+idx_to_site
+matrix
+~~~
+
+SVD and contrastive additive can be served using the current backend contract.
+
+Models with learned history/candidate scoring state add an optional scorer payload. Their evaluator uses that scorer so experiment-time inference matches training, but they must not be promoted until production serving understands the scorer.
+
+See [ADR 0003](../decisions/0003-scorer-aware-artifacts.md).
+
+## Tracking and recovery
+
+A successful run writes the model artifact and evaluation.json under outputs/ and logs configuration, fingerprints, benchmark identity, metrics, Git SHA, and artifacts to MLflow.
+
+If training and evaluation succeed but MLflow is temporarily unavailable, the saved run can be backfilled without retraining:
+
+~~~bash
+glideator-ml backfill s2s --config configs/s2s/deepsets.yaml
+~~~
+
+Backfill is idempotent after mlflow_run_id has been persisted to evaluation.json.
+
+Inspect local runs with:
+
+~~~bash
+mlflow ui --backend-store-uri sqlite:///mlruns/mlflow.db
+~~~

--- a/ml/docs/s2s/models/README.md
+++ b/ml/docs/s2s/models/README.md
@@ -1,0 +1,24 @@
+# S2S model documentation
+
+Each S2S architecture gets one short page. The page should stay stable as new runs accumulate.
+
+## Required sections
+
+1. **Role** — baseline, reference, ablation, or candidate.
+2. **Hypothesis** — what limitation of the reference model it is testing.
+3. **Architecture** — the scoring function at the level needed to reason about behavior.
+4. **Delta from reference** — what changed and, equally important, what stayed fixed.
+5. **Config** — canonical checked-in config.
+6. **Serving contract** — whether the current backend can score the artifact.
+7. **What to learn from it** — the question the experiment is intended to answer.
+
+Do not maintain copied benchmark tables here. MLflow is the run-level system of record. If evidence leads to a durable choice — promotion, rejection, benchmark change, serving-contract change — record that conclusion in docs/decisions/.
+
+## Current models
+
+- [SVD](svd.md)
+- [Contrastive additive](contrastive.md)
+- [DeepSets](deepsets.md)
+- [Asymmetric additive](asymmetric.md)
+- [Transformed additive](transformed-additive.md)
+- [Candidate attention](candidate-attention.md)

--- a/ml/docs/s2s/models/asymmetric.md
+++ b/ml/docs/s2s/models/asymmetric.md
@@ -1,0 +1,36 @@
+# Asymmetric additive
+
+**Role:** representation-tie ablation  
+**Config:** configs/s2s/asymmetric.yaml  
+**Serving:** requires scorer-aware serving
+
+## Hypothesis
+
+A site may need a different representation when it appears in a pilot's history than when it is scored as a future candidate. Sharing one embedding table forces those two roles together.
+
+## Architecture
+
+History and candidates use separate embedding tables:
+
+~~~text
+query = normalize(sum(source_embedding(history_sites)))
+score(candidate) = cosine(query, target_embedding(candidate))
+~~~
+
+History composition remains purely additive.
+
+## Delta from contrastive additive
+
+The only architectural change is untied source and target embeddings. The additive history function and contrastive training structure remain unchanged.
+
+That makes the model a focused test of **representation asymmetry**, rather than a test of additional history-encoder capacity.
+
+## Serving contract
+
+Target embeddings remain in matrix. The source embedding table is stored in scorer.source_matrix.
+
+Current production serving assumes the same matrix is used for history and candidates, so this artifact needs scorer-aware inference.
+
+## What to learn from it
+
+Use this ablation to decide whether the shared-embedding constraint itself is limiting the reference model.

--- a/ml/docs/s2s/models/candidate-attention.md
+++ b/ml/docs/s2s/models/candidate-attention.md
@@ -1,0 +1,36 @@
+# Candidate attention
+
+**Role:** candidate-conditioned residual experiment  
+**Config:** configs/s2s/candidate-attention.yaml  
+**Serving:** requires scorer-aware serving
+
+## Hypothesis
+
+A single global history vector forces every candidate to interpret the pilot's history in the same way. A candidate may instead care about different visited sites.
+
+## Architecture
+
+The normalized additive history remains the residual base.
+
+For each candidate, a single attention head uses learned Q/K/V projections to weight history sites and produce a candidate-specific context. A learned scalar controls the correction:
+
+~~~text
+candidate_query = normalize(additive_base + attention_scale * context(candidate, history))
+score(candidate) = cosine(candidate_query, candidate_embedding)
+~~~
+
+The attention scale is initialized small so training starts close to the strong additive reference.
+
+The S2S catalogue is only a few hundred sites, so candidate-conditioned full-catalogue scoring is tractable.
+
+## Delta from contrastive additive
+
+The additive representation is retained as a residual path. The only new capability is a candidate-specific correction over the visited-site set.
+
+## Serving contract
+
+The artifact stores history embeddings, Q/K/V weights, and attention_scale in scorer. Current production inference does not execute this scorer.
+
+## What to learn from it
+
+This tests whether candidate-specific interpretation of history adds value without discarding the additive inductive bias.

--- a/ml/docs/s2s/models/contrastive.md
+++ b/ml/docs/s2s/models/contrastive.md
@@ -1,0 +1,34 @@
+# Contrastive additive
+
+**Role:** production-equivalent neural reference  
+**Configs:** configs/s2s/contrastive-prod-equivalent.yaml and configs/s2s/contrastive-temporal-v2.yaml  
+**Serving:** compatible with the current backend
+
+## Hypothesis
+
+A pilot's discovered sites can be represented well by a normalized additive embedding, trained directly to separate the next first-visit target from sampled negatives.
+
+## Architecture
+
+A single site embedding table is shared between history and candidate representations.
+
+For a training episode:
+
+~~~text
+query = normalize(sum(embedding(history_sites)))
+positive = normalize(embedding(target_site))
+~~~
+
+The loss contrasts the positive against sampled negative sites using temperature-scaled cross entropy.
+
+The checked-in production-equivalent configuration uses popularity-powered negative sampling. History sites and the positive target are excluded from sampled negatives. In-batch negatives are configurable.
+
+## Why this is the reference
+
+The additive representation is simple, permutation-invariant, fast to score over the whole catalogue, and matches the current production artifact contract.
+
+Every experimental neural architecture should state exactly which part of this reference it changes while keeping benchmark and training policy aligned.
+
+## What to learn from it
+
+This is the main neural comparison point and the serving-compatible fallback. New architectures should beat it for a clear reason, not merely add capacity.

--- a/ml/docs/s2s/models/deepsets.md
+++ b/ml/docs/s2s/models/deepsets.md
@@ -1,0 +1,44 @@
+# DeepSets
+
+**Role:** nonlinear history-encoder experiment  
+**Config:** configs/s2s/deepsets.yaml  
+**Serving:** requires scorer-aware serving
+
+## Hypothesis
+
+A plain sum of site embeddings may be too restrictive. A learned permutation-invariant set encoder may capture interactions among a pilot's discovered sites.
+
+## Architecture
+
+Each history site is transformed by phi, pooled, then passed through rho:
+
+~~~text
+query = rho(pool(phi(site_1), ..., phi(site_n)))
+~~~
+
+The checked-in configuration uses mean pooling. The candidate catalogue still uses normalized site embeddings.
+
+## Delta from contrastive additive
+
+Changed:
+
+- nonlinear per-site phi network;
+- pooling before a nonlinear rho network.
+
+Kept aligned in the canonical comparison:
+
+- benchmark identity;
+- embedding dimension;
+- optimizer and contrastive objective;
+- negative-sampling policy;
+- candidate representation.
+
+## Serving contract
+
+The artifact preserves the legacy keys but adds the learned phi/rho weights in scorer. Experiment evaluation uses this scorer.
+
+Do not promote the artifact to the current backend until serving executes the same learned history encoder.
+
+## What to learn from it
+
+DeepSets tests whether the missing ingredient is **nonlinear interaction after pooling**. Compare it especially with transformed additive, which keeps the nonlinear per-site transform but removes the post-pooling bottleneck.

--- a/ml/docs/s2s/models/svd.md
+++ b/ml/docs/s2s/models/svd.md
@@ -1,0 +1,27 @@
+# SVD
+
+**Role:** classical baseline  
+**Config:** configs/s2s/svd.yaml  
+**Serving:** compatible with the current backend
+
+## Hypothesis
+
+A simple latent co-visit structure may already capture much of site discovery behavior. SVD provides a low-complexity reference before adding learned sequence/set encoders.
+
+## Architecture
+
+Training builds a binary pilot × site first-visit matrix and applies randomized truncated SVD.
+
+Site vectors come from the right singular vectors, scaled by singular values raised to sigma_power, then L2-normalized.
+
+At inference, visited-site vectors are summed and normalized. Unvisited candidates are ranked by cosine similarity.
+
+## Delta from the neural reference
+
+SVD has no learned walk-forward objective, no negative sampling, and no nonlinear history encoder. It is intentionally structurally different and cheap.
+
+## What to learn from it
+
+Use SVD to answer whether additional neural complexity creates meaningful ranking lift over a strong latent-factor baseline.
+
+Its artifact contains only the legacy site_to_idx, idx_to_site, and matrix scoring contract.

--- a/ml/docs/s2s/models/transformed-additive.md
+++ b/ml/docs/s2s/models/transformed-additive.md
@@ -1,0 +1,39 @@
+# Transformed additive
+
+**Role:** nonlinear additive ablation  
+**Config:** configs/s2s/transformed-additive.yaml  
+**Serving:** requires scorer-aware serving
+
+## Hypothesis
+
+DeepSets adds two ideas at once: nonlinear per-site transforms and a nonlinear post-pooling encoder. If DeepSets underperforms, the post-pooling compression may be the problem rather than nonlinearity itself.
+
+## Architecture
+
+Each site is transformed independently and the transformed vectors are summed:
+
+~~~text
+query = sum(rho(phi(site_i)))
+~~~
+
+The final query is normalized before cosine scoring.
+
+With a one-site history this has the same functional form as the DeepSets transform path. With longer histories it preserves additive composition instead of applying rho after pooling.
+
+## Delta from DeepSets
+
+Changed:
+
+~~~text
+rho(mean(phi(site_i)))  ->  sum(rho(phi(site_i)))
+~~~
+
+The canonical config keeps the same phi/rho dimensions and aligns the remaining contrastive training policy with the reference comparison.
+
+## Serving contract
+
+The artifact stores the phi/rho weights in scorer and therefore requires scorer-aware serving.
+
+## What to learn from it
+
+This isolates whether **nonlinear per-site representation** helps while **post-pooling nonlinear compression** hurts.

--- a/ml/glideator_ml/__init__.py
+++ b/ml/glideator_ml/__init__.py
@@ -1,0 +1,3 @@
+"""Glideator model experimentation platform."""
+
+__version__ = "0.1.0"

--- a/ml/glideator_ml/__main__.py
+++ b/ml/glideator_ml/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+main()

--- a/ml/glideator_ml/cli.py
+++ b/ml/glideator_ml/cli.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from .config import load_config
+from .s2s.run import run_s2s
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="glideator-ml")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    run = subparsers.add_parser("run", help="Run a model experiment")
+    run.add_argument("task", choices=["s2s"])
+    run.add_argument("--config", required=True)
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    config = load_config(args.config)
+    if config["task"] != args.task:
+        raise SystemExit(
+            f"Config task {config['task']!r} does not match CLI task {args.task!r}"
+        )
+
+    if args.task == "s2s":
+        report = run_s2s(config)
+    else:
+        raise SystemExit(f"Unsupported task: {args.task}")
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/ml/glideator_ml/cli.py
+++ b/ml/glideator_ml/cli.py
@@ -4,7 +4,7 @@ import argparse
 import json
 
 from .config import load_config
-from .s2s.run import run_s2s
+from .s2s.run import backfill_s2s_tracking, run_s2s
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -14,6 +14,13 @@ def build_parser() -> argparse.ArgumentParser:
     run = subparsers.add_parser("run", help="Run a model experiment")
     run.add_argument("task", choices=["s2s"])
     run.add_argument("--config", required=True)
+
+    backfill = subparsers.add_parser(
+        "backfill",
+        help="Backfill tracking from saved experiment artifacts",
+    )
+    backfill.add_argument("task", choices=["s2s"])
+    backfill.add_argument("--config", required=True)
     return parser
 
 
@@ -25,10 +32,12 @@ def main() -> None:
             f"Config task {config['task']!r} does not match CLI task {args.task!r}"
         )
 
-    if args.task == "s2s":
+    if args.command == "run" and args.task == "s2s":
         report = run_s2s(config)
+    elif args.command == "backfill" and args.task == "s2s":
+        report = backfill_s2s_tracking(config)
     else:
-        raise SystemExit(f"Unsupported task: {args.task}")
+        raise SystemExit(f"Unsupported command/task: {args.command}/{args.task}")
 
     print(json.dumps(report, indent=2, sort_keys=True))
 

--- a/ml/glideator_ml/config.py
+++ b/ml/glideator_ml/config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+def load_config(path: str | Path) -> dict[str, Any]:
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle) or {}
+
+    required = {"task", "data", "model", "evaluation", "artifact", "tracking"}
+    missing = sorted(required - config.keys())
+    if missing:
+        raise ValueError(f"Missing config sections: {', '.join(missing)}")
+    return config
+
+
+def flatten_config(value: dict[str, Any], prefix: str = "") -> dict[str, Any]:
+    flat: dict[str, Any] = {}
+    for key, item in value.items():
+        name = f"{prefix}.{key}" if prefix else key
+        if isinstance(item, dict):
+            flat.update(flatten_config(item, name))
+        elif isinstance(item, (list, tuple)):
+            flat[name] = ",".join(str(part) for part in item)
+        else:
+            flat[name] = item
+    return flat

--- a/ml/glideator_ml/s2s/__init__.py
+++ b/ml/glideator_ml/s2s/__init__.py
@@ -1,0 +1,1 @@
+"""Site-to-site recommendation experiments."""

--- a/ml/glideator_ml/s2s/artifact.py
+++ b/ml/glideator_ml/s2s/artifact.py
@@ -47,6 +47,34 @@ class S2SArtifact:
                     "Asymmetric source matrix contains non-finite values"
                 )
             return
+        if scorer_type == "candidate_attention":
+            dimension = self.matrix.shape[1]
+            history_matrix = np.asarray(self.scorer["history_matrix"])
+            if history_matrix.shape != self.matrix.shape:
+                raise ValueError(
+                    "Candidate-attention history matrix must match embedding shape"
+                )
+            arrays = {
+                "history_matrix": history_matrix,
+                "query_weight": np.asarray(self.scorer["query_weight"]),
+                "key_weight": np.asarray(self.scorer["key_weight"]),
+                "value_weight": np.asarray(self.scorer["value_weight"]),
+            }
+            for name in ("query_weight", "key_weight", "value_weight"):
+                if arrays[name].shape != (dimension, dimension):
+                    raise ValueError(
+                        f"Candidate-attention {name} has shape {arrays[name].shape}, "
+                        f"expected {(dimension, dimension)}"
+                    )
+            for name, array in arrays.items():
+                if not np.isfinite(array).all():
+                    raise ValueError(
+                        f"Candidate-attention {name} contains non-finite values"
+                    )
+            scale = float(self.scorer["attention_scale"])
+            if not np.isfinite(scale):
+                raise ValueError("Candidate-attention scale must be finite")
+            return
         if scorer_type not in {"deepsets", "transformed_additive"}:
             raise ValueError(f"Unsupported S2S scorer type: {scorer_type!r}")
 
@@ -134,6 +162,48 @@ class S2SArtifact:
         return artifact
 
 
+def _candidate_attention_scores(
+    artifact: S2SArtifact,
+    idxs: list[int],
+) -> np.ndarray:
+    scorer = artifact.scorer
+    if scorer is None:
+        raise ValueError("Candidate-attention scoring requested without scorer state")
+
+    history_matrix = np.asarray(scorer["history_matrix"])
+    base = history_matrix[idxs].sum(axis=0)
+    base_norm = np.linalg.norm(base)
+    if base_norm == 0.0:
+        return np.full(len(artifact.idx_to_site), -np.inf, dtype=np.float32)
+    base = base / base_norm
+
+    dimension = artifact.matrix.shape[1]
+    root_d = np.sqrt(float(dimension))
+    history = artifact.matrix[idxs]
+    candidates = artifact.matrix
+
+    queries = (candidates * root_d) @ np.asarray(scorer["query_weight"]).T
+    keys = (history * root_d) @ np.asarray(scorer["key_weight"]).T
+    logits = (queries @ keys.T) / root_d
+    logits = logits - logits.max(axis=1, keepdims=True)
+    attention = np.exp(logits)
+    attention = attention / attention.sum(axis=1, keepdims=True)
+
+    values = history @ np.asarray(scorer["value_weight"]).T
+    context = attention @ values
+    candidate_queries = (
+        base[None, :] + float(scorer["attention_scale"]) * context
+    )
+    norms = np.linalg.norm(candidate_queries, axis=1, keepdims=True)
+    candidate_queries = np.divide(
+        candidate_queries,
+        norms,
+        out=np.zeros_like(candidate_queries),
+        where=norms > 0,
+    )
+    return np.sum(candidate_queries * candidates, axis=1)
+
+
 def _transformed_additive_query(
     artifact: S2SArtifact,
     idxs: list[int],
@@ -195,25 +265,30 @@ def recommend(
     if not idxs or top_k <= 0:
         return []
 
-    if artifact.scorer is None:
-        query = artifact.matrix[idxs].sum(axis=0)
-    elif artifact.scorer.get("type") == "asymmetric":
-        query = np.asarray(artifact.scorer["source_matrix"])[idxs].sum(axis=0)
-    elif artifact.scorer.get("type") == "deepsets":
-        query = _deepsets_query(artifact, idxs)
-    elif artifact.scorer.get("type") == "transformed_additive":
-        query = _transformed_additive_query(artifact, idxs)
+    if (
+        artifact.scorer is not None
+        and artifact.scorer.get("type") == "candidate_attention"
+    ):
+        scores = _candidate_attention_scores(artifact, idxs)
     else:
-        raise ValueError(
-            f"Unsupported S2S scorer type: {artifact.scorer.get('type')!r}"
-        )
+        if artifact.scorer is None:
+            query = artifact.matrix[idxs].sum(axis=0)
+        elif artifact.scorer.get("type") == "asymmetric":
+            query = np.asarray(artifact.scorer["source_matrix"])[idxs].sum(axis=0)
+        elif artifact.scorer.get("type") == "deepsets":
+            query = _deepsets_query(artifact, idxs)
+        elif artifact.scorer.get("type") == "transformed_additive":
+            query = _transformed_additive_query(artifact, idxs)
+        else:
+            raise ValueError(
+                f"Unsupported S2S scorer type: {artifact.scorer.get('type')!r}"
+            )
 
-    norm = np.linalg.norm(query)
-    if norm == 0.0:
-        return []
-    query = query / norm
-
-    scores = artifact.matrix @ query
+        norm = np.linalg.norm(query)
+        if norm == 0.0:
+            return []
+        query = query / norm
+        scores = artifact.matrix @ query
     scores = scores.copy()
     scores[idxs] = -np.inf
     candidate_count = scores.size - len(set(idxs))

--- a/ml/glideator_ml/s2s/artifact.py
+++ b/ml/glideator_ml/s2s/artifact.py
@@ -47,12 +47,13 @@ class S2SArtifact:
                     "Asymmetric source matrix contains non-finite values"
                 )
             return
-        if scorer_type != "deepsets":
+        if scorer_type not in {"deepsets", "transformed_additive"}:
             raise ValueError(f"Unsupported S2S scorer type: {scorer_type!r}")
 
-        pooling = self.scorer.get("pooling")
-        if pooling not in {"mean", "sum"}:
-            raise ValueError("DeepSets scorer pooling must be 'mean' or 'sum'")
+        if scorer_type == "deepsets":
+            pooling = self.scorer.get("pooling")
+            if pooling not in {"mean", "sum"}:
+                raise ValueError("DeepSets scorer pooling must be 'mean' or 'sum'")
 
         dimension = self.matrix.shape[1]
         phi_w1 = np.asarray(self.scorer["phi_w1"])
@@ -93,7 +94,9 @@ class S2SArtifact:
                     f"expected {expected_shapes[name]}"
                 )
             if not np.isfinite(array).all():
-                raise ValueError(f"DeepSets scorer {name} contains non-finite values")
+                raise ValueError(
+                    f"{scorer_type} scorer {name} contains non-finite values"
+                )
 
     def to_payload(self) -> dict[str, Any]:
         self.validate()
@@ -129,6 +132,30 @@ class S2SArtifact:
         )
         artifact.validate()
         return artifact
+
+
+def _transformed_additive_query(
+    artifact: S2SArtifact,
+    idxs: list[int],
+) -> np.ndarray:
+    scorer = artifact.scorer
+    if scorer is None:
+        raise ValueError("Transformed-additive query requested without scorer state")
+
+    items = artifact.matrix[idxs]
+    phi = np.maximum(
+        items @ np.asarray(scorer["phi_w1"]).T + np.asarray(scorer["phi_b1"]),
+        0.0,
+    )
+    phi = phi @ np.asarray(scorer["phi_w2"]).T + np.asarray(scorer["phi_b2"])
+    rho = np.maximum(
+        phi @ np.asarray(scorer["rho_w1"]).T + np.asarray(scorer["rho_b1"]),
+        0.0,
+    )
+    transformed = (
+        rho @ np.asarray(scorer["rho_w2"]).T + np.asarray(scorer["rho_b2"])
+    )
+    return transformed.sum(axis=0)
 
 
 def _deepsets_query(artifact: S2SArtifact, idxs: list[int]) -> np.ndarray:
@@ -174,6 +201,8 @@ def recommend(
         query = np.asarray(artifact.scorer["source_matrix"])[idxs].sum(axis=0)
     elif artifact.scorer.get("type") == "deepsets":
         query = _deepsets_query(artifact, idxs)
+    elif artifact.scorer.get("type") == "transformed_additive":
+        query = _transformed_additive_query(artifact, idxs)
     else:
         raise ValueError(
             f"Unsupported S2S scorer type: {artifact.scorer.get('type')!r}"

--- a/ml/glideator_ml/s2s/artifact.py
+++ b/ml/glideator_ml/s2s/artifact.py
@@ -36,6 +36,17 @@ class S2SArtifact:
         if self.scorer is None:
             return
         scorer_type = self.scorer.get("type")
+        if scorer_type == "asymmetric":
+            source_matrix = np.asarray(self.scorer["source_matrix"])
+            if source_matrix.shape != self.matrix.shape:
+                raise ValueError(
+                    "Asymmetric source matrix must match target embedding shape"
+                )
+            if not np.isfinite(source_matrix).all():
+                raise ValueError(
+                    "Asymmetric source matrix contains non-finite values"
+                )
+            return
         if scorer_type != "deepsets":
             raise ValueError(f"Unsupported S2S scorer type: {scorer_type!r}")
 
@@ -159,6 +170,8 @@ def recommend(
 
     if artifact.scorer is None:
         query = artifact.matrix[idxs].sum(axis=0)
+    elif artifact.scorer.get("type") == "asymmetric":
+        query = np.asarray(artifact.scorer["source_matrix"])[idxs].sum(axis=0)
     elif artifact.scorer.get("type") == "deepsets":
         query = _deepsets_query(artifact, idxs)
     else:

--- a/ml/glideator_ml/s2s/artifact.py
+++ b/ml/glideator_ml/s2s/artifact.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+@dataclass
+class S2SArtifact:
+    site_to_idx: dict[int, int]
+    idx_to_site: list[int]
+    matrix: np.ndarray
+    metadata: dict[str, Any]
+
+    def validate(self) -> None:
+        if self.matrix.ndim != 2:
+            raise ValueError("S2S embedding matrix must be two-dimensional")
+        if self.matrix.shape[0] != len(self.idx_to_site):
+            raise ValueError("Embedding row count does not match idx_to_site")
+        if set(self.site_to_idx) != set(self.idx_to_site):
+            raise ValueError("site_to_idx and idx_to_site describe different catalogs")
+        for index, site_id in enumerate(self.idx_to_site):
+            if self.site_to_idx[site_id] != index:
+                raise ValueError("S2S site index mappings are inconsistent")
+        if not np.isfinite(self.matrix).all():
+            raise ValueError("S2S embedding matrix contains non-finite values")
+
+    def to_payload(self) -> dict[str, Any]:
+        self.validate()
+        # The first three keys intentionally preserve the current backend contract.
+        return {
+            "site_to_idx": self.site_to_idx,
+            "idx_to_site": self.idx_to_site,
+            "matrix": self.matrix,
+            "metadata": self.metadata,
+        }
+
+    def save(self, path: str | Path) -> Path:
+        destination = Path(path)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("wb") as handle:
+            pickle.dump(self.to_payload(), handle, protocol=pickle.HIGHEST_PROTOCOL)
+        return destination
+
+    @classmethod
+    def load(cls, path: str | Path) -> "S2SArtifact":
+        with Path(path).open("rb") as handle:
+            payload = pickle.load(handle)
+        artifact = cls(
+            site_to_idx={int(k): int(v) for k, v in payload["site_to_idx"].items()},
+            idx_to_site=[int(site_id) for site_id in payload["idx_to_site"]],
+            matrix=np.asarray(payload["matrix"], dtype=np.float32),
+            metadata=dict(payload.get("metadata", {})),
+        )
+        artifact.validate()
+        return artifact
+
+
+def recommend(
+    artifact: S2SArtifact,
+    source_ids: tuple[int, ...] | list[int],
+    *,
+    top_k: int,
+) -> list[tuple[int, float]]:
+    idxs = [
+        artifact.site_to_idx[site_id]
+        for site_id in source_ids
+        if site_id in artifact.site_to_idx
+    ]
+    if not idxs or top_k <= 0:
+        return []
+
+    query = artifact.matrix[idxs].sum(axis=0)
+    norm = np.linalg.norm(query)
+    if norm == 0.0:
+        return []
+    query = query / norm
+
+    scores = artifact.matrix @ query
+    scores = scores.copy()
+    scores[idxs] = -np.inf
+    candidate_count = scores.size - len(set(idxs))
+    if candidate_count <= 0:
+        return []
+
+    k = min(top_k, candidate_count)
+    top = np.argpartition(-scores, k - 1)[:k]
+    top = top[np.argsort(-scores[top], kind="mergesort")]
+    return [
+        (int(artifact.idx_to_site[index]), float(scores[index]))
+        for index in top
+        if np.isfinite(scores[index])
+    ]

--- a/ml/glideator_ml/s2s/artifact.py
+++ b/ml/glideator_ml/s2s/artifact.py
@@ -14,6 +14,7 @@ class S2SArtifact:
     idx_to_site: list[int]
     matrix: np.ndarray
     metadata: dict[str, Any]
+    scorer: dict[str, Any] | None = None
 
     def validate(self) -> None:
         if self.matrix.ndim != 2:
@@ -28,15 +29,73 @@ class S2SArtifact:
         if not np.isfinite(self.matrix).all():
             raise ValueError("S2S embedding matrix contains non-finite values")
 
+        if self.scorer is not None:
+            self._validate_scorer()
+
+    def _validate_scorer(self) -> None:
+        if self.scorer is None:
+            return
+        scorer_type = self.scorer.get("type")
+        if scorer_type != "deepsets":
+            raise ValueError(f"Unsupported S2S scorer type: {scorer_type!r}")
+
+        pooling = self.scorer.get("pooling")
+        if pooling not in {"mean", "sum"}:
+            raise ValueError("DeepSets scorer pooling must be 'mean' or 'sum'")
+
+        dimension = self.matrix.shape[1]
+        phi_w1 = np.asarray(self.scorer["phi_w1"])
+        phi_b1 = np.asarray(self.scorer["phi_b1"])
+        phi_w2 = np.asarray(self.scorer["phi_w2"])
+        phi_b2 = np.asarray(self.scorer["phi_b2"])
+        rho_w1 = np.asarray(self.scorer["rho_w1"])
+        rho_b1 = np.asarray(self.scorer["rho_b1"])
+        rho_w2 = np.asarray(self.scorer["rho_w2"])
+        rho_b2 = np.asarray(self.scorer["rho_b2"])
+
+        phi_hidden = phi_w1.shape[0]
+        rho_hidden = rho_w1.shape[0]
+        expected_shapes = {
+            "phi_w1": (phi_hidden, dimension),
+            "phi_b1": (phi_hidden,),
+            "phi_w2": (dimension, phi_hidden),
+            "phi_b2": (dimension,),
+            "rho_w1": (rho_hidden, dimension),
+            "rho_b1": (rho_hidden,),
+            "rho_w2": (dimension, rho_hidden),
+            "rho_b2": (dimension,),
+        }
+        arrays = {
+            "phi_w1": phi_w1,
+            "phi_b1": phi_b1,
+            "phi_w2": phi_w2,
+            "phi_b2": phi_b2,
+            "rho_w1": rho_w1,
+            "rho_b1": rho_b1,
+            "rho_w2": rho_w2,
+            "rho_b2": rho_b2,
+        }
+        for name, array in arrays.items():
+            if array.shape != expected_shapes[name]:
+                raise ValueError(
+                    f"DeepSets scorer {name} has shape {array.shape}, "
+                    f"expected {expected_shapes[name]}"
+                )
+            if not np.isfinite(array).all():
+                raise ValueError(f"DeepSets scorer {name} contains non-finite values")
+
     def to_payload(self) -> dict[str, Any]:
         self.validate()
         # The first three keys intentionally preserve the current backend contract.
-        return {
+        payload = {
             "site_to_idx": self.site_to_idx,
             "idx_to_site": self.idx_to_site,
             "matrix": self.matrix,
             "metadata": self.metadata,
         }
+        if self.scorer is not None:
+            payload["scorer"] = self.scorer
+        return payload
 
     def save(self, path: str | Path) -> Path:
         destination = Path(path)
@@ -49,14 +108,39 @@ class S2SArtifact:
     def load(cls, path: str | Path) -> "S2SArtifact":
         with Path(path).open("rb") as handle:
             payload = pickle.load(handle)
+        raw_scorer = payload.get("scorer")
         artifact = cls(
             site_to_idx={int(k): int(v) for k, v in payload["site_to_idx"].items()},
             idx_to_site=[int(site_id) for site_id in payload["idx_to_site"]],
             matrix=np.asarray(payload["matrix"], dtype=np.float32),
             metadata=dict(payload.get("metadata", {})),
+            scorer=dict(raw_scorer) if raw_scorer is not None else None,
         )
         artifact.validate()
         return artifact
+
+
+def _deepsets_query(artifact: S2SArtifact, idxs: list[int]) -> np.ndarray:
+    scorer = artifact.scorer
+    if scorer is None:
+        raise ValueError("DeepSets query requested without scorer state")
+
+    items = artifact.matrix[idxs]
+    phi = np.maximum(
+        items @ np.asarray(scorer["phi_w1"]).T + np.asarray(scorer["phi_b1"]),
+        0.0,
+    )
+    phi = phi @ np.asarray(scorer["phi_w2"]).T + np.asarray(scorer["phi_b2"])
+    if scorer["pooling"] == "mean":
+        pooled = phi.mean(axis=0)
+    else:
+        pooled = phi.sum(axis=0)
+
+    hidden = np.maximum(
+        pooled @ np.asarray(scorer["rho_w1"]).T + np.asarray(scorer["rho_b1"]),
+        0.0,
+    )
+    return hidden @ np.asarray(scorer["rho_w2"]).T + np.asarray(scorer["rho_b2"])
 
 
 def recommend(
@@ -73,7 +157,15 @@ def recommend(
     if not idxs or top_k <= 0:
         return []
 
-    query = artifact.matrix[idxs].sum(axis=0)
+    if artifact.scorer is None:
+        query = artifact.matrix[idxs].sum(axis=0)
+    elif artifact.scorer.get("type") == "deepsets":
+        query = _deepsets_query(artifact, idxs)
+    else:
+        raise ValueError(
+            f"Unsupported S2S scorer type: {artifact.scorer.get('type')!r}"
+        )
+
     norm = np.linalg.norm(query)
     if norm == 0.0:
         return []

--- a/ml/glideator_ml/s2s/asymmetric.py
+++ b/ml/glideator_ml/s2s/asymmetric.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .artifact import S2SArtifact
+
+logger = logging.getLogger(__name__)
+
+
+def fit_asymmetric(
+    train_visits: pd.DataFrame,
+    *,
+    n_factors: int,
+    epochs: int,
+    learning_rate: float,
+    weight_decay: float,
+    temperature: float,
+    batch_size: int,
+    negative_samples: int,
+    negative_sampling_power: float,
+    add_inbatch_negatives: bool,
+    seed: int,
+    device: str = "auto",
+    metadata: dict[str, Any] | None = None,
+) -> S2SArtifact:
+    """Fit additive S2S with separate source and target embedding tables."""
+    try:
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, Dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "Asymmetric S2S training requires the 'contrastive' extra"
+        ) from exc
+
+    if train_visits.empty:
+        raise ValueError("Cannot fit asymmetric S2S on an empty training set")
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    sites = sorted(int(site) for site in train_visits["site_id"].unique())
+    site_to_idx = {site_id: index for index, site_id in enumerate(sites)}
+    ordered = train_visits.sort_values(
+        ["pilot", "visit_at", "site_id"], kind="mergesort"
+    )
+    episodes: list[tuple[np.ndarray, int]] = []
+    for _, group in ordered.groupby("pilot", sort=True):
+        indices = [site_to_idx[int(site)] for site in group["site_id"]]
+        episodes.extend(
+            (np.asarray(indices[:position], dtype=np.int64), indices[position])
+            for position in range(1, len(indices))
+        )
+    if not episodes:
+        raise ValueError("Asymmetric S2S needs at least one training episode")
+
+    popularity = np.zeros(len(sites), dtype=np.float64)
+    for site_id, count in train_visits["site_id"].value_counts().items():
+        popularity[site_to_idx[int(site_id)]] = float(count)
+
+    class EpisodeDataset(Dataset):
+        def __len__(self):
+            return len(episodes)
+
+        def __getitem__(self, index):
+            return episodes[index]
+
+    def collate(batch):
+        histories, targets = zip(*batch)
+        offsets = np.cumsum([0, *[len(history) for history in histories]])
+        return (
+            torch.as_tensor(np.concatenate(histories), dtype=torch.long),
+            torch.as_tensor(offsets, dtype=torch.long),
+            torch.as_tensor(targets, dtype=torch.long),
+        )
+
+    class AsymmetricDiscoveryModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.source_embeddings = nn.EmbeddingBag(
+                len(sites),
+                int(n_factors),
+                mode="sum",
+                include_last_offset=True,
+            )
+            self.target_embeddings = nn.Embedding(len(sites), int(n_factors))
+            nn.init.normal_(self.source_embeddings.weight, std=0.02)
+            nn.init.normal_(self.target_embeddings.weight, std=0.02)
+
+        def forward(self, flat, offsets, targets, negatives):
+            query = nn.functional.normalize(
+                self.source_embeddings(flat, offsets), dim=1
+            )
+            positive = nn.functional.normalize(
+                self.target_embeddings(targets), dim=1
+            )
+            negative = nn.functional.normalize(
+                self.target_embeddings(negatives), dim=2
+            )
+            positive_logits = (query * positive).sum(dim=1, keepdim=True)
+            negative_logits = torch.einsum("bd,bkd->bk", query, negative)
+            if add_inbatch_negatives:
+                inbatch = query @ positive.T
+                inbatch = inbatch - torch.eye(
+                    inbatch.size(0), device=inbatch.device
+                ) * 1e9
+                negative_logits = torch.cat([negative_logits, inbatch], dim=1)
+            logits = torch.cat([positive_logits, negative_logits], dim=1)
+            labels = torch.zeros(
+                logits.size(0), dtype=torch.long, device=logits.device
+            )
+            return nn.functional.cross_entropy(logits / temperature, labels)
+
+    resolved_device = (
+        "cuda" if device == "auto" and torch.cuda.is_available() else device
+    )
+    if resolved_device == "auto":
+        resolved_device = "cpu"
+
+    model = AsymmetricDiscoveryModel().to(resolved_device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(learning_rate),
+        weight_decay=float(weight_decay),
+    )
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        EpisodeDataset(),
+        batch_size=int(batch_size),
+        shuffle=True,
+        collate_fn=collate,
+        generator=generator,
+        num_workers=0,
+    )
+    sampling_weights = torch.as_tensor(
+        np.power(popularity + 1e-8, float(negative_sampling_power)),
+        dtype=torch.float32,
+        device=resolved_device,
+    )
+    sampling_generator = torch.Generator(device=resolved_device).manual_seed(seed)
+
+    final_loss = 0.0
+    for epoch in range(1, int(epochs) + 1):
+        model.train()
+        total_loss = 0.0
+        examples = 0
+        for flat, offsets, targets in loader:
+            flat = flat.to(resolved_device)
+            offsets = offsets.to(resolved_device)
+            targets = targets.to(resolved_device)
+
+            weights = sampling_weights.expand(len(targets), -1).clone()
+            row_indices = torch.repeat_interleave(
+                torch.arange(len(targets), device=resolved_device),
+                offsets[1:] - offsets[:-1],
+            )
+            weights[row_indices, flat] = 0
+            weights[torch.arange(len(targets), device=resolved_device), targets] = 0
+            negatives = torch.multinomial(
+                weights,
+                num_samples=int(negative_samples),
+                replacement=False,
+                generator=sampling_generator,
+            )
+
+            optimizer.zero_grad(set_to_none=True)
+            loss = model(flat, offsets, targets, negatives)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+
+            total_loss += float(loss.detach()) * len(targets)
+            examples += len(targets)
+
+        final_loss = total_loss / examples
+        logger.info(
+            "Asymmetric S2S epoch %d/%d loss=%.4f",
+            epoch,
+            epochs,
+            final_loss,
+        )
+
+    model.eval()
+    with torch.no_grad():
+        source_embeddings = nn.functional.normalize(
+            model.source_embeddings.weight, dim=1
+        ).cpu().numpy().astype(np.float32)
+        target_embeddings = nn.functional.normalize(
+            model.target_embeddings.weight, dim=1
+        ).cpu().numpy().astype(np.float32)
+
+    artifact = S2SArtifact(
+        site_to_idx=site_to_idx,
+        idx_to_site=sites,
+        matrix=target_embeddings,
+        scorer={
+            "type": "asymmetric",
+            "source_matrix": source_embeddings,
+        },
+        metadata={
+            "model_type": "asymmetric",
+            "n_factors": int(n_factors),
+            "epochs": int(epochs),
+            "learning_rate": float(learning_rate),
+            "weight_decay": float(weight_decay),
+            "temperature": float(temperature),
+            "batch_size": int(batch_size),
+            "negative_samples": int(negative_samples),
+            "negative_sampling_power": float(negative_sampling_power),
+            "add_inbatch_negatives": bool(add_inbatch_negatives),
+            "seed": int(seed),
+            "device": resolved_device,
+            "train_pilots": int(train_visits["pilot"].nunique()),
+            "train_episodes": len(episodes),
+            "catalog_size": len(sites),
+            "final_loss": final_loss,
+            "requires_learned_scorer": True,
+            **(metadata or {}),
+        },
+    )
+    artifact.validate()
+    return artifact

--- a/ml/glideator_ml/s2s/candidate_attention.py
+++ b/ml/glideator_ml/s2s/candidate_attention.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .artifact import S2SArtifact
+
+logger = logging.getLogger(__name__)
+
+
+def fit_candidate_attention(
+    train_visits: pd.DataFrame,
+    *,
+    n_factors: int,
+    epochs: int,
+    learning_rate: float,
+    weight_decay: float,
+    temperature: float,
+    batch_size: int,
+    negative_samples: int,
+    negative_sampling_power: float,
+    add_inbatch_negatives: bool,
+    attention_scale_init: float,
+    seed: int,
+    device: str = "auto",
+    metadata: dict[str, Any] | None = None,
+) -> S2SArtifact:
+    """Fit residual candidate-conditioned attention for next-site discovery."""
+    try:
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, Dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "Candidate-attention S2S training requires the 'contrastive' extra"
+        ) from exc
+
+    if train_visits.empty:
+        raise ValueError("Cannot fit candidate-attention S2S on an empty training set")
+    if n_factors <= 0:
+        raise ValueError("n_factors must be positive")
+    if negative_samples <= 0:
+        raise ValueError("negative_samples must be positive")
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    sites = sorted(int(site) for site in train_visits["site_id"].unique())
+    site_to_idx = {site_id: index for index, site_id in enumerate(sites)}
+    ordered = train_visits.sort_values(
+        ["pilot", "visit_at", "site_id"], kind="mergesort"
+    )
+    episodes: list[tuple[np.ndarray, int]] = []
+    for _, group in ordered.groupby("pilot", sort=True):
+        indices = [site_to_idx[int(site)] for site in group["site_id"]]
+        episodes.extend(
+            (np.asarray(indices[:position], dtype=np.int64), indices[position])
+            for position in range(1, len(indices))
+        )
+    if not episodes:
+        raise ValueError("Candidate-attention S2S needs at least one training episode")
+
+    popularity = np.zeros(len(sites), dtype=np.float64)
+    for site_id, count in train_visits["site_id"].value_counts().items():
+        popularity[site_to_idx[int(site_id)]] = float(count)
+
+    class EpisodeDataset(Dataset):
+        def __len__(self):
+            return len(episodes)
+
+        def __getitem__(self, index):
+            return episodes[index]
+
+    def collate(batch):
+        histories, targets = zip(*batch)
+        max_history = max(len(history) for history in histories)
+        padded = np.zeros((len(histories), max_history), dtype=np.int64)
+        mask = np.zeros((len(histories), max_history), dtype=np.bool_)
+        for row, history in enumerate(histories):
+            padded[row, : len(history)] = history
+            mask[row, : len(history)] = True
+        return (
+            torch.as_tensor(padded, dtype=torch.long),
+            torch.as_tensor(mask, dtype=torch.bool),
+            torch.as_tensor(targets, dtype=torch.long),
+        )
+
+    class CandidateAttentionModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            dimension = int(n_factors)
+            self.item_embeddings = nn.Embedding(len(sites), dimension)
+            self.query_projection = nn.Linear(dimension, dimension, bias=False)
+            self.key_projection = nn.Linear(dimension, dimension, bias=False)
+            self.value_projection = nn.Linear(dimension, dimension, bias=False)
+            self.attention_scale = nn.Parameter(
+                torch.tensor(float(attention_scale_init), dtype=torch.float32)
+            )
+
+            nn.init.normal_(self.item_embeddings.weight, std=0.02)
+            nn.init.eye_(self.query_projection.weight)
+            nn.init.eye_(self.key_projection.weight)
+            nn.init.eye_(self.value_projection.weight)
+
+        def score_candidates(self, histories, history_mask, candidate_ids):
+            # Raw summed embeddings preserve the strong contrastive baseline.
+            raw_history = self.item_embeddings(histories)
+            mask_float = history_mask.unsqueeze(-1).to(raw_history.dtype)
+            base = (raw_history * mask_float).sum(dim=1)
+            base = nn.functional.normalize(base, dim=1)
+
+            normalized_history = nn.functional.normalize(raw_history, dim=2)
+            candidates = nn.functional.normalize(
+                self.item_embeddings(candidate_ids),
+                dim=2,
+            )
+
+            # Embeddings are unit length; scale Q/K inputs by sqrt(d) so the
+            # standard scaled-dot-product logits have Transformer-like magnitude.
+            root_d = math.sqrt(float(n_factors))
+            queries = self.query_projection(candidates * root_d)
+            keys = self.key_projection(normalized_history * root_d)
+            values = self.value_projection(normalized_history)
+
+            attention_logits = torch.einsum(
+                "bcd,bld->bcl", queries, keys
+            ) / root_d
+            attention_logits = attention_logits.masked_fill(
+                ~history_mask.unsqueeze(1),
+                torch.finfo(attention_logits.dtype).min,
+            )
+            attention = torch.softmax(attention_logits, dim=2)
+            context = torch.einsum("bcl,bld->bcd", attention, values)
+
+            candidate_queries = nn.functional.normalize(
+                base.unsqueeze(1) + self.attention_scale * context,
+                dim=2,
+            )
+            return (candidate_queries * candidates).sum(dim=2)
+
+        def forward(self, histories, history_mask, targets, negatives):
+            candidate_ids = torch.cat([targets.unsqueeze(1), negatives], dim=1)
+            logits = self.score_candidates(histories, history_mask, candidate_ids)
+
+            if add_inbatch_negatives:
+                inbatch_ids = targets.unsqueeze(0).expand(len(targets), -1)
+                inbatch_logits = self.score_candidates(
+                    histories,
+                    history_mask,
+                    inbatch_ids,
+                )
+                inbatch_logits = inbatch_logits - torch.eye(
+                    len(targets),
+                    device=inbatch_logits.device,
+                ) * 1e9
+                logits = torch.cat([logits, inbatch_logits], dim=1)
+
+            labels = torch.zeros(
+                logits.size(0),
+                dtype=torch.long,
+                device=logits.device,
+            )
+            return nn.functional.cross_entropy(logits / temperature, labels)
+
+    resolved_device = (
+        "cuda" if device == "auto" and torch.cuda.is_available() else device
+    )
+    if resolved_device == "auto":
+        resolved_device = "cpu"
+
+    model = CandidateAttentionModel().to(resolved_device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(learning_rate),
+        weight_decay=float(weight_decay),
+    )
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        EpisodeDataset(),
+        batch_size=int(batch_size),
+        shuffle=True,
+        collate_fn=collate,
+        generator=generator,
+        num_workers=0,
+    )
+    sampling_weights = torch.as_tensor(
+        np.power(popularity + 1e-8, float(negative_sampling_power)),
+        dtype=torch.float32,
+        device=resolved_device,
+    )
+    sampling_generator = torch.Generator(device=resolved_device).manual_seed(seed)
+
+    final_loss = 0.0
+    for epoch in range(1, int(epochs) + 1):
+        model.train()
+        total_loss = 0.0
+        examples = 0
+        for histories, history_mask, targets in loader:
+            histories = histories.to(resolved_device)
+            history_mask = history_mask.to(resolved_device)
+            targets = targets.to(resolved_device)
+
+            weights = sampling_weights.expand(len(targets), -1).clone()
+            batch_rows = torch.arange(len(targets), device=resolved_device)
+            expanded_rows = batch_rows.unsqueeze(1).expand_as(histories)
+            weights[
+                expanded_rows[history_mask],
+                histories[history_mask],
+            ] = 0
+            weights[batch_rows, targets] = 0
+
+            available = (weights > 0).sum(dim=1)
+            if torch.any(available < int(negative_samples)):
+                raise ValueError(
+                    "negative_samples exceeds the available unseen catalog "
+                    "for at least one candidate-attention training episode"
+                )
+            negatives = torch.multinomial(
+                weights,
+                num_samples=int(negative_samples),
+                replacement=False,
+                generator=sampling_generator,
+            )
+
+            optimizer.zero_grad(set_to_none=True)
+            loss = model(histories, history_mask, targets, negatives)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+
+            total_loss += float(loss.detach()) * len(targets)
+            examples += len(targets)
+
+        final_loss = total_loss / examples
+        logger.info(
+            "Candidate-attention S2S epoch %d/%d loss=%.4f scale=%.4f",
+            epoch,
+            epochs,
+            final_loss,
+            float(model.attention_scale.detach()),
+        )
+
+    model.eval()
+    with torch.no_grad():
+        raw_embeddings = (
+            model.item_embeddings.weight.detach().cpu().numpy().astype(np.float32)
+        )
+        embeddings = nn.functional.normalize(
+            model.item_embeddings.weight,
+            dim=1,
+        ).cpu().numpy().astype(np.float32)
+        scorer = {
+            "type": "candidate_attention",
+            "history_matrix": raw_embeddings,
+            "query_weight": (
+                model.query_projection.weight.detach().cpu().numpy().astype(np.float32)
+            ),
+            "key_weight": (
+                model.key_projection.weight.detach().cpu().numpy().astype(np.float32)
+            ),
+            "value_weight": (
+                model.value_projection.weight.detach().cpu().numpy().astype(np.float32)
+            ),
+            "attention_scale": float(model.attention_scale.detach().cpu()),
+        }
+
+    artifact = S2SArtifact(
+        site_to_idx=site_to_idx,
+        idx_to_site=sites,
+        matrix=embeddings,
+        scorer=scorer,
+        metadata={
+            "model_type": "candidate_attention",
+            "n_factors": int(n_factors),
+            "attention_heads": 1,
+            "attention_scale_init": float(attention_scale_init),
+            "attention_scale_final": float(scorer["attention_scale"]),
+            "residual_base": "normalized_raw_embedding_sum",
+            "epochs": int(epochs),
+            "learning_rate": float(learning_rate),
+            "weight_decay": float(weight_decay),
+            "temperature": float(temperature),
+            "batch_size": int(batch_size),
+            "negative_samples": int(negative_samples),
+            "negative_sampling_power": float(negative_sampling_power),
+            "add_inbatch_negatives": bool(add_inbatch_negatives),
+            "seed": int(seed),
+            "device": resolved_device,
+            "train_pilots": int(train_visits["pilot"].nunique()),
+            "train_episodes": len(episodes),
+            "catalog_size": len(sites),
+            "final_loss": final_loss,
+            "requires_learned_scorer": True,
+            **(metadata or {}),
+        },
+    )
+    artifact.validate()
+    return artifact

--- a/ml/glideator_ml/s2s/data.py
+++ b/ml/glideator_ml/s2s/data.py
@@ -122,6 +122,38 @@ def split_pilots(
     )
 
 
+def _as_cutoff(value: str) -> pd.Timestamp:
+    cutoff = pd.Timestamp(value)
+    if pd.isna(cutoff):
+        raise ValueError(f"Invalid temporal cutoff: {value!r}")
+    if cutoff.tzinfo is not None:
+        cutoff = cutoff.tz_localize(None)
+    return cutoff
+
+
+def split_temporal(
+    visits: pd.DataFrame,
+    *,
+    cutoff: str,
+) -> S2SSplit:
+    """Split by information availability at a fixed point in time.
+
+    Training contains only first visits known before the cutoff. eval_visits is
+    the post-cutoff portion and is used for reporting; temporal walk-forward
+    events are built from the full visit history so legitimate pre-cutoff source
+    history is retained.
+    """
+    cutoff_at = _as_cutoff(cutoff)
+    mask = visits["visit_at"] < cutoff_at
+    train_visits = visits.loc[mask].reset_index(drop=True)
+    eval_visits = visits.loc[~mask].reset_index(drop=True)
+    if train_visits.empty:
+        raise ValueError("Temporal S2S split produced an empty training set")
+    if eval_visits.empty:
+        raise ValueError("Temporal S2S split produced an empty evaluation set")
+    return S2SSplit(train_visits=train_visits, eval_visits=eval_visits)
+
+
 def walk_forward_events(
     eval_visits: pd.DataFrame,
     *,
@@ -132,6 +164,32 @@ def walk_forward_events(
     for pilot, group in ordered.groupby("pilot", sort=True):
         sites = group["site_id"].astype(int).tolist()
         for index in range(min_history, len(sites)):
+            events.append((str(pilot), tuple(sites[:index]), sites[index]))
+    return events
+
+
+def temporal_walk_forward_events(
+    visits: pd.DataFrame,
+    *,
+    cutoff: str,
+    min_history: int = 1,
+) -> list[tuple[str, tuple[int, ...], int]]:
+    """Build post-cutoff targets with only history available before each target.
+
+    Unlike applying walk_forward_events to the post-cutoff rows alone, this
+    preserves sites a pilot had already discovered before the cutoff. Later
+    post-cutoff first visits become valid history for subsequent targets, which
+    matches production recommendation semantics at each point in time.
+    """
+    cutoff_at = _as_cutoff(cutoff)
+    events: list[tuple[str, tuple[int, ...], int]] = []
+    ordered = visits.sort_values(["pilot", "visit_at", "site_id"], kind="mergesort")
+    for pilot, group in ordered.groupby("pilot", sort=True):
+        sites = group["site_id"].astype(int).tolist()
+        visit_times = group["visit_at"].tolist()
+        for index in range(min_history, len(sites)):
+            if pd.Timestamp(visit_times[index]) < cutoff_at:
+                continue
             events.append((str(pilot), tuple(sites[:index]), sites[index]))
     return events
 

--- a/ml/glideator_ml/s2s/data.py
+++ b/ml/glideator_ml/s2s/data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
 from dataclasses import dataclass
@@ -133,6 +134,20 @@ def walk_forward_events(
         for index in range(min_history, len(sites)):
             events.append((str(pilot), tuple(sites[:index]), sites[index]))
     return events
+
+
+def events_fingerprint(
+    events: list[tuple[str, tuple[int, ...], int]],
+) -> str:
+    """Fingerprint the exact ordered benchmark examples used for evaluation."""
+    hasher = hashlib.sha256()
+    for pilot, source_ids, target_id in events:
+        payload = [pilot, list(source_ids), int(target_id)]
+        hasher.update(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        )
+        hasher.update(b"\n")
+    return f"sha256:{hasher.hexdigest()}"
 
 
 def dataset_fingerprint(visits: pd.DataFrame) -> str:

--- a/ml/glideator_ml/s2s/data.py
+++ b/ml/glideator_ml/s2s/data.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+
+import pandas as pd
+from sqlalchemy import create_engine, text
+
+
+@dataclass(frozen=True)
+class S2SSplit:
+    train_visits: pd.DataFrame
+    eval_visits: pd.DataFrame
+
+
+def _database_url(config: dict) -> str:
+    env_name = config.get("database_url_env", "ML_DATABASE_URL")
+    value = os.getenv(env_name)
+    if not value:
+        raise RuntimeError(
+            f"Database source selected but environment variable {env_name!r} is not set"
+        )
+    return value
+
+
+def load_visits(config: dict) -> pd.DataFrame:
+    source = config.get("source", "database")
+    if source == "csv":
+        path = config.get("path")
+        if not path:
+            raise ValueError("data.path is required when data.source=csv")
+        raw = pd.read_csv(path)
+    elif source == "database":
+        engine = create_engine(_database_url(config))
+        query = text(
+            """
+            select
+                f.pilot,
+                s.site_id,
+                f.date,
+                f.start_time
+            from mart.fact_flights f
+            join mart.dim_sites s
+              on f.site = s.xc_name
+            where f.pilot is not null
+              and s.site_id is not null
+            """
+        )
+        with engine.connect() as connection:
+            raw = pd.read_sql(query, connection)
+    else:
+        raise ValueError(f"Unsupported S2S data source: {source!r}")
+
+    return first_visits(raw)
+
+
+def first_visits(raw: pd.DataFrame) -> pd.DataFrame:
+    required = {"pilot", "site_id", "date"}
+    missing = required - set(raw.columns)
+    if missing:
+        raise ValueError(f"Missing S2S input columns: {', '.join(sorted(missing))}")
+
+    frame = raw.copy()
+    frame = frame.dropna(subset=["pilot", "site_id", "date"])
+    frame["pilot"] = frame["pilot"].astype(str)
+    frame["site_id"] = frame["site_id"].astype(int)
+
+    date_text = frame["date"].astype(str)
+    if "start_time" in frame:
+        timestamp = pd.to_datetime(
+            date_text + " " + frame["start_time"].fillna("").astype(str),
+            errors="coerce",
+        )
+    else:
+        timestamp = pd.to_datetime(date_text, errors="coerce")
+    fallback = pd.to_datetime(frame["date"], errors="coerce")
+    frame["visit_at"] = timestamp.fillna(fallback)
+    frame = frame.dropna(subset=["visit_at"])
+
+    frame = frame.sort_values(
+        ["pilot", "visit_at", "site_id"], kind="mergesort"
+    ).drop_duplicates(["pilot", "site_id"], keep="first")
+
+    return frame[["pilot", "site_id", "visit_at"]].reset_index(drop=True)
+
+
+def _bucket(pilot: str, seed: int) -> float:
+    digest = hashlib.sha256(f"{seed}:{pilot}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") / 2**64
+
+
+def split_pilots(
+    visits: pd.DataFrame,
+    *,
+    eval_fraction: float,
+    seed: int,
+) -> S2SSplit:
+    if not 0.0 < eval_fraction < 1.0:
+        raise ValueError("eval_fraction must be between 0 and 1")
+
+    pilots = sorted(visits["pilot"].unique())
+    eval_pilots = {
+        pilot for pilot in pilots if _bucket(str(pilot), seed) < eval_fraction
+    }
+
+    # Extremely small synthetic datasets can hash entirely to one side.
+    if pilots and not eval_pilots:
+        eval_pilots.add(pilots[-1])
+    if len(eval_pilots) == len(pilots) and len(pilots) > 1:
+        eval_pilots.remove(pilots[0])
+
+    mask = visits["pilot"].isin(eval_pilots)
+    return S2SSplit(
+        train_visits=visits.loc[~mask].reset_index(drop=True),
+        eval_visits=visits.loc[mask].reset_index(drop=True),
+    )
+
+
+def walk_forward_events(
+    eval_visits: pd.DataFrame,
+    *,
+    min_history: int = 1,
+) -> list[tuple[str, tuple[int, ...], int]]:
+    events: list[tuple[str, tuple[int, ...], int]] = []
+    ordered = eval_visits.sort_values(["pilot", "visit_at", "site_id"], kind="mergesort")
+    for pilot, group in ordered.groupby("pilot", sort=True):
+        sites = group["site_id"].astype(int).tolist()
+        for index in range(min_history, len(sites)):
+            events.append((str(pilot), tuple(sites[:index]), sites[index]))
+    return events
+
+
+def dataset_fingerprint(visits: pd.DataFrame) -> str:
+    canonical = visits.sort_values(
+        ["pilot", "visit_at", "site_id"], kind="mergesort"
+    ).reset_index(drop=True)
+    hashed = pd.util.hash_pandas_object(canonical, index=False).values
+    digest = hashlib.sha256(hashed.tobytes()).hexdigest()
+    return f"sha256:{digest}"

--- a/ml/glideator_ml/s2s/data.py
+++ b/ml/glideator_ml/s2s/data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 from dataclasses import dataclass
 
 import pandas as pd
@@ -33,15 +34,18 @@ def load_visits(config: dict) -> pd.DataFrame:
         raw = pd.read_csv(path)
     elif source == "database":
         engine = create_engine(_database_url(config))
+        schema = str(config.get("schema", "mart"))
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", schema):
+            raise ValueError(f"Invalid database schema: {schema!r}")
         query = text(
-            """
+            f"""
             select
                 f.pilot,
                 s.site_id,
                 f.date,
                 f.start_time
-            from mart.fact_flights f
-            join mart.dim_sites s
+            from {schema}.fact_flights f
+            join {schema}.dim_sites s
               on f.site = s.xc_name
             where f.pilot is not null
               and s.site_id is not null

--- a/ml/glideator_ml/s2s/deepsets.py
+++ b/ml/glideator_ml/s2s/deepsets.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .artifact import S2SArtifact
+
+logger = logging.getLogger(__name__)
+
+
+def fit_deepsets(
+    train_visits: pd.DataFrame,
+    *,
+    n_factors: int,
+    phi_hidden_dim: int,
+    rho_hidden_dim: int,
+    pooling: str,
+    epochs: int,
+    learning_rate: float,
+    weight_decay: float,
+    temperature: float,
+    batch_size: int,
+    negative_samples: int,
+    negative_sampling_power: float,
+    add_inbatch_negatives: bool,
+    seed: int,
+    device: str = "auto",
+    metadata: dict[str, Any] | None = None,
+) -> S2SArtifact:
+    """Fit a DeepSets history encoder for next-new-site discovery."""
+    try:
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, Dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "DeepSets S2S training requires the 'contrastive' extra"
+        ) from exc
+
+    if train_visits.empty:
+        raise ValueError("Cannot fit DeepSets S2S on an empty training set")
+    if pooling not in {"mean", "sum"}:
+        raise ValueError("DeepSets pooling must be 'mean' or 'sum'")
+    if n_factors <= 0 or phi_hidden_dim <= 0 or rho_hidden_dim <= 0:
+        raise ValueError("DeepSets dimensions must be positive")
+    if negative_samples <= 0:
+        raise ValueError("negative_samples must be positive")
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    sites = sorted(int(site) for site in train_visits["site_id"].unique())
+    site_to_idx = {site_id: index for index, site_id in enumerate(sites)}
+    ordered = train_visits.sort_values(
+        ["pilot", "visit_at", "site_id"], kind="mergesort"
+    )
+    episodes: list[tuple[np.ndarray, int]] = []
+    for _, group in ordered.groupby("pilot", sort=True):
+        indices = [site_to_idx[int(site)] for site in group["site_id"]]
+        episodes.extend(
+            (np.asarray(indices[:position], dtype=np.int64), indices[position])
+            for position in range(1, len(indices))
+        )
+    if not episodes:
+        raise ValueError("DeepSets S2S needs at least one training episode")
+
+    popularity = np.zeros(len(sites), dtype=np.float64)
+    for site_id, count in train_visits["site_id"].value_counts().items():
+        popularity[site_to_idx[int(site_id)]] = float(count)
+
+    class EpisodeDataset(Dataset):
+        def __len__(self):
+            return len(episodes)
+
+        def __getitem__(self, index):
+            return episodes[index]
+
+    def collate(batch):
+        histories, targets = zip(*batch)
+        offsets = np.cumsum([0, *[len(history) for history in histories]])
+        return (
+            torch.as_tensor(np.concatenate(histories), dtype=torch.long),
+            torch.as_tensor(offsets, dtype=torch.long),
+            torch.as_tensor(targets, dtype=torch.long),
+        )
+
+    class DeepSetsDiscoveryModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.item_embeddings = nn.Embedding(len(sites), int(n_factors))
+            self.phi = nn.Sequential(
+                nn.Linear(int(n_factors), int(phi_hidden_dim)),
+                nn.ReLU(),
+                nn.Linear(int(phi_hidden_dim), int(n_factors)),
+            )
+            self.rho = nn.Sequential(
+                nn.Linear(int(n_factors), int(rho_hidden_dim)),
+                nn.ReLU(),
+                nn.Linear(int(rho_hidden_dim), int(n_factors)),
+            )
+            nn.init.normal_(self.item_embeddings.weight, std=0.02)
+
+        def encode_history(self, flat, offsets):
+            items = nn.functional.normalize(
+                self.item_embeddings(flat),
+                dim=1,
+            )
+            transformed = self.phi(items)
+            lengths = offsets[1:] - offsets[:-1]
+            batch_rows = torch.repeat_interleave(
+                torch.arange(len(lengths), device=flat.device),
+                lengths,
+            )
+            pooled = torch.zeros(
+                (len(lengths), int(n_factors)),
+                dtype=transformed.dtype,
+                device=transformed.device,
+            )
+            pooled.index_add_(0, batch_rows, transformed)
+            if pooling == "mean":
+                pooled = pooled / lengths.clamp_min(1).unsqueeze(1)
+            return nn.functional.normalize(self.rho(pooled), dim=1)
+
+        def forward(self, flat, offsets, targets, negatives):
+            query = self.encode_history(flat, offsets)
+            positive = nn.functional.normalize(
+                self.item_embeddings(targets),
+                dim=1,
+            )
+            negative = nn.functional.normalize(
+                self.item_embeddings(negatives),
+                dim=2,
+            )
+            positive_logits = (query * positive).sum(dim=1, keepdim=True)
+            negative_logits = torch.einsum("bd,bkd->bk", query, negative)
+            if add_inbatch_negatives:
+                inbatch = query @ positive.T
+                inbatch = inbatch - torch.eye(
+                    inbatch.size(0), device=inbatch.device
+                ) * 1e9
+                negative_logits = torch.cat([negative_logits, inbatch], dim=1)
+            logits = torch.cat([positive_logits, negative_logits], dim=1)
+            labels = torch.zeros(
+                logits.size(0),
+                dtype=torch.long,
+                device=logits.device,
+            )
+            return nn.functional.cross_entropy(logits / temperature, labels)
+
+    resolved_device = (
+        "cuda" if device == "auto" and torch.cuda.is_available() else device
+    )
+    if resolved_device == "auto":
+        resolved_device = "cpu"
+
+    model = DeepSetsDiscoveryModel().to(resolved_device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(learning_rate),
+        weight_decay=float(weight_decay),
+    )
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        EpisodeDataset(),
+        batch_size=int(batch_size),
+        shuffle=True,
+        collate_fn=collate,
+        generator=generator,
+        num_workers=0,
+    )
+    sampling_weights = torch.as_tensor(
+        np.power(popularity + 1e-8, float(negative_sampling_power)),
+        dtype=torch.float32,
+        device=resolved_device,
+    )
+    sampling_generator = torch.Generator(device=resolved_device).manual_seed(seed)
+
+    final_loss = 0.0
+    for epoch in range(1, int(epochs) + 1):
+        model.train()
+        total_loss = 0.0
+        examples = 0
+        for flat, offsets, targets in loader:
+            flat = flat.to(resolved_device)
+            offsets = offsets.to(resolved_device)
+            targets = targets.to(resolved_device)
+
+            weights = sampling_weights.expand(len(targets), -1).clone()
+            row_indices = torch.repeat_interleave(
+                torch.arange(len(targets), device=resolved_device),
+                offsets[1:] - offsets[:-1],
+            )
+            weights[row_indices, flat] = 0
+            weights[torch.arange(len(targets), device=resolved_device), targets] = 0
+            available = (weights > 0).sum(dim=1)
+            if torch.any(available < int(negative_samples)):
+                raise ValueError(
+                    "negative_samples exceeds the available unseen catalog "
+                    "for at least one DeepSets training episode"
+                )
+            negatives = torch.multinomial(
+                weights,
+                num_samples=int(negative_samples),
+                replacement=False,
+                generator=sampling_generator,
+            )
+
+            optimizer.zero_grad(set_to_none=True)
+            loss = model(flat, offsets, targets, negatives)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+
+            total_loss += float(loss.detach()) * len(targets)
+            examples += len(targets)
+
+        final_loss = total_loss / examples
+        logger.info(
+            "DeepSets S2S epoch %d/%d loss=%.4f",
+            epoch,
+            epochs,
+            final_loss,
+        )
+
+    model.eval()
+    with torch.no_grad():
+        embeddings = nn.functional.normalize(
+            model.item_embeddings.weight,
+            dim=1,
+        ).cpu().numpy().astype(np.float32)
+
+        scorer = {
+            "type": "deepsets",
+            "pooling": pooling,
+            "phi_w1": model.phi[0].weight.detach().cpu().numpy().astype(np.float32),
+            "phi_b1": model.phi[0].bias.detach().cpu().numpy().astype(np.float32),
+            "phi_w2": model.phi[2].weight.detach().cpu().numpy().astype(np.float32),
+            "phi_b2": model.phi[2].bias.detach().cpu().numpy().astype(np.float32),
+            "rho_w1": model.rho[0].weight.detach().cpu().numpy().astype(np.float32),
+            "rho_b1": model.rho[0].bias.detach().cpu().numpy().astype(np.float32),
+            "rho_w2": model.rho[2].weight.detach().cpu().numpy().astype(np.float32),
+            "rho_b2": model.rho[2].bias.detach().cpu().numpy().astype(np.float32),
+        }
+
+    artifact = S2SArtifact(
+        site_to_idx=site_to_idx,
+        idx_to_site=sites,
+        matrix=embeddings,
+        scorer=scorer,
+        metadata={
+            "model_type": "deepsets",
+            "n_factors": int(n_factors),
+            "phi_hidden_dim": int(phi_hidden_dim),
+            "rho_hidden_dim": int(rho_hidden_dim),
+            "pooling": pooling,
+            "epochs": int(epochs),
+            "learning_rate": float(learning_rate),
+            "weight_decay": float(weight_decay),
+            "temperature": float(temperature),
+            "batch_size": int(batch_size),
+            "negative_samples": int(negative_samples),
+            "negative_sampling_power": float(negative_sampling_power),
+            "add_inbatch_negatives": bool(add_inbatch_negatives),
+            "seed": int(seed),
+            "device": resolved_device,
+            "train_pilots": int(train_visits["pilot"].nunique()),
+            "train_episodes": len(episodes),
+            "catalog_size": len(sites),
+            "final_loss": final_loss,
+            "requires_learned_scorer": True,
+            **(metadata or {}),
+        },
+    )
+    artifact.validate()
+    return artifact

--- a/ml/glideator_ml/s2s/evaluation.py
+++ b/ml/glideator_ml/s2s/evaluation.py
@@ -2,11 +2,71 @@ from __future__ import annotations
 
 import math
 from collections import Counter
+from typing import Any
 
 import numpy as np
 import pandas as pd
 
 from .artifact import S2SArtifact, recommend
+
+
+def _history_bucket(history_length: int) -> str:
+    if history_length <= 1:
+        return "history_1"
+    if history_length <= 3:
+        return "history_2_3"
+    return "history_4_plus"
+
+
+def _head_sites(popularity: Counter[int]) -> set[int]:
+    if not popularity:
+        return set()
+    ranked = sorted(popularity, key=lambda site_id: (-popularity[site_id], site_id))
+    head_size = max(1, math.ceil(len(ranked) * 0.20))
+    return set(ranked[:head_size])
+
+
+def _ranking_metrics(
+    outcomes: list[dict[str, Any]],
+    *,
+    ks: list[int],
+    prefix: str = "",
+) -> dict[str, float | int]:
+    eligible = [row for row in outcomes if row["eligible"]]
+    metrics: dict[str, float | int] = {
+        f"{prefix}events": len(outcomes),
+        f"{prefix}eligible_events": len(eligible),
+    }
+    for k in ks:
+        eligible_hits = [
+            row["rank"] is not None and row["rank"] <= k for row in eligible
+        ]
+        reciprocal = [
+            1.0 / row["rank"]
+            if row["rank"] is not None and row["rank"] <= k
+            else 0.0
+            for row in eligible
+        ]
+        ndcg = [
+            1.0 / math.log2(row["rank"] + 1)
+            if row["rank"] is not None and row["rank"] <= k
+            else 0.0
+            for row in eligible
+        ]
+        all_hits = [
+            row["rank"] is not None and row["rank"] <= k for row in outcomes
+        ]
+        metrics[f"{prefix}hit_rate_at_{k}"] = (
+            float(np.mean(eligible_hits)) if eligible_hits else 0.0
+        )
+        metrics[f"{prefix}mrr_at_{k}"] = (
+            float(np.mean(reciprocal)) if reciprocal else 0.0
+        )
+        metrics[f"{prefix}ndcg_at_{k}"] = float(np.mean(ndcg)) if ndcg else 0.0
+        metrics[f"{prefix}end_to_end_hit_rate_at_{k}"] = (
+            float(np.mean(all_hits)) if all_hits else 0.0
+        )
+    return metrics
 
 
 def evaluate(
@@ -22,62 +82,67 @@ def evaluate(
     ks = sorted(set(int(k) for k in ks))
     max_k = max(ks)
     popularity = Counter(train_visits["site_id"].astype(int).tolist())
+    head_sites = _head_sites(popularity)
     catalog_size = len(artifact.idx_to_site)
 
-    eligible = 0
     known_source = 0
     cold_start_targets = 0
-    ranks: list[int | None] = []
+    outcomes: list[dict[str, Any]] = []
     recommendations: list[list[int]] = []
 
     for _, source_ids, target_id in events:
-        if any(site_id in artifact.site_to_idx for site_id in source_ids):
+        source_known = any(
+            site_id in artifact.site_to_idx for site_id in source_ids
+        )
+        if source_known:
             known_source += 1
-        if target_id not in artifact.site_to_idx:
+
+        target_known = target_id in artifact.site_to_idx
+        if not target_known:
             cold_start_targets += 1
-            continue
+            target_bucket = "target_cold_start"
+        elif target_id in head_sites:
+            target_bucket = "target_head"
+        else:
+            target_bucket = "target_tail"
 
-        ranked = [site_id for site_id, _ in recommend(artifact, source_ids, top_k=max_k)]
-        if not ranked:
-            continue
+        ranked: list[int] = []
+        if target_known:
+            ranked = [
+                site_id
+                for site_id, _ in recommend(artifact, source_ids, top_k=max_k)
+            ]
 
-        eligible += 1
-        recommendations.append(ranked)
-        try:
-            rank = ranked.index(target_id) + 1
-        except ValueError:
-            rank = None
-        ranks.append(rank)
+        eligible = bool(ranked)
+        rank = None
+        if eligible:
+            recommendations.append(ranked)
+            try:
+                rank = ranked.index(target_id) + 1
+            except ValueError:
+                rank = None
 
-    metrics: dict[str, float | int] = {
-        "events": len(events),
-        "eligible_events": eligible,
-        "catalog_size": catalog_size,
-        "cold_start_target_rate": (
-            cold_start_targets / len(events) if events else 0.0
-        ),
-        "known_source_rate": known_source / len(events) if events else 0.0,
-    }
+        outcomes.append(
+            {
+                "rank": rank,
+                "eligible": eligible,
+                "history_bucket": _history_bucket(len(source_ids)),
+                "target_bucket": target_bucket,
+            }
+        )
+
+    metrics = _ranking_metrics(outcomes, ks=ks)
+    metrics.update(
+        {
+            "catalog_size": catalog_size,
+            "cold_start_target_rate": (
+                cold_start_targets / len(events) if events else 0.0
+            ),
+            "known_source_rate": known_source / len(events) if events else 0.0,
+        }
+    )
 
     for k in ks:
-        if eligible:
-            hits = [rank is not None and rank <= k for rank in ranks]
-            reciprocal = [
-                1.0 / rank if rank is not None and rank <= k else 0.0
-                for rank in ranks
-            ]
-            ndcg = [
-                1.0 / math.log2(rank + 1) if rank is not None and rank <= k else 0.0
-                for rank in ranks
-            ]
-            metrics[f"hit_rate_at_{k}"] = float(np.mean(hits))
-            metrics[f"mrr_at_{k}"] = float(np.mean(reciprocal))
-            metrics[f"ndcg_at_{k}"] = float(np.mean(ndcg))
-        else:
-            metrics[f"hit_rate_at_{k}"] = 0.0
-            metrics[f"mrr_at_{k}"] = 0.0
-            metrics[f"ndcg_at_{k}"] = 0.0
-
         recommended = [site for row in recommendations for site in row[:k]]
         metrics[f"coverage_at_{k}"] = (
             len(set(recommended)) / catalog_size if catalog_size else 0.0
@@ -87,5 +152,13 @@ def evaluate(
             if recommended
             else 0.0
         )
+
+    for bucket in ("history_1", "history_2_3", "history_4_plus"):
+        subset = [row for row in outcomes if row["history_bucket"] == bucket]
+        metrics.update(_ranking_metrics(subset, ks=ks, prefix=f"{bucket}_"))
+
+    for bucket in ("target_head", "target_tail", "target_cold_start"):
+        subset = [row for row in outcomes if row["target_bucket"] == bucket]
+        metrics.update(_ranking_metrics(subset, ks=ks, prefix=f"{bucket}_"))
 
     return metrics

--- a/ml/glideator_ml/s2s/evaluation.py
+++ b/ml/glideator_ml/s2s/evaluation.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import math
+from collections import Counter
+
+import numpy as np
+import pandas as pd
+
+from .artifact import S2SArtifact, recommend
+
+
+def evaluate(
+    artifact: S2SArtifact,
+    events: list[tuple[str, tuple[int, ...], int]],
+    train_visits: pd.DataFrame,
+    *,
+    ks: list[int],
+) -> dict[str, float | int]:
+    if not ks or min(ks) <= 0:
+        raise ValueError("evaluation.ks must contain positive integers")
+
+    ks = sorted(set(int(k) for k in ks))
+    max_k = max(ks)
+    popularity = Counter(train_visits["site_id"].astype(int).tolist())
+    catalog_size = len(artifact.idx_to_site)
+
+    eligible = 0
+    known_source = 0
+    cold_start_targets = 0
+    ranks: list[int | None] = []
+    recommendations: list[list[int]] = []
+
+    for _, source_ids, target_id in events:
+        if any(site_id in artifact.site_to_idx for site_id in source_ids):
+            known_source += 1
+        if target_id not in artifact.site_to_idx:
+            cold_start_targets += 1
+            continue
+
+        ranked = [site_id for site_id, _ in recommend(artifact, source_ids, top_k=max_k)]
+        if not ranked:
+            continue
+
+        eligible += 1
+        recommendations.append(ranked)
+        try:
+            rank = ranked.index(target_id) + 1
+        except ValueError:
+            rank = None
+        ranks.append(rank)
+
+    metrics: dict[str, float | int] = {
+        "events": len(events),
+        "eligible_events": eligible,
+        "catalog_size": catalog_size,
+        "cold_start_target_rate": (
+            cold_start_targets / len(events) if events else 0.0
+        ),
+        "known_source_rate": known_source / len(events) if events else 0.0,
+    }
+
+    for k in ks:
+        if eligible:
+            hits = [rank is not None and rank <= k for rank in ranks]
+            reciprocal = [
+                1.0 / rank if rank is not None and rank <= k else 0.0
+                for rank in ranks
+            ]
+            ndcg = [
+                1.0 / math.log2(rank + 1) if rank is not None and rank <= k else 0.0
+                for rank in ranks
+            ]
+            metrics[f"hit_rate_at_{k}"] = float(np.mean(hits))
+            metrics[f"mrr_at_{k}"] = float(np.mean(reciprocal))
+            metrics[f"ndcg_at_{k}"] = float(np.mean(ndcg))
+        else:
+            metrics[f"hit_rate_at_{k}"] = 0.0
+            metrics[f"mrr_at_{k}"] = 0.0
+            metrics[f"ndcg_at_{k}"] = 0.0
+
+        recommended = [site for row in recommendations for site in row[:k]]
+        metrics[f"coverage_at_{k}"] = (
+            len(set(recommended)) / catalog_size if catalog_size else 0.0
+        )
+        metrics[f"avg_log_popularity_at_{k}"] = (
+            float(np.mean([math.log1p(popularity[site]) for site in recommended]))
+            if recommended
+            else 0.0
+        )
+
+    return metrics

--- a/ml/glideator_ml/s2s/models.py
+++ b/ml/glideator_ml/s2s/models.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from scipy import sparse
+from sklearn.utils.extmath import randomized_svd
+
+from .artifact import S2SArtifact
+
+
+def fit_svd(
+    train_visits: pd.DataFrame,
+    *,
+    n_factors: int,
+    sigma_power: float,
+    seed: int,
+    metadata: dict[str, Any] | None = None,
+) -> S2SArtifact:
+    if train_visits.empty:
+        raise ValueError("Cannot fit S2S SVD on an empty training set")
+
+    pilots = sorted(train_visits["pilot"].astype(str).unique())
+    sites = sorted(int(site) for site in train_visits["site_id"].unique())
+    pilot_to_idx = {pilot: index for index, pilot in enumerate(pilots)}
+    site_to_idx = {site_id: index for index, site_id in enumerate(sites)}
+
+    rows = train_visits["pilot"].astype(str).map(pilot_to_idx).to_numpy()
+    cols = train_visits["site_id"].astype(int).map(site_to_idx).to_numpy()
+    values = np.ones(len(train_visits), dtype=np.float32)
+    matrix = sparse.csr_matrix(
+        (values, (rows, cols)),
+        shape=(len(pilots), len(sites)),
+        dtype=np.float32,
+    )
+    matrix.data[:] = 1.0
+
+    max_rank = min(matrix.shape)
+    if max_rank < 2:
+        raise ValueError("S2S SVD needs at least two pilots and two sites")
+    components = min(int(n_factors), max_rank - 1)
+    if components < 1:
+        raise ValueError("n_factors must be positive")
+
+    _, singular_values, vt = randomized_svd(
+        matrix,
+        n_components=components,
+        random_state=seed,
+    )
+    embeddings = vt.T * np.power(singular_values, float(sigma_power))
+    norms = np.linalg.norm(embeddings, axis=1, keepdims=True)
+    embeddings = np.divide(
+        embeddings,
+        norms,
+        out=np.zeros_like(embeddings),
+        where=norms > 0,
+    ).astype(np.float32)
+
+    artifact_metadata = {
+        "model_type": "svd",
+        "n_factors_requested": int(n_factors),
+        "n_factors_fitted": int(components),
+        "sigma_power": float(sigma_power),
+        "seed": int(seed),
+        "train_pilots": len(pilots),
+        "catalog_size": len(sites),
+        "train_interactions": int(matrix.nnz),
+        **(metadata or {}),
+    }
+    artifact = S2SArtifact(
+        site_to_idx=site_to_idx,
+        idx_to_site=sites,
+        matrix=embeddings,
+        metadata=artifact_metadata,
+    )
+    artifact.validate()
+    return artifact

--- a/ml/glideator_ml/s2s/models.py
+++ b/ml/glideator_ml/s2s/models.py
@@ -91,6 +91,7 @@ def fit_contrastive(
     temperature: float,
     batch_size: int,
     negative_samples: int,
+    negative_sampling_power: float,
     add_inbatch_negatives: bool,
     seed: int,
     device: str = "auto",
@@ -205,7 +206,7 @@ def fit_contrastive(
         num_workers=0,
     )
     sampling_weights = torch.as_tensor(
-        np.power(popularity + 1e-8, 0.75),
+        np.power(popularity + 1e-8, float(negative_sampling_power)),
         dtype=torch.float32,
         device=resolved_device,
     )
@@ -266,6 +267,7 @@ def fit_contrastive(
             "temperature": float(temperature),
             "batch_size": int(batch_size),
             "negative_samples": int(negative_samples),
+            "negative_sampling_power": float(negative_sampling_power),
             "add_inbatch_negatives": bool(add_inbatch_negatives),
             "seed": int(seed),
             "device": resolved_device,

--- a/ml/glideator_ml/s2s/models.py
+++ b/ml/glideator_ml/s2s/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import numpy as np
@@ -8,6 +9,8 @@ from scipy import sparse
 from sklearn.utils.extmath import randomized_svd
 
 from .artifact import S2SArtifact
+
+logger = logging.getLogger(__name__)
 
 
 def fit_svd(
@@ -73,6 +76,205 @@ def fit_svd(
         idx_to_site=sites,
         matrix=embeddings,
         metadata=artifact_metadata,
+    )
+    artifact.validate()
+    return artifact
+
+
+def fit_contrastive(
+    train_visits: pd.DataFrame,
+    *,
+    n_factors: int,
+    epochs: int,
+    learning_rate: float,
+    weight_decay: float,
+    temperature: float,
+    batch_size: int,
+    negative_samples: int,
+    add_inbatch_negatives: bool,
+    seed: int,
+    device: str = "auto",
+    metadata: dict[str, Any] | None = None,
+) -> S2SArtifact:
+    """Fit the contrastive architecture used by the production S2S model."""
+    try:
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, Dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "Contrastive S2S training requires the 'contrastive' extra"
+        ) from exc
+
+    if train_visits.empty:
+        raise ValueError("Cannot fit contrastive S2S on an empty training set")
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    sites = sorted(int(site) for site in train_visits["site_id"].unique())
+    site_to_idx = {site_id: index for index, site_id in enumerate(sites)}
+    ordered = train_visits.sort_values(
+        ["pilot", "visit_at", "site_id"], kind="mergesort"
+    )
+    episodes: list[tuple[np.ndarray, int]] = []
+    for _, group in ordered.groupby("pilot", sort=True):
+        indices = [site_to_idx[int(site)] for site in group["site_id"]]
+        episodes.extend(
+            (np.asarray(indices[:position], dtype=np.int64), indices[position])
+            for position in range(1, len(indices))
+        )
+    if not episodes:
+        raise ValueError("Contrastive S2S needs at least one training episode")
+
+    popularity = np.zeros(len(sites), dtype=np.float64)
+    for site_id, count in train_visits["site_id"].value_counts().items():
+        popularity[site_to_idx[int(site_id)]] = float(count)
+
+    class EpisodeDataset(Dataset):
+        def __len__(self):
+            return len(episodes)
+
+        def __getitem__(self, index):
+            return episodes[index]
+
+    def collate(batch):
+        histories, targets = zip(*batch)
+        offsets = np.cumsum([0, *[len(history) for history in histories]])
+        return (
+            torch.as_tensor(np.concatenate(histories), dtype=torch.long),
+            torch.as_tensor(offsets, dtype=torch.long),
+            torch.as_tensor(targets, dtype=torch.long),
+        )
+
+    class DiscoveryModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.item_embeddings = nn.Embedding(len(sites), int(n_factors))
+            self.history_embeddings = nn.EmbeddingBag(
+                len(sites),
+                int(n_factors),
+                mode="sum",
+                include_last_offset=True,
+            )
+            self.history_embeddings.weight = self.item_embeddings.weight
+            nn.init.normal_(self.item_embeddings.weight, std=0.02)
+
+        def forward(self, flat, offsets, targets, negatives):
+            query = nn.functional.normalize(
+                self.history_embeddings(flat, offsets), dim=1
+            )
+            positive = nn.functional.normalize(
+                self.item_embeddings(targets), dim=1
+            )
+            negative = nn.functional.normalize(
+                self.item_embeddings(negatives), dim=2
+            )
+            positive_logits = (query * positive).sum(dim=1, keepdim=True)
+            negative_logits = torch.einsum("bd,bkd->bk", query, negative)
+            if add_inbatch_negatives:
+                inbatch = query @ positive.T
+                inbatch = inbatch - torch.eye(
+                    inbatch.size(0), device=inbatch.device
+                ) * 1e9
+                negative_logits = torch.cat([negative_logits, inbatch], dim=1)
+            logits = torch.cat([positive_logits, negative_logits], dim=1)
+            labels = torch.zeros(logits.size(0), dtype=torch.long, device=logits.device)
+            return nn.functional.cross_entropy(logits / temperature, labels)
+
+    resolved_device = (
+        "cuda" if device == "auto" and torch.cuda.is_available() else device
+    )
+    if resolved_device == "auto":
+        resolved_device = "cpu"
+    model = DiscoveryModel().to(resolved_device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(learning_rate),
+        weight_decay=float(weight_decay),
+    )
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        EpisodeDataset(),
+        batch_size=int(batch_size),
+        shuffle=True,
+        collate_fn=collate,
+        generator=generator,
+        num_workers=0,
+    )
+    sampling_weights = torch.as_tensor(
+        np.power(popularity + 1e-8, 0.75),
+        dtype=torch.float32,
+        device=resolved_device,
+    )
+    sampling_generator = torch.Generator(device=resolved_device).manual_seed(seed)
+    final_loss = 0.0
+    for epoch in range(1, int(epochs) + 1):
+        model.train()
+        total_loss = 0.0
+        examples = 0
+        for flat, offsets, targets in loader:
+            flat = flat.to(resolved_device)
+            offsets = offsets.to(resolved_device)
+            targets = targets.to(resolved_device)
+            weights = sampling_weights.expand(len(targets), -1).clone()
+            row_indices = torch.repeat_interleave(
+                torch.arange(len(targets), device=resolved_device),
+                offsets[1:] - offsets[:-1],
+            )
+            weights[row_indices, flat] = 0
+            weights[torch.arange(len(targets), device=resolved_device), targets] = 0
+            negatives = torch.multinomial(
+                weights,
+                num_samples=int(negative_samples),
+                replacement=False,
+                generator=sampling_generator,
+            )
+            optimizer.zero_grad(set_to_none=True)
+            loss = model(flat, offsets, targets, negatives)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            total_loss += float(loss.detach()) * len(targets)
+            examples += len(targets)
+        final_loss = total_loss / examples
+        logger.info(
+            "Contrastive S2S epoch %d/%d loss=%.4f",
+            epoch,
+            epochs,
+            final_loss,
+        )
+
+    model.eval()
+    with torch.no_grad():
+        embeddings = nn.functional.normalize(
+            model.item_embeddings.weight, dim=1
+        ).cpu().numpy().astype(np.float32)
+
+    artifact = S2SArtifact(
+        site_to_idx=site_to_idx,
+        idx_to_site=sites,
+        matrix=embeddings,
+        metadata={
+            "model_type": "contrastive",
+            "n_factors": int(n_factors),
+            "epochs": int(epochs),
+            "learning_rate": float(learning_rate),
+            "weight_decay": float(weight_decay),
+            "temperature": float(temperature),
+            "batch_size": int(batch_size),
+            "negative_samples": int(negative_samples),
+            "add_inbatch_negatives": bool(add_inbatch_negatives),
+            "seed": int(seed),
+            "device": resolved_device,
+            "train_pilots": int(train_visits["pilot"].nunique()),
+            "train_episodes": len(episodes),
+            "catalog_size": len(sites),
+            "final_loss": final_loss,
+            **(metadata or {}),
+        },
     )
     artifact.validate()
     return artifact

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from ..tracking import log_experiment
 from .artifact import S2SArtifact
+from .asymmetric import fit_asymmetric
 from .data import (
     dataset_fingerprint,
     events_fingerprint,
@@ -166,6 +167,26 @@ def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SA
             phi_hidden_dim=int(model.get("phi_hidden_dim", 128)),
             rho_hidden_dim=int(model.get("rho_hidden_dim", 128)),
             pooling=str(model.get("pooling", "mean")),
+            epochs=int(model.get("epochs", 50)),
+            learning_rate=float(model.get("learning_rate", 5e-3)),
+            weight_decay=float(model.get("weight_decay", 1e-4)),
+            temperature=float(model.get("temperature", 0.1)),
+            batch_size=int(model.get("batch_size", 256)),
+            negative_samples=int(model.get("negative_samples", 50)),
+            negative_sampling_power=float(
+                model.get("negative_sampling_power", 0.75)
+            ),
+            add_inbatch_negatives=bool(
+                model.get("add_inbatch_negatives", False)
+            ),
+            device=str(model.get("device", "auto")),
+            seed=seed,
+            metadata=metadata,
+        )
+    if name == "asymmetric":
+        return fit_asymmetric(
+            train_visits,
+            n_factors=int(model.get("n_factors", 64)),
             epochs=int(model.get("epochs", 50)),
             learning_rate=float(model.get("learning_rate", 5e-3)),
             weight_decay=float(model.get("weight_decay", 1e-4)),

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from ..tracking import log_experiment
 from .artifact import S2SArtifact
+from .candidate_attention import fit_candidate_attention
 from .asymmetric import fit_asymmetric
 from .data import (
     dataset_fingerprint,
@@ -221,6 +222,29 @@ def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SA
             ),
             add_inbatch_negatives=bool(
                 model.get("add_inbatch_negatives", False)
+            ),
+            device=str(model.get("device", "auto")),
+            seed=seed,
+            metadata=metadata,
+        )
+    if name == "candidate_attention":
+        return fit_candidate_attention(
+            train_visits,
+            n_factors=int(model.get("n_factors", 64)),
+            epochs=int(model.get("epochs", 50)),
+            learning_rate=float(model.get("learning_rate", 5e-3)),
+            weight_decay=float(model.get("weight_decay", 1e-4)),
+            temperature=float(model.get("temperature", 0.1)),
+            batch_size=int(model.get("batch_size", 256)),
+            negative_samples=int(model.get("negative_samples", 50)),
+            negative_sampling_power=float(
+                model.get("negative_sampling_power", 0.75)
+            ),
+            add_inbatch_negatives=bool(
+                model.get("add_inbatch_negatives", False)
+            ),
+            attention_scale_init=float(
+                model.get("attention_scale_init", 0.1)
             ),
             device=str(model.get("device", "auto")),
             seed=seed,

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -21,6 +21,7 @@ from .data import (
 from .deepsets import fit_deepsets
 from .evaluation import evaluate
 from .models import fit_contrastive, fit_svd
+from .transformed_additive import fit_transformed_additive
 
 
 def _git_sha() -> str:
@@ -187,6 +188,28 @@ def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SA
         return fit_asymmetric(
             train_visits,
             n_factors=int(model.get("n_factors", 64)),
+            epochs=int(model.get("epochs", 50)),
+            learning_rate=float(model.get("learning_rate", 5e-3)),
+            weight_decay=float(model.get("weight_decay", 1e-4)),
+            temperature=float(model.get("temperature", 0.1)),
+            batch_size=int(model.get("batch_size", 256)),
+            negative_samples=int(model.get("negative_samples", 50)),
+            negative_sampling_power=float(
+                model.get("negative_sampling_power", 0.75)
+            ),
+            add_inbatch_negatives=bool(
+                model.get("add_inbatch_negatives", False)
+            ),
+            device=str(model.get("device", "auto")),
+            seed=seed,
+            metadata=metadata,
+        )
+    if name == "transformed_additive":
+        return fit_transformed_additive(
+            train_visits,
+            n_factors=int(model.get("n_factors", 64)),
+            phi_hidden_dim=int(model.get("phi_hidden_dim", 128)),
+            rho_hidden_dim=int(model.get("rho_hidden_dim", 128)),
             epochs=int(model.get("epochs", 50)),
             learning_rate=float(model.get("learning_rate", 5e-3)),
             weight_decay=float(model.get("weight_decay", 1e-4)),

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from ..tracking import log_experiment
+from .artifact import S2SArtifact
+from .data import (
+    dataset_fingerprint,
+    load_visits,
+    split_pilots,
+    walk_forward_events,
+)
+from .evaluation import evaluate
+from .models import fit_svd
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SArtifact:
+    model = config["model"]
+    name = model.get("name", "svd")
+    if name != "svd":
+        raise ValueError(f"Unsupported S2S model: {name!r}")
+    return fit_svd(
+        train_visits,
+        n_factors=int(model.get("n_factors", 64)),
+        sigma_power=float(model.get("sigma_power", 1.0)),
+        seed=int(config.get("seed", 42)),
+        metadata=metadata,
+    )
+
+
+def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
+    visits = load_visits(config["data"])
+    fingerprint = dataset_fingerprint(visits)
+    seed = int(config.get("seed", 42))
+    split = split_pilots(
+        visits,
+        eval_fraction=float(config["data"].get("eval_fraction", 0.2)),
+        seed=seed,
+    )
+    events = walk_forward_events(
+        split.eval_visits,
+        min_history=int(config["data"].get("min_eval_history", 1)),
+    )
+
+    git_sha = _git_sha()
+    model_metadata = {
+        "task": "s2s",
+        "dataset_fingerprint": fingerprint,
+        "git_sha": git_sha,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    artifact = _fit(config, split.train_visits, model_metadata)
+
+    metrics = evaluate(
+        artifact,
+        events,
+        split.train_visits,
+        ks=[int(k) for k in config["evaluation"].get("ks", [5, 10])],
+    )
+    metrics.update(
+        {
+            "dataset_rows": len(visits),
+            "train_rows": len(split.train_visits),
+            "eval_rows": len(split.eval_visits),
+            "train_pilots": split.train_visits["pilot"].nunique(),
+            "eval_pilots": split.eval_visits["pilot"].nunique(),
+        }
+    )
+
+    output_dir = Path(config["artifact"].get("output_dir", "outputs/s2s"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifact_path = artifact.save(
+        output_dir / config["artifact"].get("filename", "s2s_embeddings.pkl")
+    )
+    report_path = output_dir / "evaluation.json"
+    report = {
+        "task": "s2s",
+        "dataset_fingerprint": fingerprint,
+        "git_sha": git_sha,
+        "model": artifact.metadata,
+        "metrics": metrics,
+    }
+    report_path.write_text(
+        json.dumps(report, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    run_id = log_experiment(
+        config=config,
+        metrics=metrics,
+        tags={
+            "task": "s2s",
+            "model_family": str(config["model"].get("name", "svd")),
+            "dataset_fingerprint": fingerprint,
+            "git_sha": git_sha,
+        },
+        artifacts=[artifact_path, report_path],
+    )
+    report["mlflow_run_id"] = run_id
+    return report

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -43,6 +43,40 @@ def _split_seed(config: dict[str, Any]) -> int:
     return int(config["data"].get("split_seed", config.get("seed", 42)))
 
 
+def _write_report(path: Path, report: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(report, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _tracking_tags(
+    config: dict[str, Any],
+    report: dict[str, Any],
+) -> dict[str, str]:
+    benchmark = report["benchmark"]
+    tags = {
+        "task": "s2s",
+        "model_family": str(
+            config["model"].get(
+                "name",
+                report["model"].get("model_type", "svd"),
+            )
+        ),
+        "benchmark_id": str(report["benchmark_id"]),
+        "dataset_fingerprint": str(report["dataset_fingerprint"]),
+        "eval_set_fingerprint": str(report["eval_set_fingerprint"]),
+        "model_seed": str(report["model_seed"]),
+        "git_sha": str(report["git_sha"]),
+        "split_strategy": str(benchmark["split_strategy"]),
+    }
+    if "split_seed" in benchmark:
+        tags["split_seed"] = str(benchmark["split_seed"])
+    if "temporal_cutoff" in benchmark:
+        tags["temporal_cutoff"] = str(benchmark["temporal_cutoff"])
+    return tags
+
+
 def _benchmark(
     config: dict[str, Any],
     visits,
@@ -210,31 +244,46 @@ def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
         # Preserve the v1 report contract for existing comparisons/scripts.
         report["split_seed"] = benchmark_metadata["split_seed"]
 
-    report_path.write_text(
-        json.dumps(report, indent=2, sort_keys=True),
-        encoding="utf-8",
-    )
-
-    tags = {
-        "task": "s2s",
-        "model_family": str(config["model"].get("name", "svd")),
-        "benchmark_id": benchmark_id,
-        "dataset_fingerprint": fingerprint,
-        "eval_set_fingerprint": eval_fingerprint,
-        "model_seed": str(model_seed),
-        "git_sha": git_sha,
-        "split_strategy": str(benchmark_metadata["split_strategy"]),
-    }
-    if "split_seed" in benchmark_metadata:
-        tags["split_seed"] = str(benchmark_metadata["split_seed"])
-    if "temporal_cutoff" in benchmark_metadata:
-        tags["temporal_cutoff"] = str(benchmark_metadata["temporal_cutoff"])
+    _write_report(report_path, report)
 
     run_id = log_experiment(
         config=config,
         metrics=metrics,
-        tags=tags,
+        tags=_tracking_tags(config, report),
         artifacts=[artifact_path, report_path],
     )
     report["mlflow_run_id"] = run_id
+    if run_id is not None:
+        _write_report(report_path, report)
+    return report
+
+
+def backfill_s2s_tracking(config: dict[str, Any]) -> dict[str, Any]:
+    output_dir = Path(config["artifact"].get("output_dir", "outputs/s2s"))
+    report_path = output_dir / "evaluation.json"
+    artifact_path = output_dir / config["artifact"].get(
+        "filename",
+        "s2s_embeddings.pkl",
+    )
+
+    if not report_path.is_file():
+        raise FileNotFoundError(f"Missing S2S evaluation report: {report_path}")
+    if not artifact_path.is_file():
+        raise FileNotFoundError(f"Missing S2S model artifact: {artifact_path}")
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    if report.get("mlflow_run_id"):
+        return report
+
+    run_id = log_experiment(
+        config=config,
+        metrics=report["metrics"],
+        tags=_tracking_tags(config, report),
+        artifacts=[artifact_path, report_path],
+    )
+    if run_id is None:
+        raise RuntimeError("MLflow tracking is disabled; cannot backfill S2S run")
+
+    report["mlflow_run_id"] = run_id
+    _write_report(report_path, report)
     return report

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -13,6 +13,8 @@ from .data import (
     events_fingerprint,
     load_visits,
     split_pilots,
+    split_temporal,
+    temporal_walk_forward_events,
     walk_forward_events,
 )
 from .evaluation import evaluate
@@ -38,6 +40,56 @@ def _model_seed(config: dict[str, Any]) -> int:
 def _split_seed(config: dict[str, Any]) -> int:
     # Split identity belongs to the data/benchmark, not to stochastic model training.
     return int(config["data"].get("split_seed", config.get("seed", 42)))
+
+
+def _benchmark(
+    config: dict[str, Any],
+    visits,
+):
+    data = config["data"]
+    strategy = str(data.get("split_strategy", "pilot"))
+    min_history = int(data.get("min_eval_history", 1))
+
+    if strategy == "pilot":
+        split_seed = _split_seed(config)
+        split = split_pilots(
+            visits,
+            eval_fraction=float(data.get("eval_fraction", 0.2)),
+            seed=split_seed,
+        )
+        events = walk_forward_events(
+            split.eval_visits,
+            min_history=min_history,
+        )
+        metadata = {
+            "split_strategy": "pilot",
+            "split_seed": split_seed,
+        }
+    elif strategy == "temporal":
+        cutoff = data.get("temporal_cutoff")
+        if not cutoff:
+            raise ValueError(
+                "data.temporal_cutoff is required when split_strategy=temporal"
+            )
+        cutoff = str(cutoff)
+        split = split_temporal(visits, cutoff=cutoff)
+        events = temporal_walk_forward_events(
+            visits,
+            cutoff=cutoff,
+            min_history=min_history,
+        )
+        metadata = {
+            "split_strategy": "temporal",
+            "temporal_cutoff": cutoff,
+        }
+    else:
+        raise ValueError(f"Unsupported S2S split strategy: {strategy!r}")
+
+    if not events:
+        raise ValueError(
+            f"S2S benchmark {strategy!r} produced no walk-forward evaluation events"
+        )
+    return split, events, metadata
 
 
 def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SArtifact:
@@ -75,19 +127,10 @@ def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SA
 def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
     visits = load_visits(config["data"])
     fingerprint = dataset_fingerprint(visits)
-    split_seed = _split_seed(config)
     model_seed = _model_seed(config)
     benchmark_id = str(config["evaluation"].get("benchmark_id", "s2s-v1"))
 
-    split = split_pilots(
-        visits,
-        eval_fraction=float(config["data"].get("eval_fraction", 0.2)),
-        seed=split_seed,
-    )
-    events = walk_forward_events(
-        split.eval_visits,
-        min_history=int(config["data"].get("min_eval_history", 1)),
-    )
+    split, events, benchmark_metadata = _benchmark(config, visits)
     eval_fingerprint = events_fingerprint(events)
 
     git_sha = _git_sha()
@@ -96,10 +139,10 @@ def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
         "dataset_fingerprint": fingerprint,
         "benchmark_id": benchmark_id,
         "eval_set_fingerprint": eval_fingerprint,
-        "split_seed": split_seed,
         "model_seed": model_seed,
         "git_sha": git_sha,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        **benchmark_metadata,
     }
     artifact = _fit(config, split.train_visits, model_metadata)
 
@@ -128,32 +171,42 @@ def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
     report = {
         "task": "s2s",
         "benchmark_id": benchmark_id,
+        "benchmark": benchmark_metadata,
         "dataset_fingerprint": fingerprint,
         "eval_set_fingerprint": eval_fingerprint,
-        "split_seed": split_seed,
         "model_seed": model_seed,
         "git_sha": git_sha,
         "model": artifact.metadata,
         "metrics": metrics,
     }
+    if "split_seed" in benchmark_metadata:
+        # Preserve the v1 report contract for existing comparisons/scripts.
+        report["split_seed"] = benchmark_metadata["split_seed"]
+
     report_path.write_text(
         json.dumps(report, indent=2, sort_keys=True),
         encoding="utf-8",
     )
 
+    tags = {
+        "task": "s2s",
+        "model_family": str(config["model"].get("name", "svd")),
+        "benchmark_id": benchmark_id,
+        "dataset_fingerprint": fingerprint,
+        "eval_set_fingerprint": eval_fingerprint,
+        "model_seed": str(model_seed),
+        "git_sha": git_sha,
+        "split_strategy": str(benchmark_metadata["split_strategy"]),
+    }
+    if "split_seed" in benchmark_metadata:
+        tags["split_seed"] = str(benchmark_metadata["split_seed"])
+    if "temporal_cutoff" in benchmark_metadata:
+        tags["temporal_cutoff"] = str(benchmark_metadata["temporal_cutoff"])
+
     run_id = log_experiment(
         config=config,
         metrics=metrics,
-        tags={
-            "task": "s2s",
-            "model_family": str(config["model"].get("name", "svd")),
-            "benchmark_id": benchmark_id,
-            "dataset_fingerprint": fingerprint,
-            "eval_set_fingerprint": eval_fingerprint,
-            "split_seed": str(split_seed),
-            "model_seed": str(model_seed),
-            "git_sha": git_sha,
-        },
+        tags=tags,
         artifacts=[artifact_path, report_path],
     )
     report["mlflow_run_id"] = run_id

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -114,6 +114,9 @@ def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SA
             temperature=float(model.get("temperature", 0.1)),
             batch_size=int(model.get("batch_size", 256)),
             negative_samples=int(model.get("negative_samples", 50)),
+            negative_sampling_power=float(
+                model.get("negative_sampling_power", 0.75)
+            ),
             add_inbatch_negatives=bool(
                 model.get("add_inbatch_negatives", False)
             ),

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -17,6 +17,7 @@ from .data import (
     temporal_walk_forward_events,
     walk_forward_events,
 )
+from .deepsets import fit_deepsets
 from .evaluation import evaluate
 from .models import fit_contrastive, fit_svd
 
@@ -108,6 +109,29 @@ def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SA
         return fit_contrastive(
             train_visits,
             n_factors=int(model.get("n_factors", 64)),
+            epochs=int(model.get("epochs", 50)),
+            learning_rate=float(model.get("learning_rate", 5e-3)),
+            weight_decay=float(model.get("weight_decay", 1e-4)),
+            temperature=float(model.get("temperature", 0.1)),
+            batch_size=int(model.get("batch_size", 256)),
+            negative_samples=int(model.get("negative_samples", 50)),
+            negative_sampling_power=float(
+                model.get("negative_sampling_power", 0.75)
+            ),
+            add_inbatch_negatives=bool(
+                model.get("add_inbatch_negatives", False)
+            ),
+            device=str(model.get("device", "auto")),
+            seed=seed,
+            metadata=metadata,
+        )
+    if name == "deepsets":
+        return fit_deepsets(
+            train_visits,
+            n_factors=int(model.get("n_factors", 64)),
+            phi_hidden_dim=int(model.get("phi_hidden_dim", 128)),
+            rho_hidden_dim=int(model.get("rho_hidden_dim", 128)),
+            pooling=str(model.get("pooling", "mean")),
             epochs=int(model.get("epochs", 50)),
             learning_rate=float(model.get("learning_rate", 5e-3)),
             weight_decay=float(model.get("weight_decay", 1e-4)),

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -15,7 +15,7 @@ from .data import (
     walk_forward_events,
 )
 from .evaluation import evaluate
-from .models import fit_svd
+from .models import fit_contrastive, fit_svd
 
 
 def _git_sha() -> str:
@@ -32,15 +32,33 @@ def _git_sha() -> str:
 def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SArtifact:
     model = config["model"]
     name = model.get("name", "svd")
-    if name != "svd":
-        raise ValueError(f"Unsupported S2S model: {name!r}")
-    return fit_svd(
-        train_visits,
-        n_factors=int(model.get("n_factors", 64)),
-        sigma_power=float(model.get("sigma_power", 1.0)),
-        seed=int(config.get("seed", 42)),
-        metadata=metadata,
-    )
+    seed = int(config.get("seed", 42))
+    if name == "svd":
+        return fit_svd(
+            train_visits,
+            n_factors=int(model.get("n_factors", 64)),
+            sigma_power=float(model.get("sigma_power", 1.0)),
+            seed=seed,
+            metadata=metadata,
+        )
+    if name == "contrastive":
+        return fit_contrastive(
+            train_visits,
+            n_factors=int(model.get("n_factors", 64)),
+            epochs=int(model.get("epochs", 50)),
+            learning_rate=float(model.get("learning_rate", 5e-3)),
+            weight_decay=float(model.get("weight_decay", 1e-4)),
+            temperature=float(model.get("temperature", 0.1)),
+            batch_size=int(model.get("batch_size", 256)),
+            negative_samples=int(model.get("negative_samples", 50)),
+            add_inbatch_negatives=bool(
+                model.get("add_inbatch_negatives", False)
+            ),
+            device=str(model.get("device", "auto")),
+            seed=seed,
+            metadata=metadata,
+        )
+    raise ValueError(f"Unsupported S2S model: {name!r}")
 
 
 def run_s2s(config: dict[str, Any]) -> dict[str, Any]:

--- a/ml/glideator_ml/s2s/run.py
+++ b/ml/glideator_ml/s2s/run.py
@@ -10,6 +10,7 @@ from ..tracking import log_experiment
 from .artifact import S2SArtifact
 from .data import (
     dataset_fingerprint,
+    events_fingerprint,
     load_visits,
     split_pilots,
     walk_forward_events,
@@ -29,10 +30,20 @@ def _git_sha() -> str:
         return "unknown"
 
 
+def _model_seed(config: dict[str, Any]) -> int:
+    # Top-level seed is retained as a backward-compatible fallback for old configs.
+    return int(config["model"].get("seed", config.get("seed", 42)))
+
+
+def _split_seed(config: dict[str, Any]) -> int:
+    # Split identity belongs to the data/benchmark, not to stochastic model training.
+    return int(config["data"].get("split_seed", config.get("seed", 42)))
+
+
 def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SArtifact:
     model = config["model"]
     name = model.get("name", "svd")
-    seed = int(config.get("seed", 42))
+    seed = _model_seed(config)
     if name == "svd":
         return fit_svd(
             train_visits,
@@ -64,21 +75,29 @@ def _fit(config: dict[str, Any], train_visits, metadata: dict[str, Any]) -> S2SA
 def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
     visits = load_visits(config["data"])
     fingerprint = dataset_fingerprint(visits)
-    seed = int(config.get("seed", 42))
+    split_seed = _split_seed(config)
+    model_seed = _model_seed(config)
+    benchmark_id = str(config["evaluation"].get("benchmark_id", "s2s-v1"))
+
     split = split_pilots(
         visits,
         eval_fraction=float(config["data"].get("eval_fraction", 0.2)),
-        seed=seed,
+        seed=split_seed,
     )
     events = walk_forward_events(
         split.eval_visits,
         min_history=int(config["data"].get("min_eval_history", 1)),
     )
+    eval_fingerprint = events_fingerprint(events)
 
     git_sha = _git_sha()
     model_metadata = {
         "task": "s2s",
         "dataset_fingerprint": fingerprint,
+        "benchmark_id": benchmark_id,
+        "eval_set_fingerprint": eval_fingerprint,
+        "split_seed": split_seed,
+        "model_seed": model_seed,
         "git_sha": git_sha,
         "created_at": datetime.now(timezone.utc).isoformat(),
     }
@@ -108,7 +127,11 @@ def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
     report_path = output_dir / "evaluation.json"
     report = {
         "task": "s2s",
+        "benchmark_id": benchmark_id,
         "dataset_fingerprint": fingerprint,
+        "eval_set_fingerprint": eval_fingerprint,
+        "split_seed": split_seed,
+        "model_seed": model_seed,
         "git_sha": git_sha,
         "model": artifact.metadata,
         "metrics": metrics,
@@ -124,7 +147,11 @@ def run_s2s(config: dict[str, Any]) -> dict[str, Any]:
         tags={
             "task": "s2s",
             "model_family": str(config["model"].get("name", "svd")),
+            "benchmark_id": benchmark_id,
             "dataset_fingerprint": fingerprint,
+            "eval_set_fingerprint": eval_fingerprint,
+            "split_seed": str(split_seed),
+            "model_seed": str(model_seed),
             "git_sha": git_sha,
         },
         artifacts=[artifact_path, report_path],

--- a/ml/glideator_ml/s2s/transformed_additive.py
+++ b/ml/glideator_ml/s2s/transformed_additive.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .artifact import S2SArtifact
+
+logger = logging.getLogger(__name__)
+
+
+def fit_transformed_additive(
+    train_visits: pd.DataFrame,
+    *,
+    n_factors: int,
+    phi_hidden_dim: int,
+    rho_hidden_dim: int,
+    epochs: int,
+    learning_rate: float,
+    weight_decay: float,
+    temperature: float,
+    batch_size: int,
+    negative_samples: int,
+    negative_sampling_power: float,
+    add_inbatch_negatives: bool,
+    seed: int,
+    device: str = "auto",
+    metadata: dict[str, Any] | None = None,
+) -> S2SArtifact:
+    """Fit per-site nonlinear transforms followed by additive history composition."""
+    try:
+        import torch
+        from torch import nn
+        from torch.utils.data import DataLoader, Dataset
+    except ImportError as exc:
+        raise RuntimeError(
+            "Transformed-additive S2S training requires the 'contrastive' extra"
+        ) from exc
+
+    if train_visits.empty:
+        raise ValueError("Cannot fit transformed-additive S2S on an empty training set")
+    if n_factors <= 0 or phi_hidden_dim <= 0 or rho_hidden_dim <= 0:
+        raise ValueError("Transformed-additive dimensions must be positive")
+    if negative_samples <= 0:
+        raise ValueError("negative_samples must be positive")
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    sites = sorted(int(site) for site in train_visits["site_id"].unique())
+    site_to_idx = {site_id: index for index, site_id in enumerate(sites)}
+    ordered = train_visits.sort_values(
+        ["pilot", "visit_at", "site_id"], kind="mergesort"
+    )
+    episodes: list[tuple[np.ndarray, int]] = []
+    for _, group in ordered.groupby("pilot", sort=True):
+        indices = [site_to_idx[int(site)] for site in group["site_id"]]
+        episodes.extend(
+            (np.asarray(indices[:position], dtype=np.int64), indices[position])
+            for position in range(1, len(indices))
+        )
+    if not episodes:
+        raise ValueError("Transformed-additive S2S needs at least one training episode")
+
+    popularity = np.zeros(len(sites), dtype=np.float64)
+    for site_id, count in train_visits["site_id"].value_counts().items():
+        popularity[site_to_idx[int(site_id)]] = float(count)
+
+    class EpisodeDataset(Dataset):
+        def __len__(self):
+            return len(episodes)
+
+        def __getitem__(self, index):
+            return episodes[index]
+
+    def collate(batch):
+        histories, targets = zip(*batch)
+        offsets = np.cumsum([0, *[len(history) for history in histories]])
+        return (
+            torch.as_tensor(np.concatenate(histories), dtype=torch.long),
+            torch.as_tensor(offsets, dtype=torch.long),
+            torch.as_tensor(targets, dtype=torch.long),
+        )
+
+    class TransformedAdditiveDiscoveryModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.item_embeddings = nn.Embedding(len(sites), int(n_factors))
+            self.phi = nn.Sequential(
+                nn.Linear(int(n_factors), int(phi_hidden_dim)),
+                nn.ReLU(),
+                nn.Linear(int(phi_hidden_dim), int(n_factors)),
+            )
+            self.rho = nn.Sequential(
+                nn.Linear(int(n_factors), int(rho_hidden_dim)),
+                nn.ReLU(),
+                nn.Linear(int(rho_hidden_dim), int(n_factors)),
+            )
+            nn.init.normal_(self.item_embeddings.weight, std=0.02)
+
+        def encode_history(self, flat, offsets):
+            items = nn.functional.normalize(
+                self.item_embeddings(flat),
+                dim=1,
+            )
+            transformed = self.rho(self.phi(items))
+            lengths = offsets[1:] - offsets[:-1]
+            batch_rows = torch.repeat_interleave(
+                torch.arange(len(lengths), device=flat.device),
+                lengths,
+            )
+            pooled = torch.zeros(
+                (len(lengths), int(n_factors)),
+                dtype=transformed.dtype,
+                device=transformed.device,
+            )
+            pooled.index_add_(0, batch_rows, transformed)
+            return nn.functional.normalize(pooled, dim=1)
+
+        def forward(self, flat, offsets, targets, negatives):
+            query = self.encode_history(flat, offsets)
+            positive = nn.functional.normalize(
+                self.item_embeddings(targets),
+                dim=1,
+            )
+            negative = nn.functional.normalize(
+                self.item_embeddings(negatives),
+                dim=2,
+            )
+            positive_logits = (query * positive).sum(dim=1, keepdim=True)
+            negative_logits = torch.einsum("bd,bkd->bk", query, negative)
+            if add_inbatch_negatives:
+                inbatch = query @ positive.T
+                inbatch = inbatch - torch.eye(
+                    inbatch.size(0), device=inbatch.device
+                ) * 1e9
+                negative_logits = torch.cat([negative_logits, inbatch], dim=1)
+            logits = torch.cat([positive_logits, negative_logits], dim=1)
+            labels = torch.zeros(
+                logits.size(0),
+                dtype=torch.long,
+                device=logits.device,
+            )
+            return nn.functional.cross_entropy(logits / temperature, labels)
+
+    resolved_device = (
+        "cuda" if device == "auto" and torch.cuda.is_available() else device
+    )
+    if resolved_device == "auto":
+        resolved_device = "cpu"
+
+    model = TransformedAdditiveDiscoveryModel().to(resolved_device)
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=float(learning_rate),
+        weight_decay=float(weight_decay),
+    )
+    generator = torch.Generator().manual_seed(seed)
+    loader = DataLoader(
+        EpisodeDataset(),
+        batch_size=int(batch_size),
+        shuffle=True,
+        collate_fn=collate,
+        generator=generator,
+        num_workers=0,
+    )
+    sampling_weights = torch.as_tensor(
+        np.power(popularity + 1e-8, float(negative_sampling_power)),
+        dtype=torch.float32,
+        device=resolved_device,
+    )
+    sampling_generator = torch.Generator(device=resolved_device).manual_seed(seed)
+
+    final_loss = 0.0
+    for epoch in range(1, int(epochs) + 1):
+        model.train()
+        total_loss = 0.0
+        examples = 0
+        for flat, offsets, targets in loader:
+            flat = flat.to(resolved_device)
+            offsets = offsets.to(resolved_device)
+            targets = targets.to(resolved_device)
+
+            weights = sampling_weights.expand(len(targets), -1).clone()
+            row_indices = torch.repeat_interleave(
+                torch.arange(len(targets), device=resolved_device),
+                offsets[1:] - offsets[:-1],
+            )
+            weights[row_indices, flat] = 0
+            weights[torch.arange(len(targets), device=resolved_device), targets] = 0
+            available = (weights > 0).sum(dim=1)
+            if torch.any(available < int(negative_samples)):
+                raise ValueError(
+                    "negative_samples exceeds the available unseen catalog "
+                    "for at least one transformed-additive training episode"
+                )
+            negatives = torch.multinomial(
+                weights,
+                num_samples=int(negative_samples),
+                replacement=False,
+                generator=sampling_generator,
+            )
+
+            optimizer.zero_grad(set_to_none=True)
+            loss = model(flat, offsets, targets, negatives)
+            loss.backward()
+            nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+
+            total_loss += float(loss.detach()) * len(targets)
+            examples += len(targets)
+
+        final_loss = total_loss / examples
+        logger.info(
+            "Transformed-additive S2S epoch %d/%d loss=%.4f",
+            epoch,
+            epochs,
+            final_loss,
+        )
+
+    model.eval()
+    with torch.no_grad():
+        embeddings = nn.functional.normalize(
+            model.item_embeddings.weight,
+            dim=1,
+        ).cpu().numpy().astype(np.float32)
+        scorer = {
+            "type": "transformed_additive",
+            "phi_w1": model.phi[0].weight.detach().cpu().numpy().astype(np.float32),
+            "phi_b1": model.phi[0].bias.detach().cpu().numpy().astype(np.float32),
+            "phi_w2": model.phi[2].weight.detach().cpu().numpy().astype(np.float32),
+            "phi_b2": model.phi[2].bias.detach().cpu().numpy().astype(np.float32),
+            "rho_w1": model.rho[0].weight.detach().cpu().numpy().astype(np.float32),
+            "rho_b1": model.rho[0].bias.detach().cpu().numpy().astype(np.float32),
+            "rho_w2": model.rho[2].weight.detach().cpu().numpy().astype(np.float32),
+            "rho_b2": model.rho[2].bias.detach().cpu().numpy().astype(np.float32),
+        }
+
+    artifact = S2SArtifact(
+        site_to_idx=site_to_idx,
+        idx_to_site=sites,
+        matrix=embeddings,
+        scorer=scorer,
+        metadata={
+            "model_type": "transformed_additive",
+            "n_factors": int(n_factors),
+            "phi_hidden_dim": int(phi_hidden_dim),
+            "rho_hidden_dim": int(rho_hidden_dim),
+            "aggregation": "sum_after_phi_rho",
+            "epochs": int(epochs),
+            "learning_rate": float(learning_rate),
+            "weight_decay": float(weight_decay),
+            "temperature": float(temperature),
+            "batch_size": int(batch_size),
+            "negative_samples": int(negative_samples),
+            "negative_sampling_power": float(negative_sampling_power),
+            "add_inbatch_negatives": bool(add_inbatch_negatives),
+            "seed": int(seed),
+            "device": resolved_device,
+            "train_pilots": int(train_visits["pilot"].nunique()),
+            "train_episodes": len(episodes),
+            "catalog_size": len(sites),
+            "final_loss": final_loss,
+            "requires_learned_scorer": True,
+            **(metadata or {}),
+        },
+    )
+    artifact.validate()
+    return artifact

--- a/ml/glideator_ml/tracking.py
+++ b/ml/glideator_ml/tracking.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from .config import flatten_config
+
+
+def _import_mlflow():
+    try:
+        import mlflow
+    except ImportError as exc:
+        raise RuntimeError(
+            "MLflow tracking is enabled but MLflow is not installed. "
+            "Install the tracking extra with: pip install -e '.[tracking]'"
+        ) from exc
+    return mlflow
+
+
+def log_experiment(
+    *,
+    config: dict[str, Any],
+    metrics: dict[str, float | int],
+    tags: dict[str, str],
+    artifacts: list[Path],
+) -> str | None:
+    tracking = config.get("tracking", {})
+    if not tracking.get("enabled", True):
+        return None
+
+    mlflow = _import_mlflow()
+    uri_env = tracking.get("tracking_uri_env", "MLFLOW_TRACKING_URI")
+    tracking_uri = os.getenv(uri_env) or tracking.get("default_tracking_uri", "file:./mlruns")
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(tracking.get("experiment_name", f"glideator-{config['task']}"))
+
+    run_name = tracking.get("run_name")
+    with mlflow.start_run(run_name=run_name) as run:
+        params = {
+            key: value
+            for key, value in flatten_config(config).items()
+            if value is not None
+        }
+        mlflow.log_params(params)
+        mlflow.log_metrics({key: float(value) for key, value in metrics.items()})
+        mlflow.set_tags(tags)
+        for artifact in artifacts:
+            mlflow.log_artifact(str(artifact))
+        return run.info.run_id

--- a/ml/glideator_ml/tracking.py
+++ b/ml/glideator_ml/tracking.py
@@ -31,7 +31,9 @@ def log_experiment(
 
     mlflow = _import_mlflow()
     uri_env = tracking.get("tracking_uri_env", "MLFLOW_TRACKING_URI")
-    tracking_uri = os.getenv(uri_env) or tracking.get("default_tracking_uri", "file:./mlruns")
+    tracking_uri = os.getenv(uri_env) or tracking.get(
+        "default_tracking_uri", "sqlite:///mlruns/mlflow.db"
+    )
     mlflow.set_tracking_uri(tracking_uri)
     mlflow.set_experiment(tracking.get("experiment_name", f"glideator-{config['task']}"))
 

--- a/ml/pyproject.toml
+++ b/ml/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "glideator-ml"
+version = "0.1.0"
+description = "Experimentation harness for Glideator ML model families"
+requires-python = ">=3.10"
+dependencies = [
+  "numpy>=2.1,<3",
+  "pandas>=2.2,<3",
+  "scikit-learn>=1.6,<2",
+  "SQLAlchemy>=2,<3",
+  "psycopg2-binary>=2.9,<3",
+  "PyYAML>=6,<7",
+]
+
+[project.optional-dependencies]
+tracking = ["mlflow==3.15.2"]
+test = ["pytest>=8,<9"]
+
+[project.scripts]
+glideator-ml = "glideator_ml.cli:main"
+
+[build-system]
+requires = ["setuptools>=75"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["glideator_ml*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/ml/pyproject.toml
+++ b/ml/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
   "numpy>=2.1,<3",
   "pandas>=2.2,<3",
+  "scipy>=1.14,<2",
   "scikit-learn>=1.6,<2",
   "SQLAlchemy>=2,<3",
   "psycopg2-binary>=2.9,<3",

--- a/ml/pyproject.toml
+++ b/ml/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+contrastive = ["torch>=2.13,<3"]
 tracking = ["mlflow==3.15.2"]
 test = ["pytest>=8,<9"]
 

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -12,6 +12,7 @@ from glideator_ml.s2s.data import (
     temporal_walk_forward_events,
     walk_forward_events,
 )
+from glideator_ml.s2s.deepsets import fit_deepsets
 from glideator_ml.s2s.evaluation import evaluate
 from glideator_ml.s2s.models import fit_contrastive, fit_svd
 from glideator_ml.s2s.run import _model_seed, _split_seed
@@ -196,3 +197,76 @@ def test_contrastive_model_exports_backend_compatible_embeddings():
     )
     assert artifact.metadata["model_type"] == "contrastive"
     assert artifact.metadata["negative_sampling_power"] == 0.5
+
+
+def test_deepsets_scorer_changes_history_query_ranking():
+    artifact = S2SArtifact(
+        site_to_idx={1: 0, 2: 1, 3: 2},
+        idx_to_site=[1, 2, 3],
+        matrix=np.asarray(
+            [
+                [1.0, 0.0],
+                [0.8, 0.6],
+                [0.0, 1.0],
+            ],
+            dtype=np.float32,
+        ),
+        metadata={"model_type": "deepsets"},
+        scorer={
+            "type": "deepsets",
+            "pooling": "mean",
+            "phi_w1": np.eye(2, dtype=np.float32),
+            "phi_b1": np.zeros(2, dtype=np.float32),
+            "phi_w2": np.eye(2, dtype=np.float32),
+            "phi_b2": np.zeros(2, dtype=np.float32),
+            "rho_w1": np.eye(2, dtype=np.float32),
+            "rho_b1": np.zeros(2, dtype=np.float32),
+            "rho_w2": np.asarray([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32),
+            "rho_b2": np.zeros(2, dtype=np.float32),
+        },
+    )
+    artifact.validate()
+
+    assert recommend(artifact, [1], top_k=1)[0][0] == 3
+
+
+def test_deepsets_model_roundtrips_learned_history_encoder(tmp_path):
+    visits = first_visits(_raw_visits())
+    artifact = fit_deepsets(
+        visits,
+        n_factors=4,
+        phi_hidden_dim=8,
+        rho_hidden_dim=8,
+        pooling="mean",
+        epochs=1,
+        learning_rate=5e-3,
+        weight_decay=1e-4,
+        temperature=0.1,
+        batch_size=4,
+        negative_samples=1,
+        negative_sampling_power=0.5,
+        add_inbatch_negatives=False,
+        seed=42,
+        device="cpu",
+    )
+
+    assert artifact.matrix.shape == (4, 4)
+    np.testing.assert_allclose(
+        np.linalg.norm(artifact.matrix, axis=1),
+        np.ones(4),
+        atol=1e-6,
+    )
+    assert artifact.metadata["model_type"] == "deepsets"
+    assert artifact.metadata["requires_learned_scorer"] is True
+    assert artifact.scorer is not None
+    assert artifact.scorer["type"] == "deepsets"
+
+    before = recommend(artifact, [1, 2], top_k=2)
+    loaded = S2SArtifact.load(artifact.save(tmp_path / "deepsets.pkl"))
+    after = recommend(loaded, [1, 2], top_k=2)
+
+    assert [site for site, _ in before] == [site for site, _ in after]
+    np.testing.assert_allclose(
+        [score for _, score in before],
+        [score for _, score in after],
+    )

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -4,9 +4,15 @@ import numpy as np
 import pandas as pd
 
 from glideator_ml.s2s.artifact import S2SArtifact, recommend
-from glideator_ml.s2s.data import first_visits, split_pilots, walk_forward_events
+from glideator_ml.s2s.data import (
+    events_fingerprint,
+    first_visits,
+    split_pilots,
+    walk_forward_events,
+)
 from glideator_ml.s2s.evaluation import evaluate
 from glideator_ml.s2s.models import fit_contrastive, fit_svd
+from glideator_ml.s2s.run import _model_seed, _split_seed
 
 
 def _raw_visits():
@@ -51,6 +57,35 @@ def test_first_visits_and_split_have_no_pilot_leakage():
         position = len(prefix)
         assert list(prefix) == ordered[:position]
         assert target == ordered[position]
+
+
+def test_benchmark_split_seed_is_independent_from_model_seed():
+    config = {
+        "seed": 99,
+        "data": {"split_seed": 42},
+        "model": {"name": "contrastive", "seed": 46},
+    }
+    assert _split_seed(config) == 42
+    assert _model_seed(config) == 46
+
+    # Old configs remain reproducible via the legacy top-level fallback.
+    legacy = {"seed": 7, "data": {}, "model": {"name": "svd"}}
+    assert _split_seed(legacy) == 7
+    assert _model_seed(legacy) == 7
+
+
+def test_eval_set_fingerprint_identifies_exact_walk_forward_benchmark():
+    visits = first_visits(_raw_visits())
+    split = split_pilots(visits, eval_fraction=0.5, seed=42)
+    events = walk_forward_events(split.eval_visits)
+
+    fingerprint = events_fingerprint(events)
+    assert fingerprint == events_fingerprint(list(events))
+
+    changed = list(events)
+    pilot, prefix, target = changed[0]
+    changed[0] = (pilot, prefix, target + 1000)
+    assert events_fingerprint(changed) != fingerprint
 
 
 def test_artifact_is_backward_compatible_with_backend_pickle_contract(tmp_path):

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -182,6 +182,7 @@ def test_contrastive_model_exports_backend_compatible_embeddings():
         temperature=0.1,
         batch_size=4,
         negative_samples=1,
+        negative_sampling_power=0.5,
         add_inbatch_negatives=False,
         seed=42,
         device="cpu",
@@ -194,3 +195,4 @@ def test_contrastive_model_exports_backend_compatible_embeddings():
         atol=1e-6,
     )
     assert artifact.metadata["model_type"] == "contrastive"
+    assert artifact.metadata["negative_sampling_power"] == 0.5

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -1,0 +1,102 @@
+import pickle
+
+import numpy as np
+import pandas as pd
+
+from glideator_ml.s2s.artifact import S2SArtifact, recommend
+from glideator_ml.s2s.data import first_visits, split_pilots, walk_forward_events
+from glideator_ml.s2s.evaluation import evaluate
+from glideator_ml.s2s.models import fit_svd
+
+
+def _raw_visits():
+    return pd.DataFrame(
+        [
+            ("p1", 1, "2026-01-01", "10:00:00"),
+            ("p1", 1, "2026-01-02", "10:00:00"),
+            ("p1", 2, "2026-01-03", "10:00:00"),
+            ("p1", 3, "2026-01-04", "10:00:00"),
+            ("p2", 1, "2026-01-01", "10:00:00"),
+            ("p2", 2, "2026-01-02", "10:00:00"),
+            ("p2", 4, "2026-01-03", "10:00:00"),
+            ("p3", 2, "2026-01-01", "10:00:00"),
+            ("p3", 3, "2026-01-02", "10:00:00"),
+            ("p3", 4, "2026-01-03", "10:00:00"),
+            ("p4", 1, "2026-01-01", "10:00:00"),
+            ("p4", 3, "2026-01-02", "10:00:00"),
+            ("p4", 4, "2026-01-03", "10:00:00"),
+        ],
+        columns=["pilot", "site_id", "date", "start_time"],
+    )
+
+
+def test_first_visits_and_split_have_no_pilot_leakage():
+    visits = first_visits(_raw_visits())
+    assert len(visits[visits["pilot"] == "p1"]) == 3
+
+    split = split_pilots(visits, eval_fraction=0.5, seed=42)
+    train_pilots = set(split.train_visits["pilot"])
+    eval_pilots = set(split.eval_visits["pilot"])
+    assert train_pilots
+    assert eval_pilots
+    assert train_pilots.isdisjoint(eval_pilots)
+
+    events = walk_forward_events(split.eval_visits)
+    for pilot, prefix, target in events:
+        ordered = (
+            split.eval_visits[split.eval_visits["pilot"] == pilot]
+            .sort_values("visit_at")["site_id"]
+            .tolist()
+        )
+        position = len(prefix)
+        assert list(prefix) == ordered[:position]
+        assert target == ordered[position]
+
+
+def test_artifact_is_backward_compatible_with_backend_pickle_contract(tmp_path):
+    artifact = S2SArtifact(
+        site_to_idx={1: 0, 2: 1, 3: 2},
+        idx_to_site=[1, 2, 3],
+        matrix=np.asarray(
+            [
+                [1.0, 0.0],
+                [0.9, 0.1],
+                [0.0, 1.0],
+            ],
+            dtype=np.float32,
+        ),
+        metadata={"model_type": "test"},
+    )
+    path = artifact.save(tmp_path / "artifact.pkl")
+    with path.open("rb") as handle:
+        payload = pickle.load(handle)
+
+    assert {"site_to_idx", "idx_to_site", "matrix"} <= payload.keys()
+    assert recommend(artifact, [1], top_k=1)[0][0] == 2
+
+
+def test_svd_is_reproducible_and_evaluator_reports_ranking_metrics():
+    visits = first_visits(_raw_visits())
+    artifact_a = fit_svd(
+        visits,
+        n_factors=2,
+        sigma_power=1.0,
+        seed=7,
+    )
+    artifact_b = fit_svd(
+        visits,
+        n_factors=2,
+        sigma_power=1.0,
+        seed=7,
+    )
+    np.testing.assert_allclose(artifact_a.matrix, artifact_b.matrix)
+
+    events = [("heldout", (1,), 2), ("heldout", (2,), 3)]
+    metrics = evaluate(artifact_a, events, visits, ks=[1, 3])
+
+    assert metrics["events"] == 2
+    assert "hit_rate_at_1" in metrics
+    assert "mrr_at_3" in metrics
+    assert "ndcg_at_3" in metrics
+    assert "coverage_at_3" in metrics
+    assert "avg_log_popularity_at_3" in metrics

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -6,7 +6,7 @@ import pandas as pd
 from glideator_ml.s2s.artifact import S2SArtifact, recommend
 from glideator_ml.s2s.data import first_visits, split_pilots, walk_forward_events
 from glideator_ml.s2s.evaluation import evaluate
-from glideator_ml.s2s.models import fit_svd
+from glideator_ml.s2s.models import fit_contrastive, fit_svd
 
 
 def _raw_visits():
@@ -100,3 +100,28 @@ def test_svd_is_reproducible_and_evaluator_reports_ranking_metrics():
     assert "ndcg_at_3" in metrics
     assert "coverage_at_3" in metrics
     assert "avg_log_popularity_at_3" in metrics
+
+
+def test_contrastive_model_exports_backend_compatible_embeddings():
+    visits = first_visits(_raw_visits())
+    artifact = fit_contrastive(
+        visits,
+        n_factors=4,
+        epochs=1,
+        learning_rate=5e-3,
+        weight_decay=1e-4,
+        temperature=0.1,
+        batch_size=4,
+        negative_samples=1,
+        add_inbatch_negatives=False,
+        seed=42,
+        device="cpu",
+    )
+
+    assert artifact.matrix.shape == (4, 4)
+    np.testing.assert_allclose(
+        np.linalg.norm(artifact.matrix, axis=1),
+        np.ones(4),
+        atol=1e-6,
+    )
+    assert artifact.metadata["model_type"] == "contrastive"

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -17,6 +17,7 @@ from glideator_ml.s2s.deepsets import fit_deepsets
 from glideator_ml.s2s.evaluation import evaluate
 from glideator_ml.s2s.models import fit_contrastive, fit_svd
 from glideator_ml.s2s.run import _model_seed, _split_seed
+from glideator_ml.s2s.transformed_additive import fit_transformed_additive
 
 
 def _raw_visits():
@@ -342,6 +343,86 @@ def test_asymmetric_model_roundtrips_source_and_target_embeddings(tmp_path):
 
     before = recommend(artifact, [1, 2], top_k=2)
     loaded = S2SArtifact.load(artifact.save(tmp_path / "asymmetric.pkl"))
+    after = recommend(loaded, [1, 2], top_k=2)
+
+    assert [site for site, _ in before] == [site for site, _ in after]
+    np.testing.assert_allclose(
+        [score for _, score in before],
+        [score for _, score in after],
+    )
+
+
+def test_transformed_additive_scorer_transforms_each_site_before_sum():
+    artifact = S2SArtifact(
+        site_to_idx={1: 0, 2: 1, 3: 2, 4: 3},
+        idx_to_site=[1, 2, 3, 4],
+        matrix=np.asarray(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 1.0],
+                [-1.0, 1.0],
+            ],
+            dtype=np.float32,
+        ),
+        metadata={"model_type": "transformed_additive"},
+        scorer={
+            "type": "transformed_additive",
+            "phi_w1": np.eye(2, dtype=np.float32),
+            "phi_b1": np.zeros(2, dtype=np.float32),
+            "phi_w2": np.eye(2, dtype=np.float32),
+            "phi_b2": np.zeros(2, dtype=np.float32),
+            "rho_w1": np.asarray(
+                [[1.0, -1.0], [-1.0, 1.0]],
+                dtype=np.float32,
+            ),
+            "rho_b1": np.zeros(2, dtype=np.float32),
+            "rho_w2": np.eye(2, dtype=np.float32),
+            "rho_b2": np.zeros(2, dtype=np.float32),
+        },
+    )
+    artifact.validate()
+
+    # Site 1 transforms to [1, 0] and site 2 to [0, 1], so additive
+    # composition points toward candidate 3.
+    assert recommend(artifact, [1, 2], top_k=1)[0][0] == 3
+
+
+def test_transformed_additive_model_roundtrips_scorer(tmp_path):
+    visits = first_visits(_raw_visits())
+    artifact = fit_transformed_additive(
+        visits,
+        n_factors=4,
+        phi_hidden_dim=8,
+        rho_hidden_dim=8,
+        epochs=1,
+        learning_rate=5e-3,
+        weight_decay=1e-4,
+        temperature=0.1,
+        batch_size=4,
+        negative_samples=1,
+        negative_sampling_power=0.5,
+        add_inbatch_negatives=False,
+        seed=42,
+        device="cpu",
+    )
+
+    assert artifact.matrix.shape == (4, 4)
+    np.testing.assert_allclose(
+        np.linalg.norm(artifact.matrix, axis=1),
+        np.ones(4),
+        atol=1e-6,
+    )
+    assert artifact.metadata["model_type"] == "transformed_additive"
+    assert artifact.metadata["aggregation"] == "sum_after_phi_rho"
+    assert artifact.metadata["requires_learned_scorer"] is True
+    assert artifact.scorer is not None
+    assert artifact.scorer["type"] == "transformed_additive"
+
+    before = recommend(artifact, [1, 2], top_k=2)
+    loaded = S2SArtifact.load(
+        artifact.save(tmp_path / "transformed_additive.pkl")
+    )
     after = recommend(loaded, [1, 2], top_k=2)
 
     assert [site for site, _ in before] == [site for site, _ in after]

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -8,6 +8,8 @@ from glideator_ml.s2s.data import (
     events_fingerprint,
     first_visits,
     split_pilots,
+    split_temporal,
+    temporal_walk_forward_events,
     walk_forward_events,
 )
 from glideator_ml.s2s.evaluation import evaluate
@@ -57,6 +59,28 @@ def test_first_visits_and_split_have_no_pilot_leakage():
         position = len(prefix)
         assert list(prefix) == ordered[:position]
         assert target == ordered[position]
+
+
+def test_temporal_split_uses_only_past_training_data_and_keeps_prior_history():
+    visits = first_visits(_raw_visits())
+    cutoff = "2026-01-03"
+    split = split_temporal(visits, cutoff=cutoff)
+
+    assert split.train_visits["visit_at"].max() < pd.Timestamp(cutoff)
+    assert split.eval_visits["visit_at"].min() >= pd.Timestamp(cutoff)
+
+    events = temporal_walk_forward_events(visits, cutoff=cutoff)
+    assert ("p1", (1,), 2) in events
+    assert ("p1", (1, 2), 3) in events
+
+    for pilot, prefix, target in events:
+        ordered = (
+            visits[visits["pilot"] == pilot]
+            .sort_values(["visit_at", "site_id"])["site_id"]
+            .tolist()
+        )
+        position = ordered.index(target)
+        assert list(prefix) == ordered[:position]
 
 
 def test_benchmark_split_seed_is_independent_from_model_seed():
@@ -126,15 +150,25 @@ def test_svd_is_reproducible_and_evaluator_reports_ranking_metrics():
     )
     np.testing.assert_allclose(artifact_a.matrix, artifact_b.matrix)
 
-    events = [("heldout", (1,), 2), ("heldout", (2,), 3)]
+    events = [
+        ("heldout-a", (1,), 2),
+        ("heldout-b", (2, 1), 3),
+        ("heldout-c", (1, 2, 3, 4), 999),
+    ]
     metrics = evaluate(artifact_a, events, visits, ks=[1, 3])
 
-    assert metrics["events"] == 2
+    assert metrics["events"] == 3
     assert "hit_rate_at_1" in metrics
     assert "mrr_at_3" in metrics
     assert "ndcg_at_3" in metrics
+    assert "end_to_end_hit_rate_at_3" in metrics
     assert "coverage_at_3" in metrics
     assert "avg_log_popularity_at_3" in metrics
+    assert metrics["history_1_events"] == 1
+    assert metrics["history_2_3_events"] == 1
+    assert metrics["history_4_plus_events"] == 1
+    assert metrics["target_cold_start_events"] == 1
+    assert metrics["cold_start_target_rate"] == 1 / 3
 
 
 def test_contrastive_model_exports_backend_compatible_embeddings():

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from glideator_ml.s2s.artifact import S2SArtifact, recommend
+from glideator_ml.s2s.asymmetric import fit_asymmetric
 from glideator_ml.s2s.data import (
     events_fingerprint,
     first_visits,
@@ -263,6 +264,84 @@ def test_deepsets_model_roundtrips_learned_history_encoder(tmp_path):
 
     before = recommend(artifact, [1, 2], top_k=2)
     loaded = S2SArtifact.load(artifact.save(tmp_path / "deepsets.pkl"))
+    after = recommend(loaded, [1, 2], top_k=2)
+
+    assert [site for site, _ in before] == [site for site, _ in after]
+    np.testing.assert_allclose(
+        [score for _, score in before],
+        [score for _, score in after],
+    )
+
+
+def test_asymmetric_scorer_uses_source_embeddings_for_history():
+    artifact = S2SArtifact(
+        site_to_idx={1: 0, 2: 1, 3: 2},
+        idx_to_site=[1, 2, 3],
+        matrix=np.asarray(
+            [
+                [1.0, 0.0],
+                [0.8, 0.6],
+                [0.0, 1.0],
+            ],
+            dtype=np.float32,
+        ),
+        metadata={"model_type": "asymmetric"},
+        scorer={
+            "type": "asymmetric",
+            "source_matrix": np.asarray(
+                [
+                    [0.0, 1.0],
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                ],
+                dtype=np.float32,
+            ),
+        },
+    )
+    artifact.validate()
+
+    # Target-space site 1 points right, but its source-space representation
+    # points up, so candidate 3 should be ranked first.
+    assert recommend(artifact, [1], top_k=1)[0][0] == 3
+
+
+def test_asymmetric_model_roundtrips_source_and_target_embeddings(tmp_path):
+    visits = first_visits(_raw_visits())
+    artifact = fit_asymmetric(
+        visits,
+        n_factors=4,
+        epochs=1,
+        learning_rate=5e-3,
+        weight_decay=1e-4,
+        temperature=0.1,
+        batch_size=4,
+        negative_samples=1,
+        negative_sampling_power=0.5,
+        add_inbatch_negatives=False,
+        seed=42,
+        device="cpu",
+    )
+
+    assert artifact.matrix.shape == (4, 4)
+    np.testing.assert_allclose(
+        np.linalg.norm(artifact.matrix, axis=1),
+        np.ones(4),
+        atol=1e-6,
+    )
+    assert artifact.metadata["model_type"] == "asymmetric"
+    assert artifact.metadata["requires_learned_scorer"] is True
+    assert artifact.scorer is not None
+    assert artifact.scorer["type"] == "asymmetric"
+    source_matrix = np.asarray(artifact.scorer["source_matrix"])
+    assert source_matrix.shape == (4, 4)
+    np.testing.assert_allclose(
+        np.linalg.norm(source_matrix, axis=1),
+        np.ones(4),
+        atol=1e-6,
+    )
+
+    before = recommend(artifact, [1, 2], top_k=2)
+    loaded = S2SArtifact.load(artifact.save(tmp_path / "asymmetric.pkl"))
     after = recommend(loaded, [1, 2], top_k=2)
 
     assert [site for site, _ in before] == [site for site, _ in after]

--- a/ml/tests/test_s2s.py
+++ b/ml/tests/test_s2s.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from glideator_ml.s2s.artifact import S2SArtifact, recommend
 from glideator_ml.s2s.asymmetric import fit_asymmetric
+from glideator_ml.s2s.candidate_attention import fit_candidate_attention
 from glideator_ml.s2s.data import (
     events_fingerprint,
     first_visits,
@@ -422,6 +423,92 @@ def test_transformed_additive_model_roundtrips_scorer(tmp_path):
     before = recommend(artifact, [1, 2], top_k=2)
     loaded = S2SArtifact.load(
         artifact.save(tmp_path / "transformed_additive.pkl")
+    )
+    after = recommend(loaded, [1, 2], top_k=2)
+
+    assert [site for site, _ in before] == [site for site, _ in after]
+    np.testing.assert_allclose(
+        [score for _, score in before],
+        [score for _, score in after],
+    )
+
+
+def test_candidate_attention_scores_candidates_with_different_history_weights():
+    artifact = S2SArtifact(
+        site_to_idx={1: 0, 2: 1, 3: 2, 4: 3},
+        idx_to_site=[1, 2, 3, 4],
+        matrix=np.asarray(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+            ],
+            dtype=np.float32,
+        ),
+        metadata={"model_type": "candidate_attention"},
+        scorer={
+            "type": "candidate_attention",
+            "history_matrix": np.asarray(
+                [
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                    [1.0, 0.0],
+                    [0.0, 1.0],
+                ],
+                dtype=np.float32,
+            ),
+            "query_weight": np.eye(2, dtype=np.float32),
+            "key_weight": np.eye(2, dtype=np.float32),
+            "value_weight": np.asarray(
+                [[1.0, 0.0], [0.0, -1.0]],
+                dtype=np.float32,
+            ),
+            "attention_scale": 1.0,
+        },
+    )
+    artifact.validate()
+
+    # Candidates 3 and 4 have identical cosine similarity to the additive
+    # baseline [1, 1]. Candidate-conditioned attention breaks that tie because
+    # each candidate attends to a different history site.
+    assert recommend(artifact, [1, 2], top_k=1)[0][0] == 3
+
+
+def test_candidate_attention_model_roundtrips_scorer(tmp_path):
+    visits = first_visits(_raw_visits())
+    artifact = fit_candidate_attention(
+        visits,
+        n_factors=4,
+        epochs=1,
+        learning_rate=5e-3,
+        weight_decay=1e-4,
+        temperature=0.1,
+        batch_size=4,
+        negative_samples=1,
+        negative_sampling_power=0.5,
+        add_inbatch_negatives=False,
+        attention_scale_init=0.1,
+        seed=42,
+        device="cpu",
+    )
+
+    assert artifact.matrix.shape == (4, 4)
+    np.testing.assert_allclose(
+        np.linalg.norm(artifact.matrix, axis=1),
+        np.ones(4),
+        atol=1e-6,
+    )
+    assert artifact.metadata["model_type"] == "candidate_attention"
+    assert artifact.metadata["attention_heads"] == 1
+    assert artifact.metadata["requires_learned_scorer"] is True
+    assert artifact.scorer is not None
+    assert artifact.scorer["type"] == "candidate_attention"
+    assert np.asarray(artifact.scorer["history_matrix"]).shape == (4, 4)
+
+    before = recommend(artifact, [1, 2], top_k=2)
+    loaded = S2SArtifact.load(
+        artifact.save(tmp_path / "candidate_attention.pkl")
     )
     after = recommend(loaded, [1, 2], top_k=2)
 

--- a/ml/tests/test_tracking_backfill.py
+++ b/ml/tests/test_tracking_backfill.py
@@ -1,0 +1,102 @@
+import json
+
+import pytest
+
+from glideator_ml.s2s import run
+
+
+def _config(output_dir):
+    return {
+        "task": "s2s",
+        "data": {},
+        "model": {"name": "deepsets", "seed": 42},
+        "evaluation": {"benchmark_id": "s2s-v1"},
+        "artifact": {
+            "output_dir": str(output_dir),
+            "filename": "model.pkl",
+        },
+        "tracking": {"enabled": True},
+    }
+
+
+def _report():
+    return {
+        "task": "s2s",
+        "benchmark_id": "s2s-v1",
+        "benchmark": {
+            "split_strategy": "pilot",
+            "split_seed": 42,
+        },
+        "dataset_fingerprint": "sha256:dataset",
+        "eval_set_fingerprint": "sha256:evaluation",
+        "model_seed": 42,
+        "git_sha": "abc123",
+        "model": {"model_type": "deepsets"},
+        "metrics": {"hit_rate_at_5": 0.5},
+    }
+
+
+def test_backfill_tracks_saved_artifacts_and_persists_run_id(
+    tmp_path,
+    monkeypatch,
+):
+    report_path = tmp_path / "evaluation.json"
+    report_path.write_text(json.dumps(_report()), encoding="utf-8")
+    artifact_path = tmp_path / "model.pkl"
+    artifact_path.write_bytes(b"model")
+    captured = {}
+
+    def fake_log_experiment(**kwargs):
+        captured.update(kwargs)
+        return "run-123"
+
+    monkeypatch.setattr(run, "log_experiment", fake_log_experiment)
+
+    result = run.backfill_s2s_tracking(_config(tmp_path))
+
+    assert result["mlflow_run_id"] == "run-123"
+    assert json.loads(report_path.read_text())["mlflow_run_id"] == "run-123"
+    assert captured["metrics"] == {"hit_rate_at_5": 0.5}
+    assert captured["tags"]["model_family"] == "deepsets"
+    assert captured["artifacts"] == [artifact_path, report_path]
+
+
+def test_backfill_is_idempotent(tmp_path, monkeypatch):
+    report = _report()
+    report["mlflow_run_id"] = "existing-run"
+    (tmp_path / "evaluation.json").write_text(
+        json.dumps(report),
+        encoding="utf-8",
+    )
+    (tmp_path / "model.pkl").write_bytes(b"model")
+
+    def unexpected_log_experiment(**kwargs):
+        raise AssertionError("already tracked report must not be logged again")
+
+    monkeypatch.setattr(run, "log_experiment", unexpected_log_experiment)
+
+    result = run.backfill_s2s_tracking(_config(tmp_path))
+
+    assert result["mlflow_run_id"] == "existing-run"
+
+
+def test_backfill_requires_saved_artifact(tmp_path):
+    (tmp_path / "evaluation.json").write_text(
+        json.dumps(_report()),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(FileNotFoundError, match="model artifact"):
+        run.backfill_s2s_tracking(_config(tmp_path))
+
+
+def test_backfill_rejects_disabled_tracking(tmp_path, monkeypatch):
+    (tmp_path / "evaluation.json").write_text(
+        json.dumps(_report()),
+        encoding="utf-8",
+    )
+    (tmp_path / "model.pkl").write_bytes(b"model")
+    monkeypatch.setattr(run, "log_experiment", lambda **kwargs: None)
+
+    with pytest.raises(RuntimeError, match="tracking is disabled"):
+        run.backfill_s2s_tracking(_config(tmp_path))


### PR DESCRIPTION
## Summary

Introduces a model-family-agnostic ML experimentation area under `ml/`, with S2S as the first complete task.

### Included
- deterministic pilot-level train/eval split to avoid held-out pilot leakage
- fixed benchmark identity: `data.split_seed` is independent from stochastic `model.seed`
- `benchmark_id` + exact walk-forward `eval_set_fingerprint` logged with every run
- walk-forward evaluation over first site visits
- SVD recommender baseline with configurable rank and singular-value power
- production-equivalent contrastive S2S training with GPU-batched negative sampling
- standardized S2S artifact compatible with the current backend pickle contract
- HitRate, MRR, NDCG, coverage, popularity-bias, cold-start, and source-coverage metrics
- dataset fingerprinting and Git SHA provenance
- optional MLflow experiment tracking
- dedicated ML CI job and synthetic tests
- documentation and baseline configs

### Not included yet
- no production artifact switch
- no model registry/promotion flow
- no XC or D2D migration yet
- no automatic retraining

This PR remains intentionally draft while we validate S2S experiments and promotion criteria.